### PR TITLE
avoid 'internal error' by reflection of unserialized parameter.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,8 @@ filter:
     paths: ["src/*"]
 tools:
     external_code_coverage: true
-    php_code_coverage: true
+    php_code_coverage:
+        timeout: 1200
     php_sim: true
     php_mess_detector: true
     php_pdepend: true

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -95,11 +95,6 @@ final class Argument
      */
     public function getDebugInfo()
     {
-        return sprintf(
-            "$%s in %s::%s()",
-            $this->reflection->getName(),
-            $this->reflection->getDeclaringClass()->getName(),
-            $this->reflection->getDeclaringFunction()->getName()
-        );
+        return $this->reflection->getName();
     }
 }


### PR DESCRIPTION
“ Internal error: Failed to retrieve the reflection object “

it is not nice to reduce debug information. but no idea. `getName()`
seems available at any time.
