### PR TITLE
AbstractModule::rename($interface, $newName)

### DIFF
--- a/src/AbstractModule.php
+++ b/src/AbstractModule.php
@@ -23,11 +23,17 @@ abstract class AbstractModule
     private $container;
 
     /**
+     * @var AbstractModule
+     */
+    protected $lastModule;
+
+    /**
      * @param AbstractModule $module
      */
     public function __construct(
         AbstractModule $module = null
     ) {
+        $this->lastModule = $module;
         $this->activate();
         if ($module) {
             $this->container->merge($module->getContainer());
@@ -96,5 +102,17 @@ abstract class AbstractModule
         $this->container = new Container;
         $this->matcher = new Matcher;
         $this->configure();
+    }
+
+    /**
+     * @param string $interface
+     * @param string $newName
+     * @param string $sourceName
+     * @param string $targetInterface
+     */
+    public function rename($interface, $newName, $sourceName = Name::ANY, $targetInterface = '')
+    {
+        $targetInterface = $targetInterface ?: $interface;
+        $this->lastModule->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
     }
 }

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -75,12 +75,10 @@ final class AnnotatedClassMethods
     {
         $bindAnnotation = $this->getBindAnnotation($method);
         if ($bindAnnotation) {
-
             return $bindAnnotation;
         }
         $namedAnnotation = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
         if ($namedAnnotation) {
-
             return $namedAnnotation;
         }
 
@@ -98,7 +96,6 @@ final class AnnotatedClassMethods
         foreach ($annotations as $annotation) {
             $bindAnnotation = $this->findBindAnnotation($annotation);
             if ($bindAnnotation) {
-
                 return $bindAnnotation;
             }
         }
@@ -115,7 +112,6 @@ final class AnnotatedClassMethods
     {
         $bindingAnnotation = $this->reader->getClassAnnotation(new \ReflectionClass($annotation), 'Ray\Di\Di\Qualifier');
         if (! $bindingAnnotation) {
-
             return null;
         }
         $named = new Named;

--- a/src/Container.php
+++ b/src/Container.php
@@ -72,6 +72,23 @@ final class Container
     }
 
     /**
+     * @param string $sourceInterface
+     * @param string $sourceName
+     * @param string $targetInterface
+     * @param string $targetName
+     */
+    public function move($sourceInterface, $sourceName, $targetInterface, $targetName)
+    {
+        $sourceIndex = $sourceInterface . '-' . $sourceName;
+        if (! isset($this->container[$sourceIndex])) {
+            $this->unbound($sourceIndex);
+        }
+        $targetIndex = $targetInterface . '-' . $targetName;
+        $this->container[$targetIndex] = $this->container[$sourceIndex];
+        unset($this->container[$sourceIndex]);
+    }
+
+    /**
      * @param string $index {interface}-{bind name}
      */
     public function unbound($index)

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -58,7 +58,6 @@ final class Dependency implements DependencyInterface
     {
         // singleton ?
         if ($this->isSingleton === true && $this->instance) {
-
             return $this->instance;
         }
 

--- a/src/DependencyProvider.php
+++ b/src/DependencyProvider.php
@@ -47,7 +47,6 @@ final class DependencyProvider implements DependencyInterface
     public function inject(Container $container)
     {
         if ($this->isSingleton && $this->instance) {
-
             return $this->instance;
         }
         $this->instance = $this->dependency->inject($container)->get();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -15,7 +15,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
         $this->container = new Container;
         $this->engine = new FakeEngine;
-        $bind = (new Bind($this->container, FakeEngineInterface::class))->toInstance($this->engine);
+        (new Bind($this->container, FakeEngineInterface::class))->toInstance($this->engine);
     }
 
     public function testGetDependency()
@@ -27,7 +27,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testClassGetDependency() {
-        $bind = (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
+        (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
         $dependencyIndex = FakeEngine::class . '-' . Name::ANY;
         $instance = $this->container->getDependency($dependencyIndex);
         $this->assertInstanceOf(FakeEngine::class, $instance);
@@ -35,7 +35,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testProviderGetDependency() {
-        $bind = (new Bind($this->container, FakeEngine::class))->toProvider(FakeEngineProvider::class);
+        (new Bind($this->container, FakeEngine::class))->toProvider(FakeEngineProvider::class);
         $dependencyIndex = FakeEngine::class . '-' . Name::ANY;
         $instance = $this->container->getDependency($dependencyIndex);
         $this->assertInstanceOf(FakeEngine::class, $instance);
@@ -49,14 +49,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testClassGetInstance() {
-        $bind = (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
+        (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
         $instance = $this->container->getInstance(FakeEngine::class, Name::ANY);
         $this->assertInstanceOf(FakeEngine::class, $instance);
         $this->assertSame($this->engine, $instance);
     }
 
     public function testProviderGetInstance() {
-        $bind = (new Bind($this->container, FakeEngine::class))->toProvider(FakeEngineProvider::class);
+        (new Bind($this->container, FakeEngine::class))->toProvider(FakeEngineProvider::class);
         $instance = $this->container->getInstance(FakeEngine::class, Name::ANY);
         $this->assertInstanceOf(FakeEngine::class, $instance);
     }
@@ -69,7 +69,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testClassGetContainer() {
-        $bind = (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
+        (new Bind($this->container, FakeEngine::class))->toInstance($this->engine);
         $array = $this->container->getContainer();
         $dependencyIndex = FakeEngine::class . '-' . Name::ANY;
         $this->assertArrayHasKey($dependencyIndex, $array);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,8 @@
 
 namespace Ray\Di;
 
+use Ray\Di\Exception\Unbound;
+
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -84,5 +86,20 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $array = $this->container->getContainer();
         $this->assertArrayHasKey(FakeEngineInterface::class . '-' . Name::ANY,  $array);
         $this->assertArrayHasKey(FakeRobotInterface::class . '-' . Name::ANY,  $array);
+    }
+
+    public function testMove()
+    {
+        $newName = 'new';
+        $this->container->move(FakeEngineInterface::class, Name::ANY, FakeEngineInterface::class, $newName);
+        $dependencyIndex = FakeEngineInterface::class . '-' . $newName;
+        $instance = $this->container->getDependency($dependencyIndex);
+        $this->assertInstanceOf(FakeEngine::class, $instance);
+    }
+
+    public function testMoveUnbound()
+    {
+        $this->setExpectedException(Unbound::class);
+        $this->container->move(FakeEngineInterface::class, 'invalid', FakeEngineInterface::class, 'new');
     }
 }

--- a/tests/Fake/FakeRenameModule.php
+++ b/tests/Fake/FakeRenameModule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeRenameModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->rename(FakeRobotInterface::class, 'original');
+    }
+}

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -24,4 +24,11 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(NotFound::class);
         new FakeToBindInvalidClassModule;
     }
+
+    public function testRename()
+    {
+        $module = new FakeRenameModule(new FakeToBindModule);
+        $instance = $module->getContainer()->getInstance(FakeRobotInterface::class, 'original');
+        $this->assertInstanceOf(FakeRobotInterface::class, $instance);
+    }
 }


### PR DESCRIPTION
You can re-bind exiting bound with `AbstractModule::rename()`

Example

``` php
class WebRouterModule extends AbstractModule
{
    protected function configure()
    {
        $this->bind(RouterInterface::class)->to(WebRouter::class);
    }
}
```

``` php
class AuraRouterModule extends AbstractModule
{
    protected function configure()
    {
        $this->rename(RouterInterface::class, 'original');
        $this->bind(RouterInterface::class)->to(AuraRouter::class);
    }
}
```

``` php
class AuraRouter implements RouterInterface
{
    /**
     * @Inject
     * @Named("original")
     */
    public function __construct(RouterInterface $router)
    {
        ....
```
### dependency graph
#### before:

``` php
$logger = (new Injector(new WebRouterModule)->getInstance(LoggerInterface::class); //  WebRouter
```

consumer → < RouterInterface:`*` > → **WebRouter**
#### after with **rename()** method

``` php
$logger = (new Injector(new AuraRouterModule(new WebRouterModule))->getInstance(LoggerInterface::class); //  AuraRouter
```

consumer → < RouterInterface:`*` > → **AuraRouter** →< RouterInterface:`original` > → **WebRouter**
