### PR TITLE
CDI (Context and Dependency Injection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,57 @@ Finally we bind to the provider using the `toProvider()` method:
 $this->bind(TransactionLogInterface::class)->toProvider(DatabaseTransactionLogProvider::class);
 ```
 
-### Named Binding
+### Binding Annotations
+
+Occasionally you'll want multiple bindings for a same type. For example, you might want both a PayPal credit card processor and a Google Checkout processor.
+To enable this, bindings support an optional binding annotation. The annotation and type together uniquely identify a binding. This pair is called a key.
+
+Define qualifier annotation first. It needs to be annotated with `@Qualifier` annotation.
+
+```php
+
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ * @Qualifier
+ */
+final class PayPal
+{
+}
+```
+
+To depend on the annotated binding, apply the annotation to the injected parameter:
+
+```php
+/**
+ * @PayPal
+ */
+public __construct(CreditCardProcessorInterface $processor, TransactionLogInterface $transactionLog){
+{
+}
+```
+You can specify parameter name with qualifier. Qualifier applied all parameters without it.
+
+```php
+/**
+ * @PayPal("processor")
+ */
+public __construct(CreditCardProcessorInterface $processor, TransactionLogInterface $transactionLog){
+{
+ ....
+}
+```
+Lastly we create a binding that uses the annotation. This uses the optional annotatedWith clause in the bind() statement:
+```php
+protected function configure()
+{
+    $this->bind(CreditCardProcessorInterface::class)
+        ->annotatedWith(PayPal::class)
+        ->to(PayPalCreditCardProcessor::class);
+```
+### @Named
 
 Ray comes with a built-in binding annotation `@Named` that takes a string.
 
@@ -134,7 +184,7 @@ use Ray\Di\Di\Named;
  *  @Inject
  *  @Named("processor=checkout")
  */
-public RealBillingService(CreditCardProcessorInterface $processor)
+public __construct(CreditCardProcessorInterface $processor)
 {
 ...
 ```
@@ -143,7 +193,9 @@ To bind a specific name, pass that string using the `annotatedWith()` method.
 ```php
 protected function configure()
 {
-    $this->bind(CreditCardProcessorInterface::class)->annotatedWith('checkout')->to(CheckoutCreditCardProcessor::class);
+    $this->bind(CreditCardProcessorInterface::class)
+        ->annotatedWith('checkout')
+        ->to(CheckoutCreditCardProcessor::class);
 }
 ```
 
@@ -154,9 +206,9 @@ use Ray\Di\Di\Named;
 
 /**
  *  @Inject
- *  @Named("processor=checkout,backup=subProcessor")
+ *  @Named("processor=checkout,subProcessor=backUp")
  */
-public RealBillingService(CreditCardProcessorInterface $processor, CreditCardProcessorInterface $subProcessor)
+public __construct(CreditCardProcessorInterface $processor, CreditCardProcessorInterface $subProcessor)
 {
 ...
 ```
@@ -174,7 +226,9 @@ You can bind a type to an instance of that type. This is usually only useful for
 ```php
 protected function configure()
 {
-    $this->bind()->annotatedWith("login_id")->toInstance('bear');
+    $this->bind()
+        ->annotatedWith("login_id")
+        ->toInstance('bear');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,10 @@ class Psr3LoggerProvider implements ProviderInterface
     }
 }
 ```
-
+Obtains the qualifiers
+```php
+$annotations =  $this->ip->getQualifiers();
+```
 ## Automatic Injection
 
 Ray.Di automatically injects all of the following:

--- a/README.md
+++ b/README.md
@@ -254,6 +254,35 @@ public function init()
     //....
 }
 ```
+## Injection Point
+
+An **InjectionPoint** is a class that has information about an injection point. 
+It provides access to metadata via `\ReflectionParameter` or an annotation in `Provider`.
+
+For example, the following get method of `Psr3LoggerProvider` class creates injectable Loggers. The log category of a Logger depends upon the class of the object into which it is injected.
+
+```php
+class Psr3LoggerProvider implements ProviderInterface
+{
+    /**
+     * @var InjectionPoint
+     */
+    private $ip;
+
+    public function __construct(InjectionPointInterface $ip)
+    {
+        $this->ip = $ip;
+    }
+
+    public function get()
+    {
+        $logger = new \Monolog\Logger($this->ip->getClass->getName());
+        $logger->pushHandler(new StreamHandler('path/to/your.log', Logger::WARNING));
+
+        return logger;
+    }
+}
+```
 
 ## Automatic Injection
 

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -6,6 +6,7 @@
  */
 namespace Ray\Di;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Ray\Di\Exception\Unbound;
 
 final class Arguments
@@ -50,11 +51,21 @@ final class Arguments
      */
     private function getParameter(Container $container, Argument $argument)
     {
+        $this->bindInjectionPoint($container, $argument);
         try {
             return $container->getDependency((string) $argument);
         } catch (Unbound $e) {
             return $this->getDefaultValue($argument);
         }
+    }
+
+    private function bindInjectionPoint(Container $container, Argument $argument)
+    {
+        $isSelf = (string) $argument === 'Ray\Di\InjectionPointInterface-*';
+        if ($isSelf) {
+            return;
+        }
+        (new Bind($container, 'Ray\Di\InjectionPointInterface'))->toInstance(new InjectionPoint($argument->get(), new AnnotationReader));
     }
 
     /**

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of the Ray package.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Di;
+
+use Doctrine\Common\Annotations\Reader;
+
+final class InjectionPoint implements InjectionPointInterface
+{
+    /**
+     * @var \ReflectionParameter
+     */
+    private $parameter;
+
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    public function __construct(\ReflectionParameter $parameter, Reader $reader)
+    {
+        $this->parameter = $parameter;
+        $this->reader = $reader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameter()
+    {
+        return $this->parameter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethod()
+    {
+        return $this->parameter->getDeclaringFunction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        return $this->parameter->getDeclaringClass();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMethodAnnotation($annotation = null)
+    {
+        if ($annotation) {
+            return $this->reader->getMethodAnnotation($this->getMethod(), $annotation);
+        }
+
+        return $this->reader->getMethodAnnotations($this->getMethod());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassAnnotation($annotation = null)
+    {
+        if ($annotation) {
+            return $this->reader->getClassAnnotation($this->getClass(), $annotation);
+        }
+
+        return $this->reader->getClassAnnotations($this->getClass());
+    }
+}

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -53,24 +53,20 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritdoc}
      */
-    public function getMethodAnnotation($annotation = null)
+    public function getQualifiers()
     {
-        if ($annotation) {
-            return $this->reader->getMethodAnnotation($this->getMethod(), $annotation);
+        $qualifiers = [];
+        $annotations = $this->reader->getMethodAnnotations($this->getMethod());
+        foreach ($annotations as $annotation) {
+            $qualifier = $this->reader->getClassAnnotation(
+                new \ReflectionClass($annotation),
+                'Ray\Di\Di\Qualifier'
+            );
+            if ($qualifier) {
+                $qualifiers[] = $annotation;
+            }
         }
 
-        return $this->reader->getMethodAnnotations($this->getMethod());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getClassAnnotation($annotation = null)
-    {
-        if ($annotation) {
-            return $this->reader->getClassAnnotation($this->getClass(), $annotation);
-        }
-
-        return $this->reader->getClassAnnotations($this->getClass());
+        return $qualifiers;
     }
 }

--- a/src/InjectionPointInterface.php
+++ b/src/InjectionPointInterface.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the Ray package.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Di;
+
+interface InjectionPointInterface
+{
+    /**
+     * Return parameter reflection
+     *
+     * @return \ReflectionParameter
+     */
+    public function getParameter();
+
+    /**
+     * Return method reflection
+     *
+     * @return \ReflectionMethod
+     */
+    public function getMethod();
+
+    /**
+     * Return class reflection
+     *
+     * @return \ReflectionClass
+     */
+    public function getClass();
+
+    /**
+     * Return method annotation
+     *
+     * @param object $annotation
+     *
+     * @return mixed
+     */
+    public function getMethodAnnotation($annotation = null);
+
+    /**
+     * Return class annotation
+     *
+     * @param object $annotation
+     *
+     * @return mixed
+     */
+    public function getClassAnnotation($annotation = null);
+}

--- a/src/InjectionPointInterface.php
+++ b/src/InjectionPointInterface.php
@@ -30,20 +30,11 @@ interface InjectionPointInterface
     public function getClass();
 
     /**
-     * Return method annotation
+     * Return Qualifier annotations
      *
      * @param object $annotation
      *
      * @return mixed
      */
-    public function getMethodAnnotation($annotation = null);
-
-    /**
-     * Return class annotation
-     *
-     * @param object $annotation
-     *
-     * @return mixed
-     */
-    public function getClassAnnotation($annotation = null);
+    public function getQualifiers();
 }

--- a/tests/Fake/FakeConstant.php
+++ b/tests/Fake/FakeConstant.php
@@ -6,7 +6,7 @@ use Ray\Di\Di\Qualifier;
 
 /**
  * @Annotation
- * @Target("METHOD")
+ * @Target({"CLASS","METHOD"})
  * @Qualifier
  */
 final class FakeConstant

--- a/tests/Fake/FakeInjectionPoint.php
+++ b/tests/Fake/FakeInjectionPoint.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Named;
+
+class FakeInjectionPoint implements ProviderInterface
+{
+    public $ip;
+
+    /**
+     * @param \ReflectionParameter $parameter
+     *
+     * @Named("aa")
+     */
+    public function __construct(\ReflectionParameter $ip)
+    {
+        $this->ip = $ip;
+    }
+
+    public function get()
+    {
+        if ($this->ip->getName())
+        return $this->ip;
+    }
+}

--- a/tests/Fake/FakeWalkRobot.php
+++ b/tests/Fake/FakeWalkRobot.php
@@ -17,7 +17,8 @@ class FakeWalkRobot
     public $rightLeg;
 
     /**
-     * @FakeConstant(10)
+     * @FakeConstant(10)  // qualifier
+     * @FakeAnnoMethod1   // non-qualifier
      */
     public function __construct(FakeLegInterface $rightLeg, FakeLegInterface $leftLeg)
     {

--- a/tests/Fake/FakeWalkRobot.php
+++ b/tests/Fake/FakeWalkRobot.php
@@ -1,0 +1,27 @@
+<?php
+namespace Ray\Di;
+
+/**
+ * @FakeConstant("class_constant_val")
+ */
+class FakeWalkRobot
+{
+    /**
+     * @var FakeLegInterface
+     */
+    public $leftLeg;
+
+    /**
+     * @var FakeLegInterface
+     */
+    public $rightLeg;
+
+    /**
+     * @FakeConstant(10)
+     */
+    public function __construct(FakeLegInterface $rightLeg, FakeLegInterface $leftLeg)
+    {
+        $this->rightLeg = $rightLeg;
+        $this->leftLeg = $leftLeg;
+    }
+}

--- a/tests/Fake/FakeWalkRobotLegProvider.php
+++ b/tests/Fake/FakeWalkRobotLegProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeWalkRobotLegProvider implements ProviderInterface
+{
+    /**
+     * @var InjectionPoint
+     */
+    private $ip;
+
+    public function __construct(InjectionPointInterface $ip)
+    {
+        $this->ip = $ip;
+    }
+
+    public function get()
+    {
+        $varName = $this->ip->getParameter()->getName();
+        if ($varName === 'leftLeg') {
+            return new FakeLeftLeg;
+        }
+        if ($varName === 'rightLeg') {
+            return new FakeRightLeg;
+        }
+
+        throw new \InvalidArgumentException('Unexpected var name for LegInterface: ' . $varName);
+    }
+}

--- a/tests/Fake/FakeWalkRobotModule.php
+++ b/tests/Fake/FakeWalkRobotModule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeWalkRobotModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeLegInterface::class)->toProvider(FakeWalkRobotLegProvider::class);
+    }
+}

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Ray\Di;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Ray\Di\Di\Qualifier;
+
+class InjectionPointTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var InjectionPointInterface
+     */
+    private $ip;
+
+    /**
+     * @var \ReflectionParameter
+     */
+    private $parameter;
+
+    protected function setUp()
+    {
+        $this->parameter = new \ReflectionParameter([FakeWalkRobot::class, '__construct'], 'rightLeg');
+        $this->ip = new InjectionPoint($this->parameter, new AnnotationReader);
+    }
+
+    public function testGetParameter()
+    {
+        $actual = $this->ip->getParameter();
+        $this->assertSame($this->parameter, $actual);
+    }
+
+    public function testGetMethod()
+    {
+        $actual = $this->ip->getMethod();
+        $this->assertSame((string) $this->parameter->getDeclaringFunction(), (string) $actual);
+    }
+
+    public function testGetClass()
+    {
+        $actual = $this->ip->getClass();
+        $this->assertSame((string) $this->parameter->getDeclaringClass(), (string) $actual);
+    }
+
+    public function testMethodAnnotation()
+    {
+        /** @var $constant FakeConstant */
+        $constant = $this->ip->getMethodAnnotation(FakeConstant::class);
+        $this->assertInstanceOf(FakeConstant::class, $constant);
+        $this->assertSame(10, $constant->value);
+    }
+
+    public function testMethodAnnotations()
+    {
+        /** @var $constant FakeConstant */
+        $annotations = $this->ip->getMethodAnnotation();
+        $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
+    }
+
+    public function testClassAnnotation()
+    {
+        /** @var $constant FakeConstant */
+        $constant = $this->ip->getClassAnnotation(FakeConstant::class);
+        $this->assertInstanceOf(FakeConstant::class, $constant);
+        $this->assertSame('class_constant_val', $constant->value);
+    }
+
+    public function testClassAnnotations()
+    {
+        /** @var $constant FakeConstant */
+        $annotations = $this->ip->getClassAnnotation();
+        $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
+    }
+}

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -45,6 +45,7 @@ class InjectionPointTest extends \PHPUnit_Framework_TestCase
     {
         /** @var $constant FakeConstant */
         $annotations = $this->ip->getQualifiers();
+        $this->assertSame(1, count($annotations));
         $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
     }
 }

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -41,33 +41,10 @@ class InjectionPointTest extends \PHPUnit_Framework_TestCase
         $this->assertSame((string) $this->parameter->getDeclaringClass(), (string) $actual);
     }
 
-    public function testMethodAnnotation()
+    public function testGetQualifiers()
     {
         /** @var $constant FakeConstant */
-        $constant = $this->ip->getMethodAnnotation(FakeConstant::class);
-        $this->assertInstanceOf(FakeConstant::class, $constant);
-        $this->assertSame(10, $constant->value);
-    }
-
-    public function testMethodAnnotations()
-    {
-        /** @var $constant FakeConstant */
-        $annotations = $this->ip->getMethodAnnotation();
-        $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
-    }
-
-    public function testClassAnnotation()
-    {
-        /** @var $constant FakeConstant */
-        $constant = $this->ip->getClassAnnotation(FakeConstant::class);
-        $this->assertInstanceOf(FakeConstant::class, $constant);
-        $this->assertSame('class_constant_val', $constant->value);
-    }
-
-    public function testClassAnnotations()
-    {
-        /** @var $constant FakeConstant */
-        $annotations = $this->ip->getClassAnnotation();
+        $annotations = $this->ip->getQualifiers();
         $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
     }
 }

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -267,6 +267,14 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
         /** @var $instance FakeConstantConsumer */
         $instance = (new Injector(new FakeConstantModule, $_ENV['TMP_DIR']))->getInstance(FakeConstantConsumer::class);
         $this->assertSame('default_construct', $instance->defaultByConstruct);
+    }
 
+    public function testContextualDependencyInjection()
+    {
+        $injector = new Injector(new FakeWalkRobotModule);
+        /** @var $robot FakeWalkRobot */
+        $robot = $injector->getInstance(FakeWalkRobot::class);
+        $this->assertInstanceOf(FakeLeftLeg::class, $robot->leftLeg);
+        $this->assertInstanceOf(FakeRightLeg::class, $robot->rightLeg);
     }
 }

--- a/tests/annotations.php
+++ b/tests/annotations.php
@@ -3,3 +3,4 @@
 require_once __DIR__ . "/Fake/FakeLeft.php";
 require_once __DIR__ . "/Fake/FakeRight.php";
 require_once __DIR__ . "/Fake/FakeConstant.php";
+require_once __DIR__ . "/Fake/FakeAnnoMethod1.php";


### PR DESCRIPTION
`InjectionPoint` provides access to metadata about an injection point. 

For example, the following `get` method creates injectable _Logger_ s. The log category of a Logger depends upon the class of the object into which it is injected.

``` php

class Psr3LoggerProvider implements ProviderInterface
{
    /**
     * @var InjectionPoint
     */
    private $ip;

    public function __construct(InjectionPointInterface $ip)
    {
        $this->ip = $ip;
    }

    public function get()
    {
        $logger = new \Monolog\Logger($this->ip->getClass->getName());
        $logger->pushHandler(new StreamHandler('path/to/your.log', Logger::WARNING));

        return logger;
    }
}
```

Following consumer takes the provided dependency.

``` php
class Consumer
{
    private $logger;

    public function __construct(LoggerInterface $logger)
    {
        $this->logger = $logger; // new Logger('Consumer');
    }
}
```

Obtains the qualifiers 

``` php
$annotations =  $this->ip->getQualifiers();
```
