### PR TITLE
[#121] windows compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4.0",
         "ray/aop": "~2.0",
-        "ray/compiler": "~0.1"
+        "ray/compiler": "~0.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -82,7 +82,7 @@ final class Arguments
 
     private function bindInjectionPoint(Container $container, Argument $argument)
     {
-        $isSelf = (string) $argument === 'Ray\Di\InjectionPointInterface-*';
+        $isSelf = (string) $argument === 'Ray\Di\InjectionPointInterface-' . Name::ANY;
         if ($isSelf) {
             return;
         }

--- a/src/Name.php
+++ b/src/Name.php
@@ -12,7 +12,7 @@ final class Name
     /**
      * 'Unnamed' name
      */
-    const ANY = '*';
+    const ANY = '';
 
     /**
      * @var string
@@ -20,6 +20,10 @@ final class Name
     private $name;
 
     /**
+     * Named database
+     *
+     * [named => varName][]
+     *
      * @var string[]
      */
     private $names;
@@ -29,7 +33,9 @@ final class Name
      */
     public function __construct($name)
     {
-        $this->setName($name);
+        if (! is_null($name)) {
+            $this->setName($name);
+        }
     }
 
     /**
@@ -50,11 +56,26 @@ final class Name
 
             return;
         }
-        // key=value name
-        // @Named(varName1=name1,varName2=name2)
-        parse_str(str_replace(',', '&', $name), $match);
-        $this->names = $match;
+        // name list
+        // @Named(varName1=name1, varName2=name2)]
+        $this->parseName($name);
     }
+
+    /**
+     * @param string $name
+     */
+    private function parseName($name)
+    {
+        $keyValues  = explode(',', $name);
+        foreach ($keyValues as $keyValue) {
+            $exploded = explode('=', $keyValue);
+            if (isset($exploded[1])) {
+                list($key, $value) = $exploded;
+                $this->names[trim($key)] = trim($value);
+            }
+        }
+    }
+
 
     /**
      * @param \ReflectionParameter $parameter

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -16,6 +16,6 @@ class ArgumentTest extends \PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $this->assertSame('Ray\Di\FakeEngineInterface-*', (string) $this->argument);
+        $this->assertSame('Ray\Di\FakeEngineInterface-' . NAME::ANY, (string) $this->argument);
     }
 }

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -27,7 +27,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $this->assertSame('Ray\Di\FakeTyreInterface-*', (string) $this->bind);
+        $this->assertSame('Ray\Di\FakeTyreInterface-' . NAME::ANY, (string) $this->bind);
     }
 
     public function testInvalidToTest()


### PR DESCRIPTION
Change `Name::Any` character from `*` to (none). This change is for the
windows compliance file name in Ray.Compiler

fix #121 
