### PR TITLE
Make annotation-based scopes match the documentation

### DIFF
--- a/src/Ray/Di/Di/Scope.php
+++ b/src/Ray/Di/Di/Scope.php
@@ -19,14 +19,14 @@ final class Scope implements Annotation
      *
      * @var string
      */
-    const SINGLETON = 'singleton';
+    const SINGLETON = 'Singleton';
 
     /**
      * Prototype
      *
      * @var string
      */
-    const PROTOTYPE = 'prototype';
+    const PROTOTYPE = 'Prototype';
 
     /**
      * Object lifecycle

--- a/src/Ray/Di/Scope.php
+++ b/src/Ray/Di/Scope.php
@@ -16,12 +16,12 @@ class Scope
      *
      * @var string
      */
-    const SINGLETON = 'singleton';
+    const SINGLETON = 'Singleton';
 
     /**
      * Prototype scope
      *
      * @var string
      */
-    const PROTOTYPE = 'prototype';
+    const PROTOTYPE = 'Prototype';
 }

--- a/tests/Ray/Di/ConfigTest.php
+++ b/tests/Ray/Di/ConfigTest.php
@@ -123,7 +123,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = 'onInit';
         $this->assertSame($expect, $definition['PostConstruct']);
         // same
-        $expect = 'prototype';
+        $expect = \Ray\Di\Scope::PROTOTYPE;
         $this->assertSame($expect, $definition['Scope']);
     }
 
@@ -133,7 +133,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $expect = 'onInit';
         $this->assertSame($expect, $definition['PostConstruct']);
         // changed
-        $expect = 'singleton';
+        $expect = \Ray\Di\Scope::SINGLETON;
         $this->assertSame($expect, $definition['Scope']);
     }
 

--- a/tests/Ray/Di/Definition/MockDefinitionChildOverrideClass.php
+++ b/tests/Ray/Di/Definition/MockDefinitionChildOverrideClass.php
@@ -5,7 +5,7 @@ namespace Ray\Di\Definition;
 use Ray\Di\Di\Scope;
 
 /**
- * @Scope("singleton")
+ * @Scope("Singleton")
  */
 class MockDefinitionChildOverrideClass extends MockDefinitionClass
 {

--- a/tests/Ray/Di/Mock/SingletonDbInterface.php
+++ b/tests/Ray/Di/Mock/SingletonDbInterface.php
@@ -5,6 +5,6 @@ namespace Ray\Di\Mock;
 use Ray\Di\Di\Scope;
 
 /**
- * @Scope("singleton")
+ * @Scope("Singleton")
  */
 interface SingletonDbInterface extends DbInterface {}


### PR DESCRIPTION
# Pros
- Match the behaviour documented here: http://code.google.com/p/rayphp/wiki/Scopes

``` php
/**
 * @Scope("Singleton")
 */
class Some_Model {
 ///
}
```
- Old behaviour required lower-case @Scope("singleton") which doesn't conform to the other 
- This causes the behaviour to match Google Guice.
# Cons

Incompatible with annotation code that uses lowercase. (Must be found and replaced in your project)

``` regex
s/\@Scope\(['"]singleton['"]\)/\@Scope\("Singleton"\)

```
