### PR TITLE
Contextual provider binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,64 @@ Finally we bind to the provider using the `toProvider()` method:
 $this->bind(TransactionLogInterface::class)->toProvider(DatabaseTransactionLogProvider::class);
 ```
 
+## Contextual Provider Bindings
+
+You may want to create an object using the context when binding with Provider. For example, you want to inject different connection destinations on the same DB interface. In such a case, we bind it by specifying the context (string) with `toProvider ()`.
+
+
+```php
+$dbConfig = ['user' => $userDsn, 'job'=> $jobDsn, 'log' => $logDsn];
+$this->bind()->annotatedWith('db_config')->toInstance(dbConfig);
+$this->bind(Connection::class)->annotatedWith('usr_db')->toProvider(DbalProvider::class, 'user');
+$this->bind(Connection::class)->annotatedWith('job_db')->toProvider(DbalProvider::class, 'job');
+$this->bind(Connection::class)->annotatedWith('log_db')->toProvider(DbalProvider::class, 'log');
+```
+
+Providers are created for each context.
+
+```php
+class DbalProvider implements ProviderInterface, SetContextInterface
+{
+    private $dbConfigs;
+
+    public function setContext($context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @Named("db_config")
+     */
+    public function __construct(array $dbConfigs)
+    {
+        $this->dbConfigs = $dbConfigs;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        $config = $this->dbConfigs[$this->context];
+        $conn = DriverManager::getConnection(config);
+
+        return $conn;
+    }
+}
+```
+
+It is the same interface, but you can receive different connections made by `Provider`.
+
+```php
+/**
+ * @Named("userDb=user,jobDb=job,logDb=log")
+ */
+public function __construct(Connection $userDb, Connection $jobDb, Connection $logDb)
+{
+  //...
+}
+```
+
 ## Injection Point
 
 An **InjectionPoint** is a class that has information about an injection point. 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -21,7 +21,7 @@
     <rule ref="rulesets/design.xml/DepthOfInheritance"/>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="minimum" value="14"/>
+            <property name="minimum" value="15"/>
         </properties>
     </rule>
     <!--naming-->

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -7,6 +7,7 @@
  */
 namespace Ray\Di;
 
+use Ray\Di\Exception\InvalidContext;
 use Ray\Di\Exception\NotFound;
 
 final class Bind
@@ -114,16 +115,20 @@ final class Bind
 
     /**
      * @param string $provider
+     * @param string $context
      *
      * @return $this
      *
      * @throws NotFound
      */
-    public function toProvider($provider)
+    public function toProvider($provider, $context = null)
     {
+        if (! is_null($context) && ! is_string($context)) {
+            throw new InvalidContext(gettype($context));
+        }
         $this->untarget = null;
         $this->validate->toProvider($provider);
-        $this->bound = (new DependencyFactory)->newProvider(new \ReflectionClass($provider));
+        $this->bound = (new DependencyFactory)->newProvider(new \ReflectionClass($provider), $context);
         $this->container->add($this);
 
         return $this;

--- a/src/DependencyFactory.php
+++ b/src/DependencyFactory.php
@@ -34,10 +34,10 @@ final class DependencyFactory
      *
      * @return DependencyProvider
      */
-    public function newProvider(\ReflectionClass $provider)
+    public function newProvider(\ReflectionClass $provider, $context)
     {
         $dependency = $this->newAnnotatedDependency($provider);
-        $dependency = new DependencyProvider($dependency);
+        $dependency = new DependencyProvider($dependency, $context);
 
         return $dependency;
     }

--- a/src/DependencyProvider.php
+++ b/src/DependencyProvider.php
@@ -9,6 +9,11 @@ namespace Ray\Di;
 final class DependencyProvider implements DependencyInterface
 {
     /**
+     * @var string
+     */
+    public $context;
+
+    /**
      * Provider dependency
      *
      * @var Dependency
@@ -25,9 +30,10 @@ final class DependencyProvider implements DependencyInterface
      */
     private $instance;
 
-    public function __construct(Dependency $dependency)
+    public function __construct(Dependency $dependency, $context = null)
     {
         $this->dependency = $dependency;
+        $this->context = $context;
     }
 
     /**
@@ -46,7 +52,11 @@ final class DependencyProvider implements DependencyInterface
         if ($this->isSingleton && $this->instance) {
             return $this->instance;
         }
-        $this->instance = $this->dependency->inject($container)->get();
+        $provider = $this->dependency->inject($container);
+        if ($provider instanceof SetContextInterface) {
+            $this->setContext($provider);
+        }
+        $this->instance = $provider->get();
 
         return $this->instance;
     }
@@ -59,6 +69,11 @@ final class DependencyProvider implements DependencyInterface
         if ($scope === Scope::SINGLETON) {
             $this->isSingleton = true;
         }
+    }
+
+    public function setContext(SetContextInterface $provider)
+    {
+        $provider->setContext($this->context);
     }
 
     public function __sleep()

--- a/src/Exception/InvalidContext.php
+++ b/src/Exception/InvalidContext.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di\Exception;
+
+class InvalidContext extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/SetContextInterface.php
+++ b/src/SetContextInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Di;
+
+/**
+ * Interface for context of object provider
+ */
+interface SetContextInterface
+{
+    /**
+     * Set provider context
+     *
+     * @return mixed
+     */
+    public function setContext($context);
+}

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -18,6 +18,7 @@ class BindTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
         $this->bind = new Bind(new Container, FakeTyreInterface::class);
     }
+
     public function testGetBound()
     {
         $this->bind->to(FakeTyre::class);
@@ -124,5 +125,22 @@ class BindTest extends \PHPUnit_Framework_TestCase
         $instance1 = $container->getInstance(ProviderInterface::class, 'handle');
         $instance2 = $container->getInstance(ProviderInterface::class, 'handle');
         $this->assertSame(spl_object_hash($instance1), spl_object_hash($instance2));
+    }
+
+    public function testProviderContext()
+    {
+        $container = new Container;
+        $bind = (new Bind($container, ProviderInterface::class))->toProvider(FakeContextualProvider::class, 'context_string');
+        $instance = $container->getInstance(ProviderInterface::class, Name::ANY);
+        $this->assertSame('context_string', $instance->context);
+    }
+
+    /**
+     * @expectedException \Ray\Di\Exception\InvalidContext
+     */
+    public function testInvalidProviderContext()
+    {
+        $container = new Container;
+        (new Bind($container, ProviderInterface::class))->toProvider(FakeHandleProvider::class, false);
     }
 }

--- a/tests/ContextualProviderTest.php
+++ b/tests/ContextualProviderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\Di;
+
+class ContextualProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testContextualProviderInjection()
+    {
+        $robot = (new Injector(new FakeContextualModule('main')))->getInstance(FakeRobotInterface::class);
+        /* @var $robot FakeContextualRobot */
+        $this->assertSame($robot->context, 'main');
+    }
+}

--- a/tests/Fake/FakeContextualModule.php
+++ b/tests/Fake/FakeContextualModule.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeContextualModule extends AbstractModule
+{
+    private $context;
+
+    public function __construct($context)
+    {
+        $this->context = $context;
+    }
+
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->toProvider(FakeContextualProvider::class, $this->context);
+    }
+}

--- a/tests/Fake/FakeContextualProvider.php
+++ b/tests/Fake/FakeContextualProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeContextualProvider implements ProviderInterface, SetContextInterface
+{
+    private $context;
+
+    /**
+     * @inheritDoc
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
+    }
+
+    public function get()
+    {
+        return new FakeContextualRobot($this->context);
+    }
+}

--- a/tests/Fake/FakeContextualRobot.php
+++ b/tests/Fake/FakeContextualRobot.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\Di;
+
+class FakeContextualRobot implements FakeRobotInterface
+{
+    public $context;
+
+    public function __construct($context)
+    {
+        $this->context = $context;
+    }
+}


### PR DESCRIPTION
## Contextual Provider Bindings

You may want to create an object using the context when binding with Provider. For example, you want to inject different connection destinations on the same DB interface. In such a case, we bind it by specifying the context (string) with `toProvider ()`.


```php
$dbConfig = ['user' => $userDsn, 'job'=> $jobDsn, 'log' => $logDsn];
$this->bind()->annotatedWith('db_config')->toInstance(dbConfig);
$this->bind(Connection::class)->annotatedWith('usr_db')->toProvider(DbalProvider::class, 'user');
$this->bind(Connection::class)->annotatedWith('job_db')->toProvider(DbalProvider::class, 'job');
$this->bind(Connection::class)->annotatedWith('log_db')->toProvider(DbalProvider::class, 'log');
```

Providers are created for each context.

```php
class DbalProvider implements ProviderInterface, SetContextInterface
{
    private $dbConfigs;

    public function setContext($context)
    {
        $this->context = $context;
    }

    /**
     * @Named("db_config")
     */
    public function __construct(array $dbConfigs)
    {
        $this->dbConfigs = $dbConfigs;
    }

    /**
     * {@inheritdoc}
     */
    public function get()
    {
        $config = $this->dbConfigs[$this->context];
        $conn = DriverManager::getConnection(config);

        return $conn;
    }
}
```

It is the same interface, but you can receive different connections made by `Provider`.

```php
/**
 * @Named("userDb=user,jobDb=job,logDb=log")
 */
public function __construct(Connection $userDb, Connection $jobDb, Connection $logDb)
{
  //...
}
```

## コンテンキストプロバイダ束縛

同じプロバイダーでコンテキスト別にオブジェクトを生成したい場合があります。例えば接続先の違う複数のDBオブジェクトを同じインターフェイスでインジェクトしたい場合などです。そういう場合には`toProvider()`でコンテキスト（文字列）を指定して束縛をします。

```php
$dbConfig = ['user' => $userDsn, 'job'=> $jobDsn, 'log' => $logDsn];
$this->bind()->annotatedWith('db_config')->toInstance(dbConfig);
$this->bind(Connection::class)->annotatedWith('usr_db')->toProvider(DbalProvider::class, 'user');
$this->bind(Connection::class)->annotatedWith('job_db')->toProvider(DbalProvider::class, 'job');
$this->bind(Connection::class)->annotatedWith('log_db')->toProvider(DbalProvider::class, 'log');
```

プロバイダーはコンテキスト別に生成します。

```php
class DbalProvider implements ProviderInterface, SetContextInterface
{
    private $dbConfigs;

    public function setContext($context)
    {
        $this->context = $context;
    }

    /**
     * @Named("db_config")
     */
    public function __construct(array $dbConfigs)
    {
        $this->dbConfigs = $dbConfigs;
    }

    /**
     * {@inheritdoc}
     */
    public function get()
    {
        $config = $this->dbConfigs[$this->context];
        $conn = DriverManager::getConnection(config);

        return $conn;
    }
}
```
同じインターフェイスですが、接続先の違う別々のDBオブジェクトを受け取ります。

```php
/**
 * @Named("userDb=user_db,jobDb=job_db,logDb=log_db")
 */
public function __construct(Connection $userDb, Connection $jobDb, Connection $logDb)
{
  //...
}
```
