### PR TITLE
Take annotated constant in constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         },
         "files": [
             "tests/Fake/FakeLeft.php",
-            "tests/Fake/FakeRight.php"
+            "tests/Fake/FakeRight.php",
+            "tests/Fake/FakeConstant.php"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,7 @@
             "FakeVendor\\Sandbox\\": "tests/Fake/FakeVendor/Sandbox/"
         },
         "files": [
-            "tests/Fake/FakeLeft.php",
-            "tests/Fake/FakeRight.php",
-            "tests/Fake/FakeConstant.php"
+            "tests/annotations.php"
         ]
     },
     "extra": {

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -36,11 +36,15 @@ final class AnnotatedClassMethods
             return new Name(Name::ANY);
         }
         $named = $this->reader->getMethodAnnotation($constructor, 'Ray\Di\Di\Named');
-        if (! $named) {
-            return new Name(Name::ANY);
+        if ($named) {
+            /** @var $named Named */
+            return new Name($named->value);
         }
-        /** @var $named Named */
-        return new Name($named->value);
+        $qualifierAnnotation = $this->getMethodAnnotation($constructor);
+        if ($qualifierAnnotation) {
+            return new Name($qualifierAnnotation->value);
+        }
+        return new Name(Name::ANY);
     }
 
     /**

--- a/src/BindValidator.php
+++ b/src/BindValidator.php
@@ -33,7 +33,8 @@ final class BindValidator
             throw new NotFound($class);
         }
         if (interface_exists($interface) && ! (new \ReflectionClass($class))->implementsInterface($interface)) {
-            throw new InvalidType($class);
+            $msg = "[{$class}] is no implemented [{$interface}] interface";
+            throw new InvalidType($msg);
         }
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -135,4 +135,16 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
             $this->assertSame(Unbound::class, get_class($e));
         }
     }
+
+    public function testAnnotateConstant()
+    {
+        $container = new Container;
+        //FakeConstantInterface
+        $container->add((new Bind($container, ''))->annotatedWith(FakeConstant::class)->toInstance('kuma'));
+        $container->add((new Bind($container, FakeConstantConsumer::class)));
+        /** @var $instance FakeConstantConsumer */
+        $instance = $container->getInstance(FakeConstantConsumer::class, Name::ANY);
+        $this->assertSame('kuma', $instance->constant);
+    }
+
 }

--- a/tests/Fake/FakeConstant.php
+++ b/tests/Fake/FakeConstant.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ * @Qualifier
+ */
+final class FakeConstant
+{
+}

--- a/tests/Fake/FakeConstantConsumer.php
+++ b/tests/Fake/FakeConstantConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeConstantConsumer
+{
+    public $constant;
+
+    /**
+     * @FakeConstant
+     */
+    public function __construct($constant)
+    {
+        $this->constant = $constant;
+    }
+}

--- a/tests/Fake/FakeConstantInterface.php
+++ b/tests/Fake/FakeConstantInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ray\Di;
+
+interface FakeConstantInterface
+{
+}

--- a/tests/Fake/FakeConstantModule.php
+++ b/tests/Fake/FakeConstantModule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeConstantModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind()->annotatedWith(FakeConstant::class)->toInstance('kuma');
+    }
+}

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -261,4 +261,12 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         $expect = [FakeAnnoInterceptor4::class, FakeAnnoInterceptor1::class, FakeAnnoInterceptor2::class, FakeAnnoInterceptor3::class, FakeAnnoInterceptor5::class];
         $this->assertSame($expect, FakeAnnoClass::$order);
     }
+
+    public function testAnnotateConstant()
+    {
+        /** @var $instance FakeConstantConsumer */
+        $instance = (new Injector(new FakeConstantModule, $_ENV['TMP_DIR']))->getInstance(FakeConstantConsumer::class);
+        $this->assertSame('kuma', $instance->constant);
+
+    }
 }

--- a/tests/annotations.php
+++ b/tests/annotations.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once __DIR__ . "/Fake/FakeLeft.php";
+require_once __DIR__ . "/Fake/FakeRight.php";
+require_once __DIR__ . "/Fake/FakeConstant.php";


### PR DESCRIPTION
Constant annotation

``` php
use Ray\Di\Di\Qualifier;

/**
 * @Annotation
 * @Target("METHOD")
 * @Qualifier
 */
final class FakeConstant
{
}
```

Constant consumer

``` php
class FakeConstantConsumer
{
    public $constant;

    /**
     * @FakeConstant
     */
    public function __construct($constant)
    {
        $this->constant = $constant; // kuma
    }
}
```

Constant binding in module.

``` php
class FakeConstantModule extends AbstractModule
{
    protected function configure()
    {
        $this->bind()->annotatedWith(FakeConstant::class)->toInstance('kuma');
    }
}
```

``` php
```
