### PR TITLE
Remove duplicative adding bind to container

### DIFF
--- a/src/AbstractModule.php
+++ b/src/AbstractModule.php
@@ -92,8 +92,7 @@ abstract class AbstractModule
         $pointcut = new Pointcut($classMatcher, $methodMatcher, $interceptors);
         $this->container->addPointcut($pointcut);
         foreach ($interceptors as $interceptor) {
-            $bind = (new Bind($this->container, $interceptor))->to($interceptor)->in(Scope::SINGLETON);
-            $this->container->add($bind);
+            (new Bind($this->container, $interceptor))->to($interceptor)->in(Scope::SINGLETON);
         }
     }
 


### PR DESCRIPTION
On `AbstractModule::bindInterceptor`, `$this->container->add($bind);` is unnecessary because calling `->to($interceptor)` already adds it. ([here](https://github.com/koriym/Ray.Di/blob/develop-2/src/Bind.php#L91))

This PR removes this unnecessary code.
