### PR TITLE
Allow bind toProvider without type hinting

### DIFF
--- a/src/Ray/Di/Injector.php
+++ b/src/Ray/Di/Injector.php
@@ -702,9 +702,16 @@ class Injector implements InjectorInterface, \Serializable
         list($bindingToType, $target) = $binding[AbstractModule::TO];
 
         $bound = $this->instanceBound($param, $bindingToType, $target, $binding);
-        if (! $bound) {
-            $this->typeBound($param, $typeHint, $bindingToType, $target);
+        if ($bound) {
+            return;
         }
+
+        if ($typeHint === '') {
+            $param = $this->getInstanceWithContainer(Scope::PROTOTYPE, $bindingToType, $target);
+            return;
+        }
+
+        $this->typeBound($param, $typeHint, $bindingToType, $target);
     }
 
     /**

--- a/tests/Ray/Di/Definition/MockScalar.php
+++ b/tests/Ray/Di/Definition/MockScalar.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ray\Di\Definition;
+
+use Ray\Di\Di\Inject;
+use Ray\Di\Di\Named;
+
+class MockScalar 
+{
+    /**
+     * @var mixed
+     */
+    public $injected;
+
+    /**
+     * @param mixed $injected
+     *
+     * @Inject
+     * @Named("scalar_value")
+     */
+    public function setScalar($injected)
+    {
+        $this->injected = $injected;
+    }
+}

--- a/tests/Ray/Di/InjectorTest.php
+++ b/tests/Ray/Di/InjectorTest.php
@@ -91,6 +91,13 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Ray\Di\Mock\UserDb', $instance->db);
     }
 
+    public function testToStringProvider()
+    {
+        $this->injector->setModule(new Modules\StringProviderModule);
+        $instance = $this->injector->getInstance('Ray\Di\Definition\MockScalar');
+        $this->assertSame('provided string', $instance->injected);
+    }
+
     public function testToClosure()
     {
         $this->injector->setModule(new Modules\ClosureModule);

--- a/tests/Ray/Di/Modules/StringProvider.php
+++ b/tests/Ray/Di/Modules/StringProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ray\Di\Modules;
+
+use Ray\Di\ProviderInterface;
+
+class StringProvider implements ProviderInterface
+{
+    /**
+     * @return string 
+     */
+    public function get()
+    {
+        return 'provided string';
+    }
+}

--- a/tests/Ray/Di/Modules/StringProviderModule.php
+++ b/tests/Ray/Di/Modules/StringProviderModule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ray\Di\Modules;
+
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+
+class StringProviderModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind()->annotatedWith('scalar_value')->toProvider('Ray\Di\Modules\StringProvider');
+    }
+}


### PR DESCRIPTION
This allows:

``` php
<?php

class Foo
{
    /**
     * scalar setter
     *
     * @param string $name
     * @Inject
     * @Named("foo_name")
      */
     public function setName($name)
     {
         $this->name = $name;
     }
}

/**
  * in Module
  */
$this->bind()->annotatedWith('foo_name')->toProvider('Foo\Bar\NameProvider');
```
