### PR TITLE
Enable to instal AOP binding after other binding

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -123,7 +123,7 @@ final class Container
     public function merge(Container $container)
     {
         $this->container = $this->container + $container->getContainer();
-        $this->pointcuts = $this->pointcuts + $container->getPointcuts();
+        $this->pointcuts = array_merge($this->pointcuts, $container->getPointcuts());
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,8 @@
 
 namespace Ray\Di;
 
+use Ray\Aop\Matcher;
+use Ray\Aop\Pointcut;
 use Ray\Di\Exception\Unbound;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
@@ -86,6 +88,22 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $array = $this->container->getContainer();
         $this->assertArrayHasKey(FakeEngineInterface::class . '-' . Name::ANY,  $array);
         $this->assertArrayHasKey(FakeRobotInterface::class . '-' . Name::ANY,  $array);
+    }
+
+    public function testMergePointcuts()
+    {
+        $extraContainer = new Container;
+        $pointcut1 = new Pointcut((new Matcher)->any(), (new Matcher)->any(), ['Interceptor1']);
+        $pointcut2 = new Pointcut((new Matcher)->any(), (new Matcher)->any(), ['Interceptor2']);
+        $this->container->addPointcut($pointcut1);
+        $extraContainer->addPointcut($pointcut2);
+        $this->container->merge($extraContainer);
+        $array = [];
+        foreach ($this->container->getPointcuts() as $pointcut) {
+            $array[] = $pointcut->interceptors[0];
+        }
+        $this->assertContains('Interceptor1', $array);
+        $this->assertContains('Interceptor2', $array);
     }
 
     public function testMove()

--- a/tests/Fake/FakeAopDoublyInstallModule.php
+++ b/tests/Fake/FakeAopDoublyInstallModule.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeAopDoublyInstallModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->install(new FakeAopInterceptorModule);
+        $this->install(new FakeAopInterceptorModule);
+        $this->install(new FakeAopInterfaceModule);
+    }
+}

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -212,6 +212,24 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(4, $result);
     }
 
+    public function testAopBoundInDifferentModuleAfterAnotherBinding()
+    {
+        $injector = new Injector(new FakeAopInstallModule(new FakeAopModule));
+        $instance = $injector->getInstance(FakeAopInterface::class);
+        /** @var $instance FakeAop */
+        $result = $instance->returnSame(2);
+        $this->assertSame(8, $result);
+    }
+
+    public function testAopBoundDoublyInDifferentModule()
+    {
+        $injector = new Injector(new FakeAopDoublyInstallModule);
+        $instance = $injector->getInstance(FakeAopInterface::class);
+        /** @var $instance FakeAop */
+        $result = $instance->returnSame(2);
+        $this->assertSame(8, $result);
+    }
+
     public function testAopClassAutoloader()
     {
         passthru('php ' . __DIR__ . '/script/aop.php');


### PR DESCRIPTION
This PR fixes following bug:

Installing AOP binding from other Module overrides previous set bindings.

Note:
- In Container, `pointcuts` is a [simple array](https://github.com/koriym/Ray.Di/blob/develop-2/src/Container.php#L41). (with key 0, 1, ...)
- When `pointcuts` is merged to other Container's one, [the right term is ignored](https://github.com/koriym/Ray.Di/blob/develop-2/src/Container.php#L126).
