### PR TITLE
Fix class to class/instance bindings (#89)

### DIFF
--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -48,9 +48,6 @@ final class Dependency implements DependencyInterface
     public function register(array &$container, Bind $bind)
     {
         $index = (string) $bind;
-        if (isset($container[$index])) {
-            return;
-        }
         $container[$index] = $bind->getBound();
     }
 

--- a/src/Instance.php
+++ b/src/Instance.php
@@ -24,11 +24,7 @@ final class Instance implements DependencyInterface
     public function register(array &$container, Bind $bind)
     {
         $index = (string) $bind;
-        if (! isset($container[$index])) {
-            $container[$index] = $bind->getBound();
-
-            return;
-        }
+        $container[$index] = $bind->getBound();
     }
 
     /**


### PR DESCRIPTION
Since targeted bindings are done in two steps (chained calls), untargeted bindings are created eagerly. However, targeted bindings must then override untargeted bindings, which does not happen.
