### PR TITLE
binding annotation can specify var name

### DIFF
--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -119,7 +119,7 @@ final class AnnotatedClassMethods
             return null;
         }
         $named = new Named;
-        $named->value = get_class($annotation);
+        $named->value = isset($annotation->value) ? sprintf("%s=%s", $annotation->value, get_class($annotation)) : get_class($annotation);
 
         return $named;
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -144,7 +144,11 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $container->add((new Bind($container, FakeConstantConsumer::class)));
         /** @var $instance FakeConstantConsumer */
         $instance = $container->getInstance(FakeConstantConsumer::class, Name::ANY);
-        $this->assertSame('kuma', $instance->constant);
+        $this->assertSame('kuma', $instance->constantByConstruct);
+        $this->assertSame('kuma', $instance->constantBySetter);
+        $this->assertSame('kuma', $instance->setterConstantWithoutVarName);
+        $this->assertSame('default_construct', $instance->defaultByConstruct);
+        $this->assertSame('default_setter', $instance->defaultBySetter);
     }
 
 }

--- a/tests/Fake/FakeConstant.php
+++ b/tests/Fake/FakeConstant.php
@@ -11,4 +11,5 @@ use Ray\Di\Di\Qualifier;
  */
 final class FakeConstant
 {
+    public $value;
 }

--- a/tests/Fake/FakeConstantConsumer.php
+++ b/tests/Fake/FakeConstantConsumer.php
@@ -2,15 +2,45 @@
 
 namespace Ray\Di;
 
+use Ray\Di\Di\Inject;
+
 class FakeConstantConsumer
 {
-    public $constant;
+    public $constantByConstruct;
+
+    public $constantBySetter;
+
+    public $defaultByConstruct;
+
+    public $defaultBySetter;
+
+    public $setterConstantWithoutVarName;
+
+    /**
+     * @FakeConstant("constant")
+     */
+    public function __construct($constant, $default = 'default_construct')
+    {
+        $this->constantByConstruct = $constant;
+        $this->defaultByConstruct = $default;
+    }
+
+    /**
+     * @FakeConstant("constant")
+     * @Inject
+     */
+    public function setFakeConstant($constant, $default = 'default_setter')
+    {
+        $this->constantBySetter = $constant;
+        $this->defaultBySetter = $default;
+    }
 
     /**
      * @FakeConstant
+     * @Inject
      */
-    public function __construct($constant)
+    public function setFakeConstantWithoutVarName($constant)
     {
-        $this->constant = $constant;
+        $this->setterConstantWithoutVarName = $constant;
     }
 }

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -266,7 +266,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
     {
         /** @var $instance FakeConstantConsumer */
         $instance = (new Injector(new FakeConstantModule, $_ENV['TMP_DIR']))->getInstance(FakeConstantConsumer::class);
-        $this->assertSame('kuma', $instance->constant);
+        $this->assertSame('default_construct', $instance->defaultByConstruct);
 
     }
 }


### PR DESCRIPTION
Binding

``` php
class FakeConstantModule extends AbstractModule
{
    protected function configure()
    {
        $this->bind()->annotatedWith(LogDir::class)->toInstance('/path/to/log');
    }
}
```

Consumer

``` php
    /**
     * @LogDir
     */
    public function __construct($dir)
    {
        $this->logDir = $dir;
    }

    /**
     * @LogDir("dir") // specif var name
     * @Inject
     */
    public function setLogDirectory($dir, $type)
    {
        $this->logDir = $dir;
    }
```
