### PR TITLE
add parameter name to Unbound exception message

### DIFF
--- a/src/Argument.php
+++ b/src/Argument.php
@@ -53,11 +53,12 @@ final class Argument
         $this->index = $interface . '-' . $name;
         $this->reflection = $parameter;
         $this->meta = sprintf(
-            "dependency '%s' with name '%s' used in %s:%d",
+            "dependency '%s' with name '%s' used in %s:%d ($%s)",
             $interface,
             $name,
             $this->reflection->getDeclaringFunction()->getFileName(),
-            $this->reflection->getDeclaringFunction()->getStartLine()
+            $this->reflection->getDeclaringFunction()->getStartLine(),
+            $parameter->getName()
         );
     }
 

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -42,14 +42,7 @@ final class Argument
         if ($isOptional) {
             $this->default = null;
         }
-        if ($this->isDefaultAvailable) {
-            try {
-                $this->default = $parameter->getDefaultValue();
-            } catch (\ReflectionException $e) {
-                // probably it is internal class like \PDO
-                $this->default = null;
-            }
-        }
+        $this->setDefaultValue($parameter);
         $this->index = $interface . '-' . $name;
         $this->reflection = $parameter;
         $this->meta = sprintf(
@@ -115,5 +108,18 @@ final class Argument
     public function getMeta()
     {
         return $this->meta;
+    }
+
+    private function setDefaultValue(\ReflectionParameter $parameter)
+    {
+        if (! $this->isDefaultAvailable) {
+            return;
+        }
+        try {
+            $this->default = $parameter->getDefaultValue();
+        } catch (\ReflectionException $e) {
+            // probably it is internal class like \PDO
+            $this->default = null;
+        }
     }
 }

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -290,7 +290,9 @@ class InjectorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsOptionalValue()
     {
-        $pdo = (new Injector(new FakePdoModule))->getInstance(\PDO::class);
-        $this->assertInstanceOf(\PDO::class, $pdo);
+        if (! defined('HHVM_VERSION')) {
+            $pdo = (new Injector(new FakePdoModule))->getInstance(\PDO::class);
+            $this->assertInstanceOf(\PDO::class, $pdo);
+        }
     }
 }


### PR DESCRIPTION
``` php
class Foo
{
    public function __construct($dep){}
}
```

It's hard to know which dependency is not bound when you forgot to annotate with Qualifier or `@Named` for no type hinted  parameter. This PR add parameter name in Unbound exception to clarify which dependency (parameter) is not bound.

before

```
dependency '' with name '' used in demo/12-dependency-chain-error-message.php:11
```

after

```
dependency '' with name '' used in demo/12-dependency-chain-error-message.php:11 ($dep)
```

See also: #129
cc/ @tbug @lorenzo 
