### PR TITLE
fix error handling when no trace given

### DIFF
--- a/src/Exception/Unbound.php
+++ b/src/Exception/Unbound.php
@@ -14,6 +14,9 @@ class Unbound extends \LogicException implements ExceptionInterface
     {
         $messages = [sprintf("- %s\n", $this->getMessage())];
         $e = $this->getPrevious();
+        if (! $e instanceof \Exception) {
+            return $this->getMainMessage($this);
+        }
 
         return $this->buildMessage($e, $messages) . "\n" . $e->getTraceAsString();
     }


### PR DESCRIPTION
fix this

> Catchable fatal error: Argument 1 passed to Ray\Di\Exception\Unbound::buildMessage() must be an instance of Ray\Di\Exception\Unbound, null given, called in vendor/ray/di/src/Exception/Unbound.php on line 18 and defined in vendor/ray/di/src/Exception/Unbound.php on line 27
