### PR TITLE
@Assisted injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Ray.Di does not support property injection.
 
 ## Assisted Injection
 
-It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null and annotate the method with `@Assisted`.
+It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and annotate the method with `@Assisted` with having assisted parameter(s).
 
 # Bindings
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Ray.Di does not support property injection.
 
 ## Assisted Injection
 
-It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null and it is also required to annotate the method with `@Assisted`.
+It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null and annotate the method with `@Assisted`.
 
 # Bindings
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Ray.Di can inject methods that have the `@Inject` annotation. Dependencies take 
 
 Ray.Di does not support property injection.
 
+## Assisted Injection
+
+It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null, it is also required to annotate the method using `@Assisted`.
+
 # Bindings
 
 The injector's job is to assemble graphs of objects. You request an instance of a given type, and it figures out what to build, resolves dependencies, and wires everything together. To specify how dependencies are resolved, configure your injector with bindings.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Ray.Di does not support property injection.
 
 ## Assisted Injection
 
-It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null, it is also required to annotate the method using `@Assisted`.
+It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments and set the default value to null and it is also required to annotate the method with `@Assisted`.
 
 # Bindings
 

--- a/build.xml
+++ b/build.xml
@@ -161,7 +161,7 @@
     </target>
 
     <target name="apigen" description="Generate API documentation using ApiGen">
-        <exec executable="apigen.php">
+        <exec executable="apigen">
             <arg line="--source src --destination ${basedir}/build/api" />
         </exec>
     </target>

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ray/aop": "~2.0",
+        "ray/aop": "~2.2",
         "ray/compiler": "~1.0"
     },
     "autoload": {
@@ -26,8 +26,6 @@
             "Ray\\Di\\": "src/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload-dev": {
         "psr-4": {
             "Ray\\Di\\": [

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ray/aop": "~2.2",
+        "ray/aop": "~2.3",
         "ray/compiler": "~1.0"
     },
     "autoload": {

--- a/docs/demo/01-linked-binding.php
+++ b/docs/demo/01-linked-binding.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -21,4 +21,4 @@ $computer = $injector->getInstance(ComputerInterface::class);
 /* @var $computer Computer */
 $works = ($computer->lang instanceof Php);
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/02a-named-by-qualifier-annotation.php
+++ b/docs/demo/02a-named-by-qualifier-annotation.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -21,4 +21,4 @@ $robot = $injector->getInstance(QualifierRobot::class);
 /* @var $robot Robot */
 $works = ($robot->leftLeg instanceof LeftLeg);
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/02b-named-by-string.php
+++ b/docs/demo/02b-named-by-string.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -21,4 +21,4 @@ $robot = $injector->getInstance(NamedRobot::class);
 /* @var $robot NamedRobot */
 $works = ($robot->leftLeg instanceof LeftLeg);
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/03-provider-binding.php
+++ b/docs/demo/03-provider-binding.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -21,4 +21,4 @@ $computer = $injector->getInstance(Computer::class);
 /* @var $computer Computer */
 $works = ($computer->lang instanceof Php) && $computer->lang->version === '7.0';
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/04-untarget-bindings.php
+++ b/docs/demo/04-untarget-bindings.php
@@ -4,8 +4,8 @@ namespace Ray\Di\Demo;
 
 require __DIR__ . '/bootstrap.php';
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 use Ray\Di\Scope;
 
 class UntargetBindingModule extends AbstractModule
@@ -22,4 +22,4 @@ $php2 = $injector->getInstance(Php::class);
 /* @var $phpRobot Robot */
 $works = spl_object_hash($php1) === spl_object_hash($php2);
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/05a-constructor-bindings-name.php
+++ b/docs/demo/05a-constructor-bindings-name.php
@@ -4,8 +4,8 @@ namespace Ray\Di\Demo;
 
 require __DIR__ . '/bootstrap.php';
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 class ConstructorBindingModule extends AbstractModule
 {
@@ -21,4 +21,4 @@ $php = $injector->getInstance(LangInterface::class);
 /* @var $php Php */
 $works = $php->version === '4.4';
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/05b-constructor-bindings-setter-injection.php
+++ b/docs/demo/05b-constructor-bindings-setter-injection.php
@@ -2,16 +2,22 @@
 
 namespace Ray\Di\Demo;
 
+use Ray\Di\AbstractModule;
 use Ray\Di\InjectionPoints;
 use Ray\Di\Injector;
-use Ray\Di\AbstractModule;
 
 require __DIR__ . '/bootstrap.php';
 
-interface FinderInterface {}
-interface ListerInterface {}
+interface FinderInterface
+{
+}
+interface ListerInterface
+{
+}
 
-class Finder implements FinderInterface {}
+class Finder implements FinderInterface
+{
+}
 class Lister implements ListerInterface
 {
     public $finder;
@@ -38,7 +44,7 @@ $injector = new Injector(new ListerModule);
 $lister = $injector->getInstance(ListerInterface::class);
 /* @var $lister Lister */
 $works = ($lister->finder instanceof FinderInterface);
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
 
 class Lister2 implements ListerInterface
 {
@@ -69,4 +75,4 @@ $injector = new Injector(new Lister2Module);
 $lister = $injector->getInstance(ListerInterface::class);
 /* @var $lister Lister */
 $works = ($lister->finder instanceof FinderInterface);
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/06-install.php
+++ b/docs/demo/06-install.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/src/modules.php';
@@ -25,4 +25,4 @@ $robot = $injector->getInstance(RobotInterface::class);
 /* @var $robot Robot */
 $works = $robot->isReady === true;
 
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/10-cache.php
+++ b/docs/demo/10-cache.php
@@ -2,8 +2,8 @@
 
 namespace Ray\Di\Demo;
 
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/src/modules.php';
@@ -34,5 +34,5 @@ $robot2 = $injector->getInstance(RobotInterface::class);
 $time2 = microtime(true) - $start;
 
 $works = $robot1->isReady === true && $robot2->isReady === true;
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
 echo 'x' . round($time1 / $time2) . ' times faster.' . PHP_EOL;

--- a/docs/demo/11-script-injector.php
+++ b/docs/demo/11-script-injector.php
@@ -4,8 +4,8 @@ namespace Ray\Di\Demo;
 
 use Ray\Compiler\DiCompiler;
 use Ray\Compiler\ScriptInjector;
-use Ray\Di\Injector;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/src/modules.php';
@@ -37,5 +37,5 @@ $robot2 = $scriptInjector->getInstance(RobotInterface::class);
 $time2 = microtime(true) - $start;
 
 $works = $robot1->isReady === true && $robot2->isReady === true;
-echo ($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;
 echo 'x' . round($time1 / $time2) . ' times faster.' . PHP_EOL;

--- a/docs/demo/12-dependency-chain-error-message.php
+++ b/docs/demo/12-dependency-chain-error-message.php
@@ -2,9 +2,9 @@
 
 namespace Ray\Di\Demo;
 
+use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\Injector;
-use Ray\Di\AbstractModule;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -22,9 +22,6 @@ class DeepLinkedClassBindingModule extends AbstractModule
         // $this->bind(E::class)->to(E::class);
     }
 }
-
-
-
 
 $injector = new Injector(new DeepLinkedClassBindingModule);
 // this will fail with an exception as E is not bound
@@ -49,4 +46,3 @@ try {
 //    Ray\Di\Exception\Unbound:dependency 'Ray\Di\Demo\E' with name '' used in /Users/akihito/git/Ray.Di/docs/demo/src/D.php:7
 //    Ray\Di\Exception\Untargetted:Ray\Di\Demo\E
 }
-

--- a/src/AnnotatedClass.php
+++ b/src/AnnotatedClass.php
@@ -8,6 +8,7 @@ namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Ray\Di\Di\PostConstruct;
 
 final class AnnotatedClass
 {
@@ -62,9 +63,9 @@ final class AnnotatedClass
     {
         $methods = $class->getMethods();
         foreach ($methods as $method) {
-            /* @var $annotation \Ray\Di\Di\PostConstruct|null */
+            /* @var $annotation PostConstruct|null */
             $annotation = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\PostConstruct');
-            if ($annotation) {
+            if ($annotation instanceof PostConstruct) {
                 return $method;
             }
         }

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -8,6 +8,7 @@ namespace Ray\Di;
 
 use Doctrine\Common\Annotations\Reader;
 use Ray\Di\Di\Named;
+use Ray\Di\Di\Qualifier;
 
 final class AnnotatedClassMethods
 {
@@ -38,7 +39,7 @@ final class AnnotatedClassMethods
             return new Name($named->value);
         }
         $name = $this->getNamedKeyVarString($constructor);
-        if ($name) {
+        if ($name !== null) {
             return new Name($name);
         }
 
@@ -70,7 +71,7 @@ final class AnnotatedClassMethods
     /**
      * @param \ReflectionMethod $method
      *
-     * @return string
+     * @return string|null
      */
     private function getNamedKeyVarString(\ReflectionMethod $method)
     {
@@ -103,7 +104,7 @@ final class AnnotatedClassMethods
         foreach ($annotations as $annotation) {
             /* @var $bindAnnotation object|null */
             $qualifier = $this->reader->getClassAnnotation(new \ReflectionClass($annotation), 'Ray\Di\Di\Qualifier');
-            if ($qualifier) {
+            if ($qualifier instanceof Qualifier) {
                 $value = isset($annotation->value) ? $annotation->value : Name::ANY;
                 $names[] = sprintf('%s=%s', $value, get_class($annotation));
             }

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -34,7 +34,7 @@ final class AnnotatedClassMethods
             return new Name(Name::ANY);
         }
         $named = $this->reader->getMethodAnnotation($constructor, 'Ray\Di\Di\Named');
-        if ($named) {
+        if ($named instanceof Named) {
             /* @var $named Named */
             return new Name($named->value);
         }
@@ -85,7 +85,7 @@ final class AnnotatedClassMethods
         if ($qualifierNamed) {
             $keyVal[] = $qualifierNamed;
         }
-        if ($keyVal) {
+        if ($keyVal !== []) {
             return implode(',', $keyVal); // var1=qualifier1,va2=qualifier2
         }
 

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -70,8 +70,8 @@ final class AssistedInterceptor implements MethodInterceptor
      * @param array                  $arguments
      *
      * @return array
-     * @internal param int $cntArgs
      *
+     * @internal param int $cntArgs
      */
     public function injectAssistedParameters(ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments)
     {

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -7,12 +7,20 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\Reader;
+use Ray\Aop\Annotation\AbstractAssisted;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 
 final class AssistedInterceptor implements MethodInterceptor
 {
+    /**
+     * @var InjectorInterface
+     */
     private $injector;
+
+    /**
+     * @var Reader
+     */
     private $reader;
 
     public function __construct(InjectorInterface $injector, Reader $reader)
@@ -28,13 +36,13 @@ final class AssistedInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         $method = $invocation->getMethod();
+        $assisted = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Assisted');
+        /* @var \Ray\Di\Di\Assisted $assisted */
         $parameters = $method->getParameters();
         $arguments = $invocation->getArguments()->getArrayCopy();
         $cntArgs = count($arguments);
-        $assisted = [];
-
         foreach ($parameters as $pos => $parameter) {
-            if ($pos < $cntArgs) {
+            if ($pos < $cntArgs || ! $assisted || ! in_array($parameter->getName(), $assisted->values)) {
                 continue;
             }
             $hint = $parameter->getClass();

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -35,7 +35,9 @@ final class AssistedInterceptor implements MethodInterceptor
         $parameters = $method->getParameters();
         $arguments = $invocation->getArguments()->getArrayCopy();
         $cntArgs = count($arguments);
-        $arguments = $this->injectAssistedParameters($method, $assisted, $parameters, $arguments, $cntArgs);
+        if ($assisted instanceof Assisted) {
+            $arguments = $this->injectAssistedParameters($method, $assisted, $parameters, $arguments, $cntArgs);
+        }
         $invocation->getArguments()->exchangeArray($arguments);
 
         return $invocation->proceed();
@@ -68,7 +70,7 @@ final class AssistedInterceptor implements MethodInterceptor
     public function injectAssistedParameters(\ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments, $cntArgs)
     {
         foreach ($parameters as $pos => $parameter) {
-            if ($pos < $cntArgs || ! $assisted || ! in_array($parameter->getName(), $assisted->values)) {
+            if (! in_array($parameter->getName(), $assisted->values)) {
                 continue;
             }
             $hint = $parameter->getClass();

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -34,15 +34,20 @@ final class AssistedInterceptor implements MethodInterceptor
         /* @var \Ray\Di\Di\Assisted $assisted */
         $parameters = $method->getParameters();
         $arguments = $invocation->getArguments()->getArrayCopy();
-        $cntArgs = count($arguments);
-        if ($assisted instanceof Assisted) {
-            $arguments = $this->injectAssistedParameters($method, $assisted, $parameters, $arguments, $cntArgs);
+        if ($assisted instanceof Assisted && $method instanceof ReflectionMethod) {
+            $arguments = $this->injectAssistedParameters($method, $assisted, $parameters, $arguments);
         }
         $invocation->getArguments()->exchangeArray($arguments);
 
         return $invocation->proceed();
     }
 
+    /**
+     * @param ReflectionMethod     $method
+     * @param \ReflectionParameter $parameter
+     *
+     * @return string
+     */
     private function getName(ReflectionMethod $method, \ReflectionParameter $parameter)
     {
         $named = $method->getAnnotation('Ray\Di\Di\Named');
@@ -59,15 +64,16 @@ final class AssistedInterceptor implements MethodInterceptor
     }
 
     /**
-     * @param \ReflectionMethod      $method
+     * @param ReflectionMethod       $method
      * @param Assisted               $assisted
      * @param \ReflectionParameter[] $parameters
      * @param array                  $arguments
-     * @param int                    $cntArgs
      *
      * @return array
+     * @internal param int $cntArgs
+     *
      */
-    public function injectAssistedParameters(\ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments, $cntArgs)
+    public function injectAssistedParameters(ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments)
     {
         foreach ($parameters as $pos => $parameter) {
             if (! in_array($parameter->getName(), $assisted->values)) {

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Annotations\Reader;
 use Ray\Aop\Annotation\AbstractAssisted;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
+use Ray\Aop\ReflectionMethod;
 
 final class AssistedInterceptor implements MethodInterceptor
 {
@@ -18,15 +19,9 @@ final class AssistedInterceptor implements MethodInterceptor
      */
     private $injector;
 
-    /**
-     * @var Reader
-     */
-    private $reader;
-
-    public function __construct(InjectorInterface $injector, Reader $reader)
+    public function __construct(InjectorInterface $injector)
     {
         $this->injector = $injector;
-        $this->reader = $reader;
     }
 
     /**
@@ -36,7 +31,7 @@ final class AssistedInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         $method = $invocation->getMethod();
-        $assisted = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Assisted');
+        $assisted = $method->getAnnotation('Ray\Di\Di\Assisted');
         /* @var \Ray\Di\Di\Assisted $assisted */
         $parameters = $method->getParameters();
         $arguments = $invocation->getArguments()->getArrayCopy();
@@ -55,9 +50,9 @@ final class AssistedInterceptor implements MethodInterceptor
         return $invocation->proceed();
     }
 
-    private function getName(\ReflectionMethod $method, \ReflectionParameter $parameter)
+    private function getName(ReflectionMethod $method, \ReflectionParameter $parameter)
     {
-        $named = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
+        $named = $method->getAnnotation('Ray\Di\Di\Named');
         if (! $named) {
             return Name::ANY;
         }

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di;
+
+use Doctrine\Common\Annotations\Reader;
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+final class AssistedInterceptor implements MethodInterceptor
+{
+    private $injector;
+    private $reader;
+
+    public function __construct(InjectorInterface $injector, Reader $reader)
+    {
+        $this->injector = $injector;
+        $this->reader = $reader;
+    }
+
+    /**
+     * Intercepts any method and injects instances of the missing arguments
+     * when they are type hinted
+     */
+    public function invoke(MethodInvocation $invocation)
+    {
+        $method = $invocation->getMethod();
+        $parameters = $method->getParameters();
+        $arguments = $invocation->getArguments()->getArrayCopy();
+        $cntArgs = count($arguments);
+        $assisted = [];
+
+        foreach ($parameters as $pos => $parameter) {
+            if ($pos < $cntArgs) {
+                continue;
+            }
+            $hint = $parameter->getClass();
+            $interface = $hint ? $hint->getName() : '';
+            $name = $this->getName($method, $parameter);
+            $arguments[] = $this->injector->getInstance($interface, $name);
+        }
+        $invocation->getArguments()->exchangeArray($arguments);
+
+        return $invocation->proceed();
+    }
+
+    private function getName(\ReflectionMethod $method, \ReflectionParameter $parameter)
+    {
+        $named = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
+        if (! $named) {
+            return Name::ANY;
+        }
+        parse_str($named->value, $names);
+        $paramName = $parameter->getName();
+        if (isset($names[$paramName])) {
+            return $names[$paramName];
+        }
+
+        return Name::ANY;
+    }
+}

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -75,7 +75,7 @@ final class AssistedInterceptor implements MethodInterceptor
      */
     public function injectAssistedParameters(ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments)
     {
-        foreach ($parameters as $pos => $parameter) {
+        foreach ($parameters as $parameter) {
             if (! in_array($parameter->getName(), $assisted->values)) {
                 continue;
             }

--- a/src/AssistedModule.php
+++ b/src/AssistedModule.php
@@ -10,7 +10,6 @@ class AssistedModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->bind('Doctrine\Common\Annotations\Reader')->to('Doctrine\Common\Annotations\AnnotationReader');
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith('Ray\Di\Di\Assisted'),

--- a/src/AssistedModule.php
+++ b/src/AssistedModule.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di;
+
+class AssistedModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind('Doctrine\Common\Annotations\Reader')->to('Doctrine\Common\Annotations\AnnotationReader');
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->annotatedWith('Ray\Di\Di\Assisted'),
+            ['\Ray\Di\AssistedInterceptor']
+        );
+    }
+}

--- a/src/Di/Assisted.php
+++ b/src/Di/Assisted.php
@@ -5,6 +5,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 namespace Ray\Di\Di;
+
 use Ray\Aop\Annotation\AbstractAssisted;
 
 /**

--- a/src/Di/Assisted.php
+++ b/src/Di/Assisted.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di\Di;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class Assisted
+{
+}

--- a/src/Di/Assisted.php
+++ b/src/Di/Assisted.php
@@ -5,11 +5,12 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 namespace Ray\Di\Di;
+use Ray\Aop\Annotation\AbstractAssisted;
 
 /**
  * @Annotation
  * @Target("METHOD")
  */
-final class Assisted
+final class Assisted extends AbstractAssisted
 {
 }

--- a/src/Di/Assisted.php
+++ b/src/Di/Assisted.php
@@ -9,6 +9,8 @@ namespace Ray\Di\Di;
 use Ray\Aop\Annotation\AbstractAssisted;
 
 /**
+ * Annotates your class methods into which the Injector should pass the values on method invocation
+ *
  * @Annotation
  * @Target("METHOD")
  */

--- a/src/Di/Inject.php
+++ b/src/Di/Inject.php
@@ -7,7 +7,7 @@
 namespace Ray\Di\Di;
 
 /**
- * Inject
+ * Annotates your class methods into which the Injector should inject values
  *
  * @Annotation
  * @Target("METHOD")
@@ -15,7 +15,7 @@ namespace Ray\Di\Di;
 final class Inject implements InjectInterface
 {
     /**
-     * Optional ?
+     * If true, and the appropriate binding is not found, the Injector will skip injection of this method or field rather than produce an error.
      *
      * @var bool
      */

--- a/src/Di/Named.php
+++ b/src/Di/Named.php
@@ -7,7 +7,7 @@
 namespace Ray\Di\Di;
 
 /**
- * Named
+ * Annotates named things
  *
  * @Annotation
  * @Target("METHOD")

--- a/src/Di/PostConstruct.php
+++ b/src/Di/PostConstruct.php
@@ -9,6 +9,15 @@ namespace Ray\Di\Di;
 /**
  * PostConstruct
  *
+ * The PostConstruct annotation is used on a method that needs to be executed after dependency injection is done to
+ * perform any initialization. This method MUST be invoked before the class is put into service. The method annotated
+ * with PostConstruct MUST be invoked even if the class does not request any resources to be injected. Only one method
+ * can be annotated with this annotation. The method on which the PostConstruct annotation is applied MUST fulfill
+ * allof the following criteria
+ *
+ *  - The method MUST NOT have any parameters.
+ *  - The return type of the method MUST be void.
+ *
  * @Annotation
  * @Target("METHOD")
  */

--- a/src/Di/Qualifier.php
+++ b/src/Di/Qualifier.php
@@ -7,7 +7,7 @@
 namespace Ray\Di\Di;
 
 /**
- * Qualifier
+ * Identifies qualifier annotations
  *
  * @Annotation
  * @Target("CLASS")

--- a/src/Exception/Unbound.php
+++ b/src/Exception/Unbound.php
@@ -29,6 +29,7 @@ class Unbound extends \LogicException implements ExceptionInterface
      */
     private function buildMessage(Unbound $e, array $msg)
     {
+        $lastE = $e;
         while ($e instanceof Unbound) {
             $msg[] = sprintf("- %s\n", $e->getMessage());
             $lastE = $e;

--- a/src/Exception/Unbound.php
+++ b/src/Exception/Unbound.php
@@ -17,8 +17,11 @@ class Unbound extends \LogicException implements ExceptionInterface
         if (! $e instanceof \Exception) {
             return $this->getMainMessage($this);
         }
+        if ($e instanceof Unbound) {
+            return $this->buildMessage($e, $messages) . "\n" . $e->getTraceAsString();
+        }
 
-        return $this->buildMessage($e, $messages) . "\n" . $e->getTraceAsString();
+        return parent::__toString();
     }
 
     /**

--- a/src/Exception/Unbound.php
+++ b/src/Exception/Unbound.php
@@ -22,8 +22,8 @@ class Unbound extends \LogicException implements ExceptionInterface
     }
 
     /**
-     * @param Unbound $e
-     * @param array   $msg
+     * @param Unbound  $e
+     * @param string[] $msg
      *
      * @return string
      */

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -7,6 +7,7 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\Reader;
+use Ray\Di\Di\Qualifier;
 
 final class InjectionPoint implements InjectionPointInterface
 {
@@ -62,7 +63,7 @@ final class InjectionPoint implements InjectionPointInterface
                 new \ReflectionClass($annotation),
                 'Ray\Di\Di\Qualifier'
             );
-            if ($qualifier) {
+            if ($qualifier instanceof Qualifier) {
                 $qualifiers[] = $annotation;
             }
         }

--- a/src/InjectionPointInterface.php
+++ b/src/InjectionPointInterface.php
@@ -18,7 +18,7 @@ interface InjectionPointInterface
     /**
      * Return method reflection
      *
-     * @return \ReflectionMethod
+     * @return \ReflectionFunctionAbstract
      */
     public function getMethod();
 

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -27,8 +27,12 @@ class Injector implements InjectorInterface
      */
     public function __construct(AbstractModule $module = null, $classDir = null)
     {
+        if (is_null($module)) {
+            $module = new NullModule;
+        }
+        $module->install(new AssistedModule);
+        $this->container = $module->getContainer();
         $this->classDir = $classDir ?: sys_get_temp_dir();
-        $this->container =  $module ? $module->getContainer() : new Container;
         $this->container->weaveAspects(new Compiler($this->classDir));
 
         // builtin injection

--- a/src/NewInstance.php
+++ b/src/NewInstance.php
@@ -26,7 +26,7 @@ final class NewInstance
     private $arguments;
 
     /**
-     * @var AopBind
+     * @var AspectBind
      */
     private $bind;
 

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -15,7 +15,7 @@ class AssistedTest extends \PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->injector = new Injector(new FakeToBindModule(new AssistedModule));
+        $this->injector = new Injector(new FakeToBindModule);
     }
 
     public function tearDown()
@@ -37,7 +37,7 @@ class AssistedTest extends \PHPUnit_Framework_TestCase
 
     public function testAssistedWithName()
     {
-        $this->injector = new Injector(new FakeInstanceBindModule(new AssistedModule));
+        $this->injector = new Injector(new FakeInstanceBindModule);
         $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
         /* @var $consumer FakeAssistedConsumer */
         $assistedDependency = $consumer->assistWithName('a7');

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -44,4 +44,15 @@ class AssistedTest extends \PHPUnit_Framework_TestCase
         $expecetd = 1;
         $this->assertSame($expecetd, $assistedDependency);
     }
+
+    public function testAssistedAnyWithName()
+    {
+        $injector = new Injector(new FakeToBindModule(new FakeInstanceBindModule));
+        $consumer = $injector->getInstance(FakeAssistedConsumer::class);
+        /* @var $consumer FakeAssistedConsumer */
+        list($assistedDependency1, $assistedDependency2) = $consumer->assistAny();
+        $expected1 = 1;
+        $this->assertSame($expected1, $assistedDependency1);
+        $this->assertInstanceOf(FakeRobot::class, $assistedDependency2);
+    }
 }

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ray\Di;
+
+use Ray\Compiler\DiCompiler;
+use Ray\Di\Exception\Unbound;
+use Ray\Di\Exception\Untargetted;
+
+class AssistedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var InjectorInterface
+     */
+    private $injector;
+
+    public function setup()
+    {
+        $this->injector = new Injector(new FakeToBindModule(new AssistedModule));
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        foreach (new \RecursiveDirectoryIterator($_ENV['TMP_DIR'], \FilesystemIterator::SKIP_DOTS) as $file) {
+            unlink($file);
+        }
+    }
+
+    public function testAssisted()
+    {
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        /* @var $consumer FakeAssistedConsumer */
+        $assistedDependency = $consumer->assistOne('a', 'b');
+        $expecetd = FakeRobot::class;
+        $this->assertInstanceOf($expecetd, $assistedDependency);
+    }
+
+    public function testAssistedWithName()
+    {
+        $this->injector = new Injector(new FakeInstanceBindModule(new AssistedModule));
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        /* @var $consumer FakeAssistedConsumer */
+        $assistedDependency = $consumer->assistWithName('a7');
+        $expecetd = 1;
+        $this->assertSame($expecetd, $assistedDependency);
+    }
+}

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: akihito
- * Date: 2016/02/14
- * Time: 8:41
- */
 
 namespace Ray\Di;
 
@@ -28,5 +22,15 @@ class FakeAssistedConsumer
     public function assistWithName($a, $var1)
     {
         return $var1;
+    }
+
+    /**
+     * @Assisted({"var2", "robot"})
+     * @Named("var2=one")
+     */
+    public function assistAny($var2, FakeRobotInterface $robot)
+    {
+        return [$var2, $robot];
+
     }
 }

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -31,6 +31,5 @@ class FakeAssistedConsumer
     public function assistAny($var2, FakeRobotInterface $robot)
     {
         return [$var2, $robot];
-
     }
 }

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -14,18 +14,18 @@ use Ray\Di\Di\Named;
 class FakeAssistedConsumer
 {
     /**
-     * @Assisted
+     * @Assisted({"robot"})
      */
-    public function assistOne($a, $b, FakeRobotInterface $robot = null)
+    public function assistOne($a, $b, FakeRobotInterface $robot)
     {
         return $robot;
     }
 
     /**
-     * @Assisted
+     * @Assisted({"var1"})
      * @Named("var1=one")
      */
-    public function assistWithName($a, $var1 = null)
+    public function assistWithName($a, $var1)
     {
         return $var1;
     }

--- a/tests/Fake/FakeAssistedConsumer.php
+++ b/tests/Fake/FakeAssistedConsumer.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: akihito
+ * Date: 2016/02/14
+ * Time: 8:41
+ */
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Assisted;
+use Ray\Di\Di\Named;
+
+class FakeAssistedConsumer
+{
+    /**
+     * @Assisted
+     */
+    public function assistOne($a, $b, FakeRobotInterface $robot = null)
+    {
+        return $robot;
+    }
+
+    /**
+     * @Assisted
+     * @Named("var1=one")
+     */
+    public function assistWithName($a, $var1 = null)
+    {
+        return $var1;
+    }
+}

--- a/tests/Fake/FakeInstanceBindModule.php
+++ b/tests/Fake/FakeInstanceBindModule.php
@@ -4,10 +4,6 @@ namespace Ray\Di;
 
 class FakeInstanceBindModule extends AbstractModule
 {
-    public function __construct()
-    {
-    }
-
     protected function configure()
     {
         $this->bind('')->annotatedWith('one')->toInstance(1);

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -211,7 +211,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
 
     public function testAopBoundInDifferentModule()
     {
-        $injector = new Injector(new FakeAopInstallModule);
+        $injector = new Injector(new FakeAopInstallModule, $_ENV['TMP_DIR']);
         $instance = $injector->getInstance(FakeAopInterface::class);
         /* @var $instance FakeAop */
         $result = $instance->returnSame(2);
@@ -220,7 +220,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
 
     public function testAopBoundInDifferentModuleAfterAnotherBinding()
     {
-        $injector = new Injector(new FakeAopInstallModule(new FakeAopModule));
+        $injector = new Injector(new FakeAopInstallModule(new FakeAopModule), $_ENV['TMP_DIR']);
         $instance = $injector->getInstance(FakeAopInterface::class);
         /* @var $instance FakeAop */
         $result = $instance->returnSame(2);
@@ -229,7 +229,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
 
     public function testAopBoundDoublyInDifferentModule()
     {
-        $injector = new Injector(new FakeAopDoublyInstallModule);
+        $injector = new Injector(new FakeAopDoublyInstallModule, $_ENV['TMP_DIR']);
         $instance = $injector->getInstance(FakeAopInterface::class);
         /* @var $instance FakeAop */
         $result = $instance->returnSame(2);
@@ -249,7 +249,7 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
 
     public function testAopOnDemandByUnboundConcreteClass()
     {
-        $injector = new Injector(new FakeAopInterceptorModule);
+        $injector = new Injector(new FakeAopInterceptorModule, $_ENV['TMP_DIR']);
         $instance = $injector->getInstance(FakeAop::class);
         /* @var $instance FakeAop */
         $result = $instance->returnSame(2);

--- a/tests/UnboundTest.php
+++ b/tests/UnboundTest.php
@@ -22,4 +22,11 @@ class UnboundTest extends \PHPUnit_Framework_TestCase
         $string = (string) $e;
         $this->assertContains("Ray\Di\Exception\Unbound", $string);
     }
+
+    public function testNonUnboundPrevious()
+    {
+        $string = (string) new Unbound('', 0, new \LogicException);
+        $expected = 'LogicException in';
+        $this->assertStringStartsWith($expected, $string);
+    }
 }

--- a/tests/UnboundTest.php
+++ b/tests/UnboundTest.php
@@ -26,7 +26,7 @@ class UnboundTest extends \PHPUnit_Framework_TestCase
     public function testNonUnboundPrevious()
     {
         $string = (string) new Unbound('', 0, new \LogicException);
-        $expected = 'LogicException in';
-        $this->assertStringStartsWith($expected, $string);
+        $expected = 'LogicException';
+        $this->assertContains($expected, $string);
     }
 }

--- a/tests/UnboundTest.php
+++ b/tests/UnboundTest.php
@@ -15,4 +15,11 @@ class UnboundTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('dep1-', $string);
         $this->assertContains('dep2-', $string);
     }
+
+    public function testNoPrevious()
+    {
+        $e = new Unbound('dep0-', 0);
+        $string = (string) $e;
+        $this->assertContains("Ray\Di\Exception\Unbound", $string);
+    }
 }


### PR DESCRIPTION
## Assisted Injection

It is also possible to inject dependencies directly in the invoke method parameter(s). When doing this, add the dependency to the end of the arguments ~~and set the default value to null~~, it is also required to annotate the method using `@Assisted`.

module

``` php
class FooModule extends AbstractModule
{
    protected function configure()
    {
        $this->bind(RobotInterface::class)->to(Robot::class);
        $this->bind()->annotatedWith('one')->toInstance(1);
    }
}
```

dependent

``` php
class AssistedConsumer
{
    /**
     * @Assisted({"robot"})
     */
    public function foo(RobotInterface $robot)
    {
        return $robot;
    }

    /**
     * @Assisted({"var1"})
     * @Named("var1=one")
     */
    public function bar($a, $var1)
    {
        return $var1;
    }

    /**
     * @Assisted({"var2", "robot"})
     * @Named("var2=one")
     */
    public function baz($var2, FakeRobotInterface $robot)
    {
        return [$var2 , $robot];
    }
} 

$consumer->foo();  // Robot
$consumer->bar(0); // 1
$consumer->baz(); // [1, Robot]
```
