### PR TITLE
"@Qualifier" annotation can specify parameter by parameter name

### DIFF
--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -106,9 +106,6 @@ final class AnnotatedClassMethods
                 $names[] = sprintf('%s=%s' ,$value ,get_class($annotation));
             }
         }
-        if (! $names) {
-            return '';
-        }
 
         return implode(',' ,$names);
     }

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -37,9 +37,9 @@ final class AnnotatedClassMethods
             /** @var $named Named */
             return new Name($named->value);
         }
-        $qualifierAnnotation = $this->getMethodAnnotation($constructor);
-        if ($qualifierAnnotation) {
-            return new Name($qualifierAnnotation->value);
+        $name = $this->getNamedKeyVarString($constructor);
+        if ($name) {
+            return new Name($name);
         }
         return new Name(Name::ANY);
     }
@@ -56,10 +56,8 @@ final class AnnotatedClassMethods
         if (! $inject) {
             return null;
         }
-        $named = $this->getMethodAnnotation($method);
-        /** @var $named \Ray\Di\Di\Named */
-        $name = $named ? $named->value : '';
-        $setterMethod = new SetterMethod($method, new Name($name));
+        $nameValue = $this->getNamedKeyVarString($method);
+        $setterMethod = new SetterMethod($method, new Name($nameValue));
         if ($inject->optional) {
             $setterMethod->setOptional();
         }
@@ -70,17 +68,22 @@ final class AnnotatedClassMethods
     /**
      * @param \ReflectionMethod $method
      *
-     * @return null|Named
+     * @return string
      */
-    private function getMethodAnnotation(\ReflectionMethod $method)
+    private function getNamedKeyVarString(\ReflectionMethod $method)
     {
-        $bindAnnotation = $this->getBindAnnotation($method);
-        if ($bindAnnotation) {
-            return $bindAnnotation;
+        $keyVal = [];
+        /** @var $named Named */
+        $named = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
+        if ($named) {
+            $keyVal[] = $named->value;
         }
-        $namedAnnotation = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
-        if ($namedAnnotation) {
-            return $namedAnnotation;
+        $qualifierNamed = $this->getQualifierKeyVarString($method);
+        if ($qualifierNamed) {
+            $keyVal[] = $qualifierNamed;
+        }
+        if ($keyVal) {
+            return implode(',', $keyVal); // var1=qualifier1,va2=qualifier2
         }
 
         return null;
@@ -89,36 +92,24 @@ final class AnnotatedClassMethods
     /**
      * @param \ReflectionMethod $method
      *
-     * @return null|Named
+     * @return string
      */
-    private function getBindAnnotation(\ReflectionMethod $method)
+    private function getQualifierKeyVarString(\ReflectionMethod $method)
     {
         $annotations = $this->reader->getMethodAnnotations($method);
+        $names = [];
         foreach ($annotations as $annotation) {
             /** @var $bindAnnotation object|null */
-            $bindAnnotation = $this->findBindAnnotation($annotation);
-            if ($bindAnnotation) {
-                return $bindAnnotation;
+            $qualifier = $this->reader->getClassAnnotation(new \ReflectionClass($annotation) ,'Ray\Di\Di\Qualifier');
+            if ($qualifier) {
+                $value = isset($annotation->value) ? $annotation->value : Name::ANY;
+                $names[] = sprintf('%s=%s' ,$value ,get_class($annotation));
             }
         }
-
-        return null;
-    }
-
-    /**
-     * @param object $annotation
-     *
-     * @return null|Named
-     */
-    private function findBindAnnotation($annotation)
-    {
-        $bindingAnnotation = $this->reader->getClassAnnotation(new \ReflectionClass($annotation), 'Ray\Di\Di\Qualifier');
-        if (! $bindingAnnotation) {
-            return null;
+        if (! $names) {
+            return '';
         }
-        $named = new Named;
-        $named->value = isset($annotation->value) ? sprintf("%s=%s", $annotation->value, get_class($annotation)) : get_class($annotation);
 
-        return $named;
+        return implode(',' ,$names);
     }
 }

--- a/src/Name.php
+++ b/src/Name.php
@@ -66,13 +66,14 @@ final class Name
         if ($this->name) {
             return $this->name;
         }
+
         // multiple variable named binding
-        if (is_array($this->names) && isset($this->names[$parameter->name])) {
+        if (isset($this->names[$parameter->name])) {
             return $this->names[$parameter->name];
         }
 
         // ANY match
-        if (is_array($this->names) && isset($this->names[Name::ANY])) {
+        if (isset($this->names[Name::ANY])) {
             return $this->names[Name::ANY];
         }
 

--- a/src/Name.php
+++ b/src/Name.php
@@ -71,6 +71,11 @@ final class Name
             return $this->names[$parameter->name];
         }
 
+        // ANY match
+        if (is_array($this->names) && isset($this->names[Name::ANY])) {
+            return $this->names[Name::ANY];
+        }
+
         // not matched
         return Name::ANY;
     }

--- a/tests/AnnotatedClassTest.php
+++ b/tests/AnnotatedClassTest.php
@@ -35,16 +35,26 @@ class AnnotatedClassTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($car->hardtop);
     }
 
-    public function testAnnotatedByAnnotation()
+    /**
+     * @dataProvider classProvider
+     */
+    public function testAnnotatedByAnnotation($class)
     {
-        $newInstance = $this->annotatedClass->getNewInstance(new \ReflectionClass(FakeHandleBar::class));
+        $newInstance = $this->annotatedClass->getNewInstance(new \ReflectionClass($class));
         $container = new Container;
         (new Bind($container, FakeMirrorInterface::class))->annotatedWith(FakeLeft::class)->to(FakeMirrorLeft::class);
         (new Bind($container, FakeMirrorInterface::class))->annotatedWith(FakeRight::class)->to(FakeMirrorRight::class);
         $handleBar = $newInstance($container);
         /** @var $handleBar FakeHandleBar */
-        $this->assertInstanceOf(FakeHandleBar::class, $handleBar);
         $this->assertInstanceOf(FakeMirrorLeft::class, $handleBar->leftMirror);
         $this->assertInstanceOf(FakeMirrorRight::class, $handleBar->rightMirror);
+    }
+
+    public function classProvider()
+    {
+        return [
+            [FakeHandleBar::class],
+            [FakeHandleBarQualifier::class]
+        ];
     }
 }

--- a/tests/Fake/FakeHandleBarQualifier.php
+++ b/tests/Fake/FakeHandleBarQualifier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeHandleBarQualifier
+{
+    public $rightMirror;
+
+    public $leftMirror;
+
+    /**
+     * @FakeRight("rightMirror")
+     * @FakeLeft("leftMirror")
+     */
+    public function __construct(FakeMirrorInterface $rightMirror, FakeMirrorInterface $leftMirror)
+    {
+        $this->rightMirror = $rightMirror;
+        $this->leftMirror = $leftMirror;
+    }
+}

--- a/tests/Fake/FakeLeft.php
+++ b/tests/Fake/FakeLeft.php
@@ -11,4 +11,5 @@ use Ray\Di\Di\Qualifier;
  */
 class FakeLeft
 {
+    public $value;
 }

--- a/tests/Fake/FakeRight.php
+++ b/tests/Fake/FakeRight.php
@@ -11,4 +11,5 @@ use Ray\Di\Di\Qualifier;
  */
 class FakeRight
 {
+    public $value;
 }


### PR DESCRIPTION
``` php
class FakeHandleBarQualifier
{
    public $rightMirror;

    public $leftMirror;

    /**
     * @FakeRight("rightMirror")
     * @FakeLeft("leftMirror")
     */
    public function __construct(FakeMirrorInterface $rightMirror, FakeMirrorInterface $leftMirror)
    {
        $this->rightMirror = $rightMirror;
        $this->leftMirror = $leftMirror;
    }
}
```

インッジェクションポイントを特定するための`Qualifier`アノテーションで変数名を指定が可能になる機能です。この例では`$rightMirror`の引数は`@FakeRight`という名前付きの依存にしています。
