### PR TITLE
Fix for unit test defined in koriym/Ray.Di#62 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ vendor
 cache.properties
 build
 composer.phar
+phpunit.phar
 *doctrinecache.data
 Ray*Aop.php
 atlassian-ide-plugin.xml

--- a/src/ChildInjector.php
+++ b/src/ChildInjector.php
@@ -24,7 +24,7 @@ class ChildInjector extends Injector {
      */
     protected function safeGetInstance( $class )
     {
-        if( $this->injector instanceof InjectorInterface ) {
+        if( $this->injector instanceof InstanceInterface ) {
             return $this->injector->getInstance( $class );
         }
 

--- a/src/ChildInjector.php
+++ b/src/ChildInjector.php
@@ -1,0 +1,34 @@
+<?php
+namespace Ray\Di;
+
+/**
+ * An injector that is capable of depending on an external injector for calculating dependencies.
+ *
+ * @package Ray\Di
+ */
+class ChildInjector extends Injector {
+
+    /** @var InstanceInterface */
+    private $injector;
+
+    /**
+     * @param InstanceInterface $injector
+     */
+    public function setChildInjector( InstanceInterface $injector )
+    {
+        $this->injector = $injector;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function safeGetInstance( $class )
+    {
+        if( $this->injector instanceof InjectorInterface ) {
+            return $this->injector->getInstance( $class );
+        }
+
+        return parent::getInstance( $class );
+    }
+
+} 

--- a/src/CompilationLogger.php
+++ b/src/CompilationLogger.php
@@ -59,7 +59,7 @@ final class CompilationLogger implements CompilationLoggerInterface, \Serializab
     /**
      * {@inheritdoc}
      */
-    public function log($class, array $params, array $setters, $instance, Bind $bind)
+    public function log($class, array $params, array $setters, $instance, Bind $bind, $isSingleton = false)
     {
         if ($instance instanceof DependencyProvider) {
             $this->buildProvider($instance);
@@ -67,7 +67,7 @@ final class CompilationLogger implements CompilationLoggerInterface, \Serializab
             return;
         }
         $this->logger->log($class, $params, $setters, $instance, $bind);
-        $this->build($class, $instance, $params, $setters);
+        $this->build($class, $instance, $params, $setters, $isSingleton);
     }
 
     /**
@@ -133,14 +133,15 @@ final class CompilationLogger implements CompilationLoggerInterface, \Serializab
      * @param array  $params
      * @param array  $setters
      * @param string $class
+     * @param bool   $isSingleton
      */
-    private function build($class, $instance, array $params, array $setters)
+    private function build($class, $instance, array $params, array $setters, $isSingleton)
     {
         $params = $this->makeParamRef($params);
         foreach ($setters as &$methodPrams) {
             $methodPrams = $this->makeParamRef($methodPrams);
         }
-        $dependencyFactory = new DependencyFactory($instance, $params, $setters, $this);
+        $dependencyFactory = new DependencyFactory($instance, $params, $setters, $this, $isSingleton);
         list(,,$definition) = $this->config->fetch($class);
         // @PostConstruct
         $postConstructMethod = $definition['PostConstruct'];

--- a/src/CompilationLogger.php
+++ b/src/CompilationLogger.php
@@ -35,14 +35,15 @@ final class CompilationLogger implements CompilationLoggerInterface, \Serializab
 
     /**
      * @param LoggerInterface $logger
+     * @param \SplObjectStorage $splObjectStorage
      *
      * @Inject
      * @Named("logger")
      */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, \SplObjectStorage $splObjectStorage = null)
     {
         $this->logger = $logger;
-        $this->objectStorage = new \SplObjectStorage;
+        $this->objectStorage = ($splObjectStorage instanceof \SplObjectStorage) ? $splObjectStorage : new \SplObjectStorage();
     }
 
     /**

--- a/src/CompilationLogger.php
+++ b/src/CompilationLogger.php
@@ -116,7 +116,7 @@ final class CompilationLogger implements CompilationLoggerInterface, \Serializab
     }
 
     /**
-     * @return array
+     * {@inheritDoc}
      */
     public function setClassMap(array $classMap, $class)
     {

--- a/src/CompilationLoggerInterface.php
+++ b/src/CompilationLoggerInterface.php
@@ -34,4 +34,11 @@ interface CompilationLoggerInterface extends LoggerInterface
      * @return string
      */
     public function getObjectHash($object);
+
+    /**
+     * @param array $classMap
+     * @param $class
+     * @return array
+     */
+    public function setClassMap(array $classMap, $class);
 }

--- a/src/DependencyFactory.php
+++ b/src/DependencyFactory.php
@@ -55,14 +55,21 @@ final class DependencyFactory implements ProviderInterface
      * @param array         $args
      * @param array         $setter
      * @param CompilationLogger $logger
+     * @param bool          $isSingleton
      */
     public function __construct(
         $object,
         array $args,
         array $setter,
-        CompilationLogger $logger
+        CompilationLogger $logger,
+        $isSingleton
     ) {
         $this->class = get_class($object);
+
+        if( $isSingleton ) {
+            $this->instance = $object;
+        }
+
         $this->hash = $logger->getObjectHash($object);
         $this->args = $args;
         $this->setters = $setter;

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -121,8 +121,9 @@ final class DiCompiler implements InstanceInterface, \Serializable
     }
 
     /**
-     * @param string $class
+     * Compile fluent interface
      *
+     * @param string $class
      * @return self
      */
     public function compile($class)

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -128,11 +128,22 @@ final class DiCompiler implements InstanceInterface, \Serializable
      */
     public function compile($class)
     {
-        $this->injector->getInstance($class);
+        $this->_compile( $class );
+        return $this;
+    }
+
+    /**
+     * Compile and return result from Injector
+     *
+     * @param $class
+     * @return object
+     */
+    private function _compile( $class )
+    {
+        $object = $this->injector->getInstance($class);
         $this->classMap = $this->logger->setClassMap($this->classMap, $class);
         $this->cache->save($this->cacheKey, $this);
-
-        return $this;
+        return $object;
     }
 
     /**
@@ -164,12 +175,11 @@ final class DiCompiler implements InstanceInterface, \Serializable
         $diCompiler = $this->injector ? $this : call_user_func_array([$this, 'createInstance'], self::$args);
         /** @var $diCompiler DiCompiler */
         $mappedClass = array_keys($this->classMap);
-        $mappedClass[] = $class;
         foreach ($mappedClass as $newClass) {
             $diCompiler->compile($newClass);
         }
 
-        return $diCompiler->getInstance($class);
+        return $diCompiler->_compile( $class );
     }
 
     /**

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -103,7 +103,7 @@ final class DiCompiler implements InstanceInterface, \Serializable
         );
         $logger = new CompilationLogger(new Logger);
         $logger->setConfig($config);
-        $injector = new Injector(
+        $injector = new ChildInjector(
             new Container(new Forge($config)),
             $moduleProvider(),
             new Bind,
@@ -113,7 +113,9 @@ final class DiCompiler implements InstanceInterface, \Serializable
             ),
             $logger
         );
+
         $diCompiler = new DiCompiler($injector, $logger, $cache, $cacheKey);
+        $injector->setChildInjector( $diCompiler );
 
         return $diCompiler;
     }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -235,6 +235,7 @@ class Injector implements InjectorInterface, \Serializable
         }
 
         // get bound config
+        //TODO $isSingleton is not trustworthy
         list($class, $isSingleton, $interfaceClass, $params, $setter, $definition) = $bound;
 
         // instantiate parameters
@@ -412,6 +413,7 @@ class Injector implements InjectorInterface, \Serializable
     private function getBoundDefinition($class, $isSingleton, $interfaceClass)
     {
         list($config, $setter, $definition) = $this->config->fetch($class);
+        $isSingleton = $isSingleton || (Scope::SINGLETON === $definition[Definition::SCOPE]);
         $hasDirectBinding = isset($this->module->bindings[$class]);
         /** @var $definition Definition */
         if ($definition->hasDefinition() || $hasDirectBinding) {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -235,7 +235,6 @@ class Injector implements InjectorInterface, \Serializable
         }
 
         // get bound config
-        //TODO $isSingleton is not trustworthy
         list($class, $isSingleton, $interfaceClass, $params, $setter, $definition) = $bound;
 
         // instantiate parameters
@@ -266,7 +265,7 @@ class Injector implements InjectorInterface, \Serializable
 
         // logger inject info
         if ($this->logger) {
-            $this->logger->log($class, $params, $setter, $object, $bind);
+            $this->logger->log($class, $params, $setter, $object, $bind, $isSingleton);
         }
 
         // Object life cycle, Singleton, and Save cache

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -36,8 +36,9 @@ class Logger implements LoggerInterface, \IteratorAggregate, \Serializable
      * @param array         $setter
      * @param object        $object
      * @param \Ray\Aop\Bind $bind
+     * @param bool          $isSingleton
      */
-    public function log($class, array $params, array $setter, $object, Bind $bind)
+    public function log($class, array $params, array $setter, $object, Bind $bind, $isSingleton = false)
     {
         $this->logs[] = [$class, $params, $setter, $object, $bind];
         $setterLog = [];

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -21,8 +21,9 @@ interface LoggerInterface
      * @param array  $setter
      * @param object $object
      * @param Bind   $bind
+     * @param bool   $isSingleton
      *
      * @return void
      */
-    public function log($class, array $params, array $setter, $object, Bind $bind);
+    public function log($class, array $params, array $setter, $object, Bind $bind, $isSingleton = false);
 }

--- a/tests/DiCompilerSingletonTest.php
+++ b/tests/DiCompilerSingletonTest.php
@@ -3,7 +3,9 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Ray\Di\Mock\AnnotatedSingleton;
 use Ray\Di\Mock\RndDb;
+use Ray\Di\Mock\SingletonConsumer;
 
 class DiCompilerSingletonTest extends InjectorSingletonTest
 {
@@ -170,5 +172,53 @@ class DiCompilerSingletonTest extends InjectorSingletonTest
         $this->assertSame($result1, $result2);
         $this->assertSame($result2, $result3);
         $this->assertSame($result3, $result4);
+    }
+
+    public function testThatConsumerIsNotConstructedMoreThanOnce()
+    {
+        $moduleProvider = function() {return new Modules\SingletonModule;};
+        $injector = DiCompiler::create($moduleProvider, new ArrayCache, __METHOD__, $_ENV['TMP_DIR']);
+
+        $injector->getInstance( 'Ray\Di\Mock\SingletonConsumer' ); //One SingletonConsumer should exist.
+
+        $numberOfSingletonConsumers = count( SingletonConsumer::$instances );
+        $numberOfSingletonConsumersThatShouldBeConstructed = 1;
+
+        $this->assertEquals( $numberOfSingletonConsumersThatShouldBeConstructed, $numberOfSingletonConsumers );
+
+        $injector->getInstance( 'Ray\Di\Mock\SingletonConsumer' ); //Two SingletonConsumer should exist.
+
+        $numberOfSingletonConsumers = count( SingletonConsumer::$instances );
+        $numberOfSingletonConsumersThatShouldBeConstructed = 2;
+
+        $this->assertEquals( $numberOfSingletonConsumersThatShouldBeConstructed, $numberOfSingletonConsumers );
+
+        //Cleanup statics after test
+        SingletonConsumer::$instances = array();
+        AnnotatedSingleton::$number = 0;
+    }
+
+    public function testThatAnnotatedSingletonIsNotConstructedMoreThanOnce()
+    {
+        $moduleProvider = function() {return new Modules\SingletonModule;};
+        $injector = DiCompiler::create($moduleProvider, new ArrayCache, __METHOD__, $_ENV['TMP_DIR']);
+
+        $injector->getInstance( 'Ray\Di\Mock\SingletonConsumer' ); //One AnnotatedSingleton should exist.
+
+        $numberOfSingletonInstances = AnnotatedSingleton::$number;
+        $numberOfTimesSingletonsShouldBeConstructed = 1;
+
+        $this->assertEquals( $numberOfTimesSingletonsShouldBeConstructed, $numberOfSingletonInstances );
+
+        $injector->getInstance( 'Ray\Di\Mock\SingletonConsumer' ); //One AnnotatedSingleton should exist.
+
+        $numberOfSingletonInstances = AnnotatedSingleton::$number;
+        $numberOfTimesSingletonsShouldBeConstructed = 1;
+
+        $this->assertEquals( $numberOfTimesSingletonsShouldBeConstructed, $numberOfSingletonInstances );
+
+        //Cleanup statics after test
+        SingletonConsumer::$instances = array();
+        AnnotatedSingleton::$number = 0;
     }
 }

--- a/tests/DiCompilerSingletonTest.php
+++ b/tests/DiCompilerSingletonTest.php
@@ -176,6 +176,10 @@ class DiCompilerSingletonTest extends InjectorSingletonTest
 
     public function testThatConsumerIsNotConstructedMoreThanOnce()
     {
+        //Set statics to known state
+        SingletonConsumer::$instances = array();
+        AnnotatedSingleton::$number = 0;
+
         $moduleProvider = function() {return new Modules\SingletonModule;};
         $injector = DiCompiler::create($moduleProvider, new ArrayCache, __METHOD__, $_ENV['TMP_DIR']);
 
@@ -193,13 +197,14 @@ class DiCompilerSingletonTest extends InjectorSingletonTest
 
         $this->assertEquals( $numberOfSingletonConsumersThatShouldBeConstructed, $numberOfSingletonConsumers );
 
-        //Cleanup statics after test
-        SingletonConsumer::$instances = array();
-        AnnotatedSingleton::$number = 0;
     }
 
     public function testThatAnnotatedSingletonIsNotConstructedMoreThanOnce()
     {
+        //Set statics to known state
+        SingletonConsumer::$instances = array();
+        AnnotatedSingleton::$number = 0;
+
         $moduleProvider = function() {return new Modules\SingletonModule;};
         $injector = DiCompiler::create($moduleProvider, new ArrayCache, __METHOD__, $_ENV['TMP_DIR']);
 
@@ -216,9 +221,5 @@ class DiCompilerSingletonTest extends InjectorSingletonTest
         $numberOfTimesSingletonsShouldBeConstructed = 1;
 
         $this->assertEquals( $numberOfTimesSingletonsShouldBeConstructed, $numberOfSingletonInstances );
-
-        //Cleanup statics after test
-        SingletonConsumer::$instances = array();
-        AnnotatedSingleton::$number = 0;
     }
 }

--- a/tests/Mock/AnnotatedSingleton.php
+++ b/tests/Mock/AnnotatedSingleton.php
@@ -1,0 +1,22 @@
+<?php
+namespace Ray\Di\Mock;
+
+use Ray\Di\Di\Scope;
+use Ray\Di\Di\PostConstruct;
+
+/**
+ * @Scope("Singleton")
+ */
+class AnnotatedSingleton {
+
+    public static $number = 0;
+
+    /**
+     * @PostConstruct
+     */
+    public function onInit()
+    {
+        self::$number++;
+    }
+
+} 

--- a/tests/Mock/SingletonConsumer.php
+++ b/tests/Mock/SingletonConsumer.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ray\Di\Mock;
+
+class SingletonConsumer {
+
+    public static $instances = array();
+
+    private $annotatedSingleton;
+
+    public function __construct( AnnotatedSingleton $annotatedSingleton )
+    {
+        $this->annotatedSingleton = $annotatedSingleton;
+        self::$instances[] = $this;
+    }
+
+} 

--- a/tests/Mock/TestLogger.php
+++ b/tests/Mock/TestLogger.php
@@ -19,8 +19,9 @@ class TestLogger implements LoggerInterface
      * @param array  $setter
      * @param object $object
      * @param Bind   $bind
+     * @param bool $isSingleton
      */
-    public function log($class, array $params, array $setter, $object, Bind $bind)
+    public function log($class, array $params, array $setter, $object, Bind $bind, $isSingleton = false)
     {
         $construct = serialize($params);
         $setter = serialize($setter);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,3 +31,8 @@ $rm(__DIR__ . '/tmp');
 
 $_ENV['TMP_DIR'] = __DIR__ . '/tmp';
 $_ENV['PACKAGE_DIR'] = dirname(__DIR__);
+
+
+if( function_exists( 'xdebug_break' ) ) {
+    ini_set( 'xdebug.max_nesting_level', 200 );
+}


### PR DESCRIPTION
- `ChildInjector` implementation so that `Injector` may know of result from `DiCompiler`
- $isSingleton in `Injector::getInstance` is now trustworthy
- Fixes test relating to singletons
