### PR TITLE
JIT Binder

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -289,17 +289,15 @@ class AopMatcherModule extends AbstractModule
 インジェクターオブジェクトは全ての依存情報を保持していてシリアライズすることができます。
 `unserialize`したインジェクターではリフレクションやアノテーションを使用しないで、高速にインジェクションを行うことができます。
 
-
 ```php
-
-// save
-$injector = new Injector(new ListerModule);
-$cachedInjector = serialize($injector);
-
-// load
-$injector = unserialize($cachedInjector);
-$lister = $injector->getInstance(ListerInterface::class);
-
+$cache = new \Doctrine\Common\Cache\Cache\ApcCache;
+$cache->setNamespace('your-app');
+$injector = $cache->fetch('injector');
+if (! $injector) {
+    $injector = new Injector(new YourModule, $tmpDir, $cache);
+    $cache->save('injector', $injector);
+}
+$instance = $injector->getInstance(Foo::class);
 ```
 
 ## Requirement ##

--- a/README.md
+++ b/README.md
@@ -500,16 +500,18 @@ The class of this object should use injection to obtain references to other obje
 An dependency injector has compiled entire dependency graph which is serializable.  It has huge performance boosts.
 Unserialized injector can invoke injection without reflection or annotation in runtime. Recommended in production use. 
 
+
 ```php
-
-// save
-$injector = new Injector(new ListerModule);
-$cachedInjector = serialize($injector);
-
-// load
-$injector = unserialize($cachedInjector);
-$lister = $injector->getInstance(ListerInterface::class);
+$cache = new \Doctrine\Common\Cache\Cache\ApcCache;
+$cache->setNamespace('your-app');
+$injector = $cache->fetch('injector');
+if (! $injector) {
+    $injector = new Injector(new YourModule, $tmpDir, $cache);
+    $cache->save('injector', $injector);
+}
+$instance = $injector->getInstance(Foo::class);
 ```
+
 ## Frameworks integration ##
 
  * [lorenzo/piping-bag](https://github.com/lorenzo/piping-bag) for CakePHP3

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ray/aop": "~2.0"
+        "ray/aop": "~2.0",
+        "doctrine/cache": "~1.2"
     },
     "autoload": {
         "psr-4": {

--- a/docs/demo/11-untarget-cache.php
+++ b/docs/demo/11-untarget-cache.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ray\Di\Demo;
+
+use Doctrine\Common\Cache\FilesystemCache;
+use Ray\Di\EmptyModule;
+use Ray\Di\FakeRobot;
+use Ray\Di\FakeRobotTeam;
+use Ray\Di\Injector;
+
+require __DIR__ . '/bootstrap.php';
+
+// save file cache
+$tmpDir = __DIR__ . '/tmp';
+$cache = new FilesystemCache($tmpDir);
+$cache->setNamespace('test-11');
+
+$injector = $cache->fetch('injector');
+if (! $injector) {
+    $injector = new Injector(new EmptyModule, $tmpDir, $cache);
+    $cache->save('injector', $injector);
+    echo 'save, ';
+} else {
+    echo 'load, ';
+}
+$start = microtime(true);
+/* @var $robotTeam1 FakeRobotTeam */
+$robotTeam1 = $injector->getInstance(FakeRobotTeam::class);
+$time = microtime(true) - $start;
+
+$works = ($robotTeam1->robot1 instanceof FakeRobot) && ($robotTeam1->robot2 instanceof FakeRobot);
+echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo $time * 1000 . 'msec' . PHP_EOL;

--- a/docs/demo/run.php
+++ b/docs/demo/run.php
@@ -7,3 +7,7 @@ passthru('php ' . __DIR__ . '/03-provider-binding.php');
 passthru('php ' . __DIR__ . '/04-untarget-bindings.php');
 passthru('php ' . __DIR__ . '/06-install.php');
 passthru('php ' . __DIR__ . '/10-cache.php');
+passthru('rm -rf '  . __DIR__ . '/tmp/');
+passthru('php ' . __DIR__ . '/11-untarget-cache.php');
+passthru('php ' . __DIR__ . '/11-untarget-cache.php');
+passthru('php ' . __DIR__ . '/11-untarget-cache.php');

--- a/docs/demo/src/InstallRobot.php
+++ b/docs/demo/src/InstallRobot.php
@@ -2,8 +2,6 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Demo\Left;
-use Ray\Di\Demo\Right;
 use Ray\Di\Di\Inject;
 use Ray\Di\Di\Named;
 

--- a/docs/demo/src/NamedRobot.php
+++ b/docs/demo/src/NamedRobot.php
@@ -2,8 +2,6 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Demo\Left;
-use Ray\Di\Demo\Right;
 use Ray\Di\Di\Inject;
 use Ray\Di\Di\Named;
 

--- a/docs/demo/src/QualifierRobot.php
+++ b/docs/demo/src/QualifierRobot.php
@@ -2,8 +2,6 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Demo\Left;
-use Ray\Di\Demo\Right;
 use Ray\Di\Di\Inject;
 
 class QualifierRobot

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -58,7 +58,7 @@ final class Argument
     private function getTypeHint(\ReflectionParameter $parameter)
     {
         if (defined('HHVM_VERSION')) {
-            /** @noinspection PhpUndefinedFieldInspection */
+            /* @noinspection PhpUndefinedFieldInspection */
             return $parameter->info['type_hint']; // @codeCoverageIgnore
         }
         $typHint = $parameter->getClass();

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -8,6 +8,7 @@ namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Ray\Di\Exception\Unbound;
+use Ray\Di\Exception\Untargetted;
 
 final class Arguments
 {
@@ -56,6 +57,11 @@ final class Arguments
         $this->bindInjectionPoint($container, $argument);
         try {
             return $container->getDependency((string) $argument);
+        } catch (Untargetted $e) {
+            $container->bind($e->getMessage());
+            $dependency = $container->getDependency((string) $argument);
+
+            return $dependency;
         } catch (Unbound $e) {
             list($hasDefaultValue, $defaultValue) = $this->getDefaultValue($argument);
             if ($hasDefaultValue) {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -6,9 +6,7 @@
  */
 namespace Ray\Di;
 
-use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use Ray\Aop\Compiler;
 use Ray\Di\Exception\Untargetted;

--- a/src/JitBinder.php
+++ b/src/JitBinder.php
@@ -42,7 +42,7 @@ class JitBinder
 
     public function bind($class)
     {
-        $classId = str_replace('\\' ,'_', $class);
+        $classId = str_replace('\\', '_', $class);
         $untargetCache = $this->cache->fetch($classId);
         $index = "{$class}-*";
         if ($untargetCache) {
@@ -63,7 +63,6 @@ class JitBinder
         $bind = new Bind($this->container, $class);
         /** @var $bound Dependency */
         $bound = $bind->getBound();
-        $this->container->weaveAspect(new Compiler($this->classDir), $bound)->getInstance($class ,Name::ANY);
+        $this->container->weaveAspect(new Compiler($this->classDir), $bound)->getInstance($class, Name::ANY);
     }
-
 }

--- a/src/JitBinder.php
+++ b/src/JitBinder.php
@@ -50,7 +50,7 @@ class JitBinder
 
             return;
         }
-        $this->JitBind($class);
+        $this->jitBind($class);
         //error_log("ray.di jit:{$class}");
         $this->cache->save($classId, $this->container[$index]);
     }
@@ -58,7 +58,7 @@ class JitBinder
     /**
      * @param string $class
      */
-    private function JitBind($class)
+    private function jitBind($class)
     {
         $bind = new Bind($this->container, $class);
         /** @var $bound Dependency */

--- a/src/JitBinder.php
+++ b/src/JitBinder.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the Ray package.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\Di;
+
+use Doctrine\Common\Cache\Cache;
+use Ray\Aop\Compiler;
+
+class JitBinder
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * Aop class dir
+     *
+     * @var string
+     */
+    private $classDir;
+
+    /**
+     * @param Container $container
+     * @param Cache     $cache
+     * @param string    $classDir
+     */
+    public function __construct(Container $container, Cache $cache, $classDir)
+    {
+        $this->container = $container;
+        $this->cache = $cache;
+        $this->classDir = $classDir;
+    }
+
+    public function bind($class)
+    {
+        $classId = str_replace('\\' ,'_', $class);
+        $untargetCache = $this->cache->fetch($classId);
+        $index = "{$class}-*";
+        if ($untargetCache) {
+            $this->container[$index] = $untargetCache;
+
+            return;
+        }
+        $this->JitBind($class);
+        //error_log("ray.di jit:{$class}");
+        $this->cache->save($classId, $this->container[$index]);
+    }
+
+    /**
+     * @param string $class
+     */
+    private function JitBind($class)
+    {
+        $bind = new Bind($this->container, $class);
+        /** @var $bound Dependency */
+        $bound = $bind->getBound();
+        $this->container->weaveAspect(new Compiler($this->classDir), $bound)->getInstance($class ,Name::ANY);
+    }
+
+}

--- a/src/UntargetedBind.php
+++ b/src/UntargetedBind.php
@@ -32,7 +32,7 @@ final class UntargetedBind
     private function getTypeHint(\ReflectionParameter $parameter)
     {
         if (defined('HHVM_VERSION')) {
-            /** @noinspection PhpUndefinedFieldInspection */
+            /* @noinspection PhpUndefinedFieldInspection */
             return $parameter->info['type_hint']; // @codeCoverageIgnore
         }
         $typeHintClass = $parameter->getClass();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -3,6 +3,7 @@
 namespace Ray\Di;
 
 use Aura\Cli\Exception;
+use Doctrine\Common\Cache\ArrayCache;
 use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
 use Ray\Di\Exception\Unbound;
@@ -150,4 +151,15 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('default_construct', $instance->defaultByConstruct);
         $this->assertSame('default_setter', $instance->defaultBySetter);
     }
+
+    public function testUntargetedBinding()
+    {
+        $container = new Container;
+        $container->setDependencies(new ArrayCache, $_ENV['TMP_DIR']);
+        $container->bind(FakeRobotTeam::class);
+        /** @var $robotTeam FakeRobotTeam */
+        $robotTeam = $container->getInstance(FakeRobotTeam::class, Name::ANY);
+        $this->assertInstanceOf(FakeRobot::class, $robotTeam->robot1);
+    }
+
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -161,5 +161,4 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $robotTeam = $container->getInstance(FakeRobotTeam::class, Name::ANY);
         $this->assertInstanceOf(FakeRobot::class, $robotTeam->robot1);
     }
-
 }

--- a/tests/Fake/FakeConstantConsumer.php
+++ b/tests/Fake/FakeConstantConsumer.php
@@ -3,7 +3,6 @@
 namespace Ray\Di;
 
 use Ray\Di\Di\Inject;
-use Ray\Di\FakeConstant;
 
 class FakeConstantConsumer
 {

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -3,7 +3,6 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Ray\Di\Di\Qualifier;
 
 class InjectionPointTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/JitBinderTest.php
+++ b/tests/JitBinderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ray\Di;
+
+use Doctrine\Common\Cache\ArrayCache;
+
+class JitBinderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JitBinder
+     */
+    private $jitBinder;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = new Container;
+        $this->jitBinder = new JitBinder($this->container, new ArrayCache, $_ENV['TMP_DIR']);
+    }
+
+    public function testBind()
+    {
+        $this->jitBinder->bind(FakeRobotTeam::class);
+        $dependency = $this->container->getContainer()['Ray\Di\FakeRobotTeam-*'];
+        $this->assertInstanceOf(Dependency::class, $dependency);
+    }
+
+    public function testBindTwice()
+    {
+        $this->jitBinder->bind(FakeRobotTeam::class);
+        $this->jitBinder->bind(FakeRobotTeam::class);
+        $dependency = $this->container->getContainer()['Ray\Di\FakeRobotTeam-*'];
+        $this->assertInstanceOf(Dependency::class, $dependency);
+    }
+}


### PR DESCRIPTION
JIT Binder compile untargeted class and store cache.

The following sample code is taken from README.

``` php
$cache = new \Doctrine\Common\Cache\Cache\ApcCache;
$cache->setNamespace('your-app');
$injector = $cache->fetch('injector');
if (! $injector) {
    $injector = new Injector(new YourModule, $tmpDir, $cache);
    $cache->save('injector', $injector);
}
$instance = $injector->getInstance(Foo::class);
```
