### PR TITLE
fix concrete class binding issue

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -58,12 +58,15 @@ class Injector implements InjectorInterface
      */
     private function bind($class)
     {
-        $bind = new Bind($this->container, $class);
+        new Bind($this->container, $class);
         /* @var $bound Dependency */
-        $bound = $bind->getBound();
+        $bound = $this->container->getContainer()[$class . '-' . Name::ANY];
         $this->container->weaveAspect(new Compiler($this->classDir), $bound)->getInstance($class, Name::ANY);
     }
 
+    /**
+     * Wakeup
+     */
     public function __wakeup()
     {
         spl_autoload_register(
@@ -71,9 +74,8 @@ class Injector implements InjectorInterface
                 $file = $this->classDir . DIRECTORY_SEPARATOR . $class . '.php';
                 if (file_exists($file)) {
                     // @codeCoverageIgnoreStart
-                    /** @noinspection PhpIncludeInspection */
                     include $file;
-                    // @@codeCoverageIgnoreEnd
+                    // @codeCoverageIgnoreEnd
                 }
             }
         );

--- a/src/Untarget.php
+++ b/src/Untarget.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di;
+
+class Untarget
+{
+    /**
+     * @var \ReflectionClass
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $scope = Scope::PROTOTYPE;
+
+    /**
+     * @param string $class
+     */
+    public function __construct($class)
+    {
+        $this->class = new \ReflectionClass($class);
+    }
+
+    public function setScope($scope)
+    {
+        $this->scope = $scope;
+    }
+
+    /**
+     * Bind untargeted binding
+     *
+     * @param Container $container
+     * @param Bind      $bind
+     */
+    public function __invoke(Container $container, Bind $bind)
+    {
+        $bound = (new DependencyFactory)->newAnnotatedDependency($this->class);
+        $bound->setScope($this->scope);
+        $bind->setBound($bound);
+        $container->add($bind);
+        $constructor = $this->class->getConstructor();
+        if ($constructor) {
+            (new UntargetedBind)->__invoke($container, $constructor);
+        }
+    }
+}

--- a/src/UntargetedBind.php
+++ b/src/UntargetedBind.php
@@ -20,7 +20,7 @@ final class UntargetedBind
     {
         $class = $this->getTypeHint($parameter);
         if (class_exists($class)) {
-            $container->add(new Bind($container, $class));
+            new Bind($container, $class);
         }
     }
 

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -50,17 +50,20 @@ class BindTest extends \PHPUnit_Framework_TestCase
 
     public function testUntargetedBind()
     {
-        $bind = new Bind(new Container, FakeEngine::class);
-        $dependency = $bind->getBound();
-        $this->assertInstanceOf(Dependency::class, $dependency);
+        $container = new Container;
+        $bind = new Bind($container, FakeEngine::class);
+        unset($bind);
+        $container = $container->getContainer();
+        $this->assertArrayHasKey(FakeEngine::class . '-' . Name::ANY, $container);
     }
 
     public function testUntargetedBindSingleton()
     {
-        $bind = (new Bind(new Container, FakeEngine::class))->in(Scope::SINGLETON);
         $container = new Container;
-        $dependency1 = $bind->getBound()->inject($container);
-        $dependency2 = $bind->getBound()->inject($container);
+        $bind = (new Bind($container, FakeEngine::class))->in(Scope::SINGLETON);
+        unset($bind);
+        $dependency1 = $container->getInstance(FakeEngine::class, Name::ANY);
+        $dependency2 = $container->getInstance(FakeEngine::class, Name::ANY);
         $this->assertSame(spl_object_hash($dependency1), spl_object_hash($dependency2));
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -140,8 +140,8 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         $container = new Container;
         //FakeConstantInterface
-        $container->add((new Bind($container, ''))->annotatedWith(FakeConstant::class)->toInstance('kuma'));
-        $container->add((new Bind($container, FakeConstantConsumer::class)));
+        (new Bind($container, ''))->annotatedWith(FakeConstant::class)->toInstance('kuma');
+        (new Bind($container, FakeConstantConsumer::class));
         /* @var $instance FakeConstantConsumer */
         $instance = $container->getInstance(FakeConstantConsumer::class, Name::ANY);
         $this->assertSame('kuma', $instance->constantByConstruct);

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Ray\Di;
+
+use Ray\Compiler\DiCompiler;
+
+class DiCompilerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUntargetInject()
+    {
+        /* @var $fake FakeUntarget */
+        $module = new FakeUntargetModule;
+        $compiler = new DiCompiler($module, $_ENV['TMP_DIR']);
+        $compiler->compile();
+        $fake = $compiler->getInstance(FakeUntarget::class);
+        $this->assertSame(1, $fake->child->val);
+    }
+}

--- a/tests/Fake/FakeUntarget.php
+++ b/tests/Fake/FakeUntarget.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the _package_ package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+
+namespace Ray\Di;
+
+class FakeUntarget
+{
+    public $child;
+
+    public function __construct(FakeUntargetChild $child)
+    {
+        $this->child = $child;
+    }
+}

--- a/tests/Fake/FakeUntargetChild.php
+++ b/tests/Fake/FakeUntargetChild.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the _package_ package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+
+namespace Ray\Di;
+
+class FakeUntargetChild
+{
+    public $val;
+    
+    public function __construct($val)
+    {
+        $this->val = $val;
+    }
+}

--- a/tests/Fake/FakeUntargetModule.php
+++ b/tests/Fake/FakeUntargetModule.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the _package_ package
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+
+namespace Ray\Di;
+
+class FakeUntargetModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $instance = new FakeUntarget(new FakeUntargetChild(1));
+        $this->bind(FakeUntarget::class)->toInstance($instance);
+    }
+}

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Ray\Di;
 
+use Ray\Compiler\DiCompiler;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\Exception\Untargetted;
 
@@ -129,12 +130,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
     public function testGetConcreteClass()
     {
         $injector = new Injector;
-        try {
-            $robot = $injector->getInstance(FakeRobot::class);
-        } catch (Untargetted $e) {
-            $injector->bind(FakeRobot::class);
-            $robot = $injector->getInstance(FakeRobot::class);
-        }
+        $robot = $injector->getInstance(FakeRobot::class);
         $this->assertInstanceOf(FakeRobot::class, $robot);
     }
 


### PR DESCRIPTION
This binding can be problematic when concrete `Untarget` class can't resolve dependencies without `UntargetProvider`.

```
$thi->bind(Untarget::class)->toProvider(UntargetProvider::class);
```

Because `Untarget::class` is registered to `Container` even it has it has `toProvider` later. (This is because `Ray.Di` DSL does not have termination method.)

This PR change to `untarget binding` at `Bind::__destruct()`. It worked like as terminate method.

Great cooperation with Toshinai san, Arigato gozaimasu !
