### PR TITLE
Drop php5.6, 7.0 and hhvm support

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -125,5 +125,6 @@ return \PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude('tests/Fake')
-            ->in('src')
+            ->exclude('tests/tmp')
+            ->in(__DIR__)
     )->setLineEnding("\n");

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: php
 sudo: required
 dist: trusty
 php:
-  - 5.6
-  - 7
   - 7.1
-  - hhvm
 cache:
   directories:
     - vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 dist: trusty
 php:
   - 7.1
+  - 7.2
 cache:
   directories:
     - vendor

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "ray/aop": "^2.4.1",
+        "php": ">=7.1.0",
+        "ray/aop": "2.x-dev",
         "ray/compiler": "^1.1.5"
     },
     "require-dev": {

--- a/docs/demo/01-linked-binding-setter-injection.php
+++ b/docs/demo/01-linked-binding-setter-injection.php
@@ -4,7 +4,7 @@ use Ray\Di\AbstractModule;
 use Ray\Di\Di\Inject;
 use Ray\Di\Injector;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 interface FinderInterface
 {

--- a/docs/demo/01-linked-binding.php
+++ b/docs/demo/01-linked-binding.php
@@ -3,7 +3,7 @@
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 interface FinderInterface
 {

--- a/docs/demo/02-provider-binding.php
+++ b/docs/demo/02-provider-binding.php
@@ -36,9 +36,6 @@ class ModernMovieLister implements MovieListerInterface
 {
     public $finder;
 
-    /**
-     *
-     */
     public function __construct(FinderInterface $finder)
     {
         $this->finder = $finder;
@@ -55,7 +52,7 @@ class FinderProvider implements ProviderInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function get()
     {

--- a/docs/demo/02b-named-by-named.php
+++ b/docs/demo/02b-named-by-named.php
@@ -2,7 +2,6 @@
 
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Named;
-use Ray\Di\Di\Qualifier;
 use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';

--- a/docs/demo/03-injection-point.php
+++ b/docs/demo/03-injection-point.php
@@ -5,7 +5,7 @@ use Ray\Di\InjectionPointInterface;
 use Ray\Di\Injector;
 use Ray\Di\ProviderInterface;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 interface FinderInterface
 {
@@ -79,4 +79,4 @@ $movieLister = $injector->getInstance(MovieListerInterface::class);
 $result = $movieLister->finder->find();
 $works = ($result === 'search for [MovieLister]');
 
-echo($works ? 'It works!' : 'It DOES NOT work!').PHP_EOL;
+echo($works ? 'It works!' : 'It DOES NOT work!') . PHP_EOL;

--- a/docs/demo/04-untarget-binding.php
+++ b/docs/demo/04-untarget-binding.php
@@ -4,7 +4,7 @@ use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 use Ray\Di\Scope;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 class Finder
 {

--- a/docs/demo/05b-constructor-binding-setter-injection.php
+++ b/docs/demo/05b-constructor-binding-setter-injection.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Ray\Di\Demo;
 
 use Ray\Di\AbstractModule;

--- a/docs/demo/06-install.php
+++ b/docs/demo/06-install.php
@@ -3,7 +3,7 @@
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 interface FinderInterface
 {

--- a/docs/demo/07-assisted-injection.php
+++ b/docs/demo/07-assisted-injection.php
@@ -4,7 +4,7 @@ use Ray\Di\AbstractModule;
 use Ray\Di\Di\Assisted;
 use Ray\Di\Injector;
 
-require __DIR__.'/bootstrap.php';
+require __DIR__ . '/bootstrap.php';
 
 interface FinderInterface
 {

--- a/docs/demo/12-dependency-chain-error-message.php
+++ b/docs/demo/12-dependency-chain-error-message.php
@@ -58,20 +58,20 @@ try {
     $injector->getInstance(A::class);
 } catch (Unbound $e) {
     echo $e->getMessage();
-//    dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
+    //    dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
     echo PHP_EOL . '---------' . PHP_EOL;
     echo $e;
-//    exception 'Ray\Di\Exception\Unbound' with message 'EInterface-'
-//    - dependency 'EInterface' with name '' used in12-dependency-chain-error-message.php:26
-//    - dependency 'D' with name '' used in12-dependency-chain-error-message.php:21
-//    - dependency 'C' with name '' used in12-dependency-chain-error-message.php:16
-//    - dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
-// ...
+    //    exception 'Ray\Di\Exception\Unbound' with message 'EInterface-'
+    //    - dependency 'EInterface' with name '' used in12-dependency-chain-error-message.php:26
+    //    - dependency 'D' with name '' used in12-dependency-chain-error-message.php:21
+    //    - dependency 'C' with name '' used in12-dependency-chain-error-message.php:16
+    //    - dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
+    // ...
     echo PHP_EOL . '---------' . PHP_EOL;
     do {
         echo get_class($e) . ':' . $e->getMessage() . PHP_EOL;
     } while ($e = $e->getPrevious());
-//    Ray\Di\Exception\Unbound:dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
+    //    Ray\Di\Exception\Unbound:dependency 'B' with name '' used in12-dependency-chain-error-message.php:11
 //    Ray\Di\Exception\Unbound:dependency 'C' with name '' used in12-dependency-chain-error-message.php:16
 //    Ray\Di\Exception\Unbound:dependency 'D' with name '' used in12-dependency-chain-error-message.php:21
 //    Ray\Di\Exception\Unbound:dependency 'EInterface' with name '' used in12-dependency-chain-error-message.php:26

--- a/docs/demo/finder_module.php
+++ b/docs/demo/finder_module.php
@@ -36,12 +36,16 @@ class DbFinder implements FinderInterface
     public function __construct(DbInterface $db)
     {
     }
-/** @Inject */public function setDb(DbInterface $db)
-{
-}
-/** @Inject */public function setSorter(Sorter $sorter, Sorter $sorte2)
-{
-}
+
+    /** @Inject */
+    public function setDb(DbInterface $db)
+    {
+    }
+
+    /** @Inject */
+    public function setSorter(Sorter $sorter, Sorter $sorte2)
+    {
+    }
 }
 
 interface MovieListerInterface
@@ -53,9 +57,11 @@ class MovieLister implements MovieListerInterface
     public function __construct(FinderInterface $finder)
     {
     }
-/** @Inject */public function setFinder01(FinderInterface $finder, FinderInterface $finder1, FinderInterface $finder2)
-{
-}
+
+    /** @Inject */
+    public function setFinder01(FinderInterface $finder, FinderInterface $finder1, FinderInterface $finder2)
+    {
+    }
 }
 
 class FinderModule extends AbstractModule

--- a/src/AbstractModule.php
+++ b/src/AbstractModule.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *
@@ -40,20 +42,16 @@ abstract class AbstractModule
 
     /**
      * Install module
-     *
-     * @param AbstractModule $module
      */
-    public function install(AbstractModule $module)
+    public function install(AbstractModule $module) : void
     {
         $this->getContainer()->merge($module->getContainer());
     }
 
     /**
      * Override module
-     *
-     * @param AbstractModule $module
      */
-    public function override(AbstractModule $module)
+    public function override(AbstractModule $module) : void
     {
         $module->getContainer()->merge($this->container);
         $this->container = $module->getContainer();
@@ -64,7 +62,7 @@ abstract class AbstractModule
      *
      * @return Container
      */
-    public function getContainer()
+    public function getContainer() : Container
     {
         if (! $this->container) {
             $this->activate();
@@ -80,7 +78,7 @@ abstract class AbstractModule
      * @param AbstractMatcher $methodMatcher
      * @param array           $interceptors
      */
-    public function bindInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors)
+    public function bindInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors) : void
     {
         $pointcut = new Pointcut($classMatcher, $methodMatcher, $interceptors);
         $this->container->addPointcut($pointcut);
@@ -96,7 +94,7 @@ abstract class AbstractModule
      * @param AbstractMatcher $methodMatcher
      * @param array           $interceptors
      */
-    public function bindPriorityInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors)
+    public function bindPriorityInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors) : void
     {
         $pointcut = new PriorityPointcut($classMatcher, $methodMatcher, $interceptors);
         $this->container->addPointcut($pointcut);
@@ -113,7 +111,7 @@ abstract class AbstractModule
      * @param string $sourceName      Original binding name
      * @param string $targetInterface Original interface
      */
-    public function rename($interface, $newName, $sourceName = Name::ANY, $targetInterface = '')
+    public function rename(string $interface, string $newName, string $sourceName = Name::ANY, string $targetInterface = '') : void
     {
         $targetInterface = $targetInterface ?: $interface;
         $this->lastModule->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
@@ -126,19 +124,18 @@ abstract class AbstractModule
 
     /**
      * Bind interface
-     *
-     * @param string $interface
-     *
-     * @return Bind
      */
-    protected function bind($interface = '')
+    protected function bind(string $interface = '') : Bind
     {
         $bind = new Bind($this->getContainer(), $interface);
 
         return $bind;
     }
 
-    private function activate()
+    /**
+     * Activate bindings
+     */
+    private function activate() : void
     {
         $this->container = new Container;
         $this->matcher = new Matcher;

--- a/src/AnnotatedClass.php
+++ b/src/AnnotatedClass.php
@@ -24,7 +24,6 @@ final class AnnotatedClass
 
     public function __construct(AnnotationReader $reader)
     {
-        AnnotationRegistry::registerFile(__DIR__ . '/DoctrineAnnotations.php');
         $this->reader = $reader;
         $this->injectionMethod = new AnnotatedClassMethods($reader);
     }

--- a/src/AnnotatedClass.php
+++ b/src/AnnotatedClass.php
@@ -63,7 +63,7 @@ final class AnnotatedClass
         $methods = $class->getMethods();
         foreach ($methods as $method) {
             /* @var $annotation PostConstruct|null */
-            $annotation = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\PostConstruct');
+            $annotation = $this->reader->getMethodAnnotation($method, PostConstruct::class);
             if ($annotation instanceof PostConstruct) {
                 return $method;
             }

--- a/src/AnnotatedClass.php
+++ b/src/AnnotatedClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *
@@ -7,7 +8,6 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Ray\Di\Di\PostConstruct;
 
 final class AnnotatedClass

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *
@@ -9,6 +8,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\Reader;
+use Ray\Di\Di\InjectInterface;
 use Ray\Di\Di\Named;
 use Ray\Di\Di\Qualifier;
 
@@ -35,7 +35,7 @@ final class AnnotatedClassMethods
         if (! $constructor) {
             return new Name(Name::ANY);
         }
-        $named = $this->reader->getMethodAnnotation($constructor, 'Ray\Di\Di\Named');
+        $named = $this->reader->getMethodAnnotation($constructor, Named::class);
         if ($named instanceof Named) {
             /* @var $named Named */
             return new Name($named->value);
@@ -55,7 +55,7 @@ final class AnnotatedClassMethods
      */
     public function getSetterMethod(\ReflectionMethod $method)
     {
-        $inject = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\InjectInterface');
+        $inject = $this->reader->getMethodAnnotation($method, InjectInterface::class);
 
         /* @var $inject \Ray\Di\Di\Inject */
         if (! $inject) {
@@ -79,7 +79,7 @@ final class AnnotatedClassMethods
     {
         $keyVal = [];
         /* @var $named Named */
-        $named = $this->reader->getMethodAnnotation($method, 'Ray\Di\Di\Named');
+        $named = $this->reader->getMethodAnnotation($method, Named::class);
         if ($named) {
             $keyVal[] = $named->value;
         }
@@ -105,7 +105,7 @@ final class AnnotatedClassMethods
         $names = [];
         foreach ($annotations as $annotation) {
             /* @var $bindAnnotation object|null */
-            $qualifier = $this->reader->getClassAnnotation(new \ReflectionClass($annotation), 'Ray\Di\Di\Qualifier');
+            $qualifier = $this->reader->getClassAnnotation(new \ReflectionClass($annotation), Qualifier::class);
             if ($qualifier instanceof Qualifier) {
                 $value = isset($annotation->value) ? $annotation->value : Name::ANY;
                 $names[] = sprintf('%s=%s', $value, get_class($annotation));

--- a/src/AnnotatedClassMethods.php
+++ b/src/AnnotatedClassMethods.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -35,7 +35,7 @@ final class Argument
      */
     private $reflection;
 
-    public function __construct(\ReflectionParameter $parameter, $name)
+    public function __construct(\ReflectionParameter $parameter, string $name)
     {
         $type = $parameter->getType();
         $isOptional = $parameter->isOptional();
@@ -66,10 +66,8 @@ final class Argument
 
     /**
      * Return reflection
-     *
-     * @return \ReflectionParameter
      */
-    public function get()
+    public function get() : \ReflectionParameter
     {
         return $this->reflection;
     }
@@ -77,7 +75,7 @@ final class Argument
     /**
      * @return bool
      */
-    public function isDefaultAvailable()
+    public function isDefaultAvailable() : bool
     {
         return $this->isDefaultAvailable;
     }
@@ -90,12 +88,12 @@ final class Argument
         return $this->default;
     }
 
-    public function getMeta()
+    public function getMeta() : string
     {
         return $this->meta;
     }
 
-    private function setDefaultValue(\ReflectionParameter $parameter)
+    private function setDefaultValue(\ReflectionParameter $parameter) : void
     {
         if (! $this->isDefaultAvailable) {
             return;

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *
@@ -92,7 +94,6 @@ final class Argument
     {
         return $this->meta;
     }
-
 
     private function setDefaultValue(\ReflectionParameter $parameter)
     {

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -35,19 +35,18 @@ final class Argument
 
     public function __construct(\ReflectionParameter $parameter, $name)
     {
-        $interface = $this->getTypeHint($parameter);
-        $interface = ($interface === 'array') ? '' : $interface; // hhvm
+        $type = $parameter->getType();
         $isOptional = $parameter->isOptional();
         $this->isDefaultAvailable = $parameter->isDefaultValueAvailable() || $isOptional;
         if ($isOptional) {
             $this->default = null;
         }
         $this->setDefaultValue($parameter);
-        $this->index = $interface . '-' . $name;
+        $this->index = $type . '-' . $name;
         $this->reflection = $parameter;
         $this->meta = sprintf(
             "dependency '%s' with name '%s' used in %s:%d ($%s)",
-            $interface,
+            $type,
             $name,
             $this->reflection->getDeclaringFunction()->getFileName(),
             $this->reflection->getDeclaringFunction()->getStartLine(),
@@ -94,21 +93,6 @@ final class Argument
         return $this->meta;
     }
 
-    /**
-     * @param \ReflectionParameter $parameter
-     *
-     * @return string
-     */
-    private function getTypeHint(\ReflectionParameter $parameter)
-    {
-        if (defined('HHVM_VERSION')) {
-            /* @noinspection PhpUndefinedFieldInspection */
-            return $parameter->info['type_hint']; // @codeCoverageIgnore
-        }
-        $typHint = $parameter->getClass();
-
-        return $typHint instanceof \ReflectionClass ? $typHint->name : '';
-    }
 
     private function setDefaultValue(\ReflectionParameter $parameter)
     {

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -35,7 +35,7 @@ final class Arguments
      *
      * @return Argument[]
      */
-    public function inject(Container $container)
+    public function inject(Container $container) : array
     {
         $parameters = $this->arguments;
         foreach ($parameters as &$parameter) {
@@ -46,9 +46,6 @@ final class Arguments
     }
 
     /**
-     * @param Container $container
-     * @param Argument  $argument
-     *
      * @throws Unbound
      *
      * @return mixed
@@ -72,7 +69,7 @@ final class Arguments
      *
      * @return array [$hasDefaultValue, $defaultValue]
      */
-    private function getDefaultValue(Argument $argument)
+    private function getDefaultValue(Argument $argument) : array
     {
         if ($argument->isDefaultAvailable()) {
             return [true, $argument->getDefaultValue()];
@@ -81,7 +78,7 @@ final class Arguments
         return [false, null];
     }
 
-    private function bindInjectionPoint(Container $container, Argument $argument)
+    private function bindInjectionPoint(Container $container, Argument $argument) : void
     {
         $isSelf = (string) $argument === 'Ray\Di\InjectionPointInterface-' . Name::ANY;
         if ($isSelf) {

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -80,10 +80,10 @@ final class Arguments
 
     private function bindInjectionPoint(Container $container, Argument $argument) : void
     {
-        $isSelf = (string) $argument === 'Ray\Di\InjectionPointInterface-' . Name::ANY;
+        $isSelf = (string) $argument === InjectionPointInterface::class . '-' . Name::ANY;
         if ($isSelf) {
             return;
         }
-        (new Bind($container, 'Ray\Di\InjectionPointInterface'))->toInstance(new InjectionPoint($argument->get(), new AnnotationReader));
+        (new Bind($container, InjectionPointInterface::class))->toInstance(new InjectionPoint($argument->get(), new AnnotationReader));
     }
 }

--- a/src/Arguments.php
+++ b/src/Arguments.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/AspectBind.php
+++ b/src/AspectBind.php
@@ -23,11 +23,9 @@ final class AspectBind
     }
 
     /**
-     * @param Container $container
-     *
-     * @return array
+     * Instantiate interceptors
      */
-    public function inject(Container $container)
+    public function inject(Container $container) : array
     {
         $bindings = $this->bind->getBindings();
         foreach ($bindings as &$interceptors) {

--- a/src/AspectBind.php
+++ b/src/AspectBind.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -11,6 +11,7 @@ use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 use Ray\Aop\ReflectionMethod;
 use Ray\Di\Di\Assisted;
+use Ray\Di\Di\Named;
 
 final class AssistedInterceptor implements MethodInterceptor
 {
@@ -64,7 +65,7 @@ final class AssistedInterceptor implements MethodInterceptor
      *
      * @internal param int $cntArgs
      */
-    public function injectAssistedParameters(ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments)
+    public function injectAssistedParameters(ReflectionMethod $method, Assisted $assisted, array $parameters, array $arguments) : array
     {
         foreach ($parameters as $parameter) {
             if (! in_array($parameter->getName(), $assisted->values, true)) {
@@ -81,14 +82,11 @@ final class AssistedInterceptor implements MethodInterceptor
     }
 
     /**
-     * @param ReflectionMethod     $method
-     * @param \ReflectionParameter $parameter
-     *
-     * @return string
+     * Return dependency "name"
      */
-    private function getName(ReflectionMethod $method, \ReflectionParameter $parameter)
+    private function getName(ReflectionMethod $method, \ReflectionParameter $parameter) : string
     {
-        $named = $method->getAnnotation('Ray\Di\Di\Named');
+        $named = $method->getAnnotation(Named::class);
         if (! $named) {
             return Name::ANY;
         }

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -42,7 +42,7 @@ final class AssistedInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         $method = $invocation->getMethod();
-        $assisted = $method->getAnnotation('Ray\Di\Di\Assisted');
+        $assisted = $method->getAnnotation(Assisted::class);
         /* @var \Ray\Di\Di\Assisted $assisted */
         $parameters = $method->getParameters();
         $arguments = $invocation->getArguments()->getArrayCopy();

--- a/src/AssistedModule.php
+++ b/src/AssistedModule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/AssistedModule.php
+++ b/src/AssistedModule.php
@@ -8,6 +8,7 @@
 namespace Ray\Di;
 
 use Ray\Aop\MethodInvocation;
+use Ray\Di\Di\Assisted;
 
 class AssistedModule extends AbstractModule
 {
@@ -15,8 +16,8 @@ class AssistedModule extends AbstractModule
     {
         $this->bindInterceptor(
             $this->matcher->any(),
-            $this->matcher->annotatedWith('Ray\Di\Di\Assisted'),
-            ['\Ray\Di\AssistedInterceptor']
+            $this->matcher->annotatedWith(Assisted::class),
+            [AssistedInterceptor::class]
         );
         $this->bind(MethodInvocation::class)->toProvider(MethodInvocationProvider::class)->in(Scope::SINGLETON);
         $this->bind(MethodInvocationProvider::class)->in(Scope::SINGLETON);

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -48,12 +48,12 @@ final class Bind
      * @param Container $container dependency container
      * @param string    $interface interface or concrete class name
      */
-    public function __construct(Container $container, $interface)
+    public function __construct(Container $container, string $interface)
     {
         $this->container = $container;
         $this->interface = $interface;
         $this->validate = new BindValidator;
-        $bindUntarget = class_exists($interface) && ! (new \ReflectionClass($interface))->isAbstract() && $this->hasNotRegistered($interface);
+        $bindUntarget = class_exists($interface) && ! (new \ReflectionClass($interface))->isAbstract() && ! $this->IsRegistered($interface);
         if ($bindUntarget) {
             $this->untarget = new Untarget($interface);
 
@@ -79,11 +79,9 @@ final class Bind
     }
 
     /**
-     * @param string $name
-     *
-     * @return $this
+     * Bind dependency name
      */
-    public function annotatedWith($name)
+    public function annotatedWith(string $name) : self
     {
         $this->name = $name;
 
@@ -91,11 +89,9 @@ final class Bind
     }
 
     /**
-     * @param string $class
-     *
-     * @return $this
+     * Bind to clss
      */
-    public function to($class)
+    public function to(string $class) : self
     {
         $this->untarget = null;
         $this->validate->to($this->interface, $class);
@@ -106,14 +102,14 @@ final class Bind
     }
 
     /**
+     * Bind to constroctur
+     *
      * @param string          $class           class name
      * @param string | array  $name            "varName=bindName,..." or [[varName=>bindName],...]
      * @param InjectionPoints $injectionPoints injection points
-     * @param null            $postConstruct   method name of initialization after all dependencies are injected
-     *
-     * @return $this
+     * @param null            $postConstruct   method name of initialization after all dependencies are injected*
      */
-    public function toConstructor($class, $name, InjectionPoints $injectionPoints = null, $postConstruct = null)
+    public function toConstructor($class, $name, InjectionPoints $injectionPoints = null, $postConstruct = null) : self
     {
         if (is_array($name)) {
             $name = $this->getStringName($name);
@@ -127,14 +123,11 @@ final class Bind
     }
 
     /**
-     * @param string $provider
-     * @param string $context
+     * Bind to provider
      *
      * @throws NotFound
-     *
-     * @return $this
      */
-    public function toProvider($provider, $context = null)
+    public function toProvider(string $provider, $context = null) : self
     {
         if (! is_null($context) && ! is_string($context)) {
             throw new InvalidContext(gettype($context));
@@ -194,16 +187,11 @@ final class Bind
         $this->bound = $bound;
     }
 
-    /**
-     * @param string $interface
-     *
-     * @return bool
-     */
-    private function hasNotRegistered($interface)
+    private function IsRegistered(string $interface) : bool
     {
-        $hasNotRegistered = ! isset($this->container->getContainer()[$interface . '-' . Name::ANY]);
+        $isRegistered = isset($this->container->getContainer()[$interface . '-' . Name::ANY]);
 
-        return $hasNotRegistered;
+        return $isRegistered;
     }
 
     /**

--- a/src/Bind.php
+++ b/src/Bind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/BindValidator.php
+++ b/src/BindValidator.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/BindValidator.php
+++ b/src/BindValidator.php
@@ -14,10 +14,7 @@ use Ray\Di\Exception\NotFound;
 
 final class BindValidator
 {
-    /**
-     * @param string $interface
-     */
-    public function constructor($interface)
+    public function constructor(string $interface)
     {
         if ($interface && ! interface_exists($interface) && ! class_exists($interface)) {
             throw new NotFound($interface);
@@ -26,11 +23,8 @@ final class BindValidator
 
     /**
      * To validator
-     *
-     * @param string $interface
-     * @param string $class
      */
-    public function to($interface, $class)
+    public function to(string $interface, string $class) : void
     {
         if (! class_exists($class)) {
             throw new NotFound($class);
@@ -44,18 +38,14 @@ final class BindValidator
     /**
      * toProvider validator
      *
-     * @param string $provider
-     *
      * @throws NotFound
-     *
-     * @return $this
      */
-    public function toProvider($provider)
+    public function toProvider(string $provider) : void
     {
         if (! class_exists($provider)) {
             throw new NotFound($provider);
         }
-        if (! (new \ReflectionClass($provider))->implementsInterface('Ray\Di\ProviderInterface')) {
+        if (! (new \ReflectionClass($provider))->implementsInterface(ProviderInterface::class)) {
             throw new InvalidProvider($provider);
         }
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Container.php
+++ b/src/Container.php
@@ -54,12 +54,9 @@ final class Container
     /**
      * Return instance by interface + name(interface namespace)
      *
-     * @param string $interface
-     * @param string $name
-     *
      * @return mixed
      */
-    public function getInstance($interface, $name)
+    public function getInstance(string $interface, string $name)
     {
         return $this->getDependency($interface . '-' . $name);
     }
@@ -67,13 +64,11 @@ final class Container
     /**
      * Return dependency injected instance
      *
-     * @param string $index
-     *
      * @throws Unbound
      *
      * @return mixed
      */
-    public function getDependency($index)
+    public function getDependency(string $index)
     {
         if (! isset($this->container[$index])) {
             throw $this->unbound($index);
@@ -86,13 +81,8 @@ final class Container
 
     /**
      * Rename existing dependency interface + name
-     *
-     * @param string $sourceInterface
-     * @param string $sourceName
-     * @param string $targetInterface
-     * @param string $targetName
      */
-    public function move($sourceInterface, $sourceName, $targetInterface, $targetName)
+    public function move(string $sourceInterface, string $sourceName, string $targetInterface, string $targetName)
     {
         $sourceIndex = $sourceInterface . '-' . $sourceName;
         if (! isset($this->container[$sourceIndex])) {
@@ -104,11 +94,13 @@ final class Container
     }
 
     /**
+     * Return Unbound exception
+     *
      * @param string $index {interface}-{bind name}
      *
      * @return Untargetted | Unbound
      */
-    public function unbound($index)
+    public function unbound(string $index)
     {
         list($class, $name) = explode('-', $index);
         if (class_exists($class) && ! (new \ReflectionClass($class))->isAbstract()) {
@@ -119,25 +111,29 @@ final class Container
     }
 
     /**
+     * Return container
+     *
      * @return DependencyInterface[]
      */
-    public function getContainer()
+    public function getContainer() : array
     {
         return $this->container;
     }
 
     /**
+     * Return pointcuts
+     *
      * @return \Ray\Aop\Pointcut[]
      */
-    public function getPointcuts()
+    public function getPointcuts() : array
     {
         return $this->pointcuts;
     }
 
     /**
-     * @param Container $container
+     * Merge container
      */
-    public function merge(Container $container)
+    public function merge(Container $container) : void
     {
         $this->container = $this->container + $container->getContainer();
         $this->pointcuts = array_merge($this->pointcuts, $container->getPointcuts());
@@ -145,10 +141,8 @@ final class Container
 
     /**
      * Weave aspects to all dependency in container
-     *
-     * @param Compiler $compiler
      */
-    public function weaveAspects(Compiler $compiler)
+    public function weaveAspects(Compiler $compiler) : void
     {
         foreach ($this->container as $dependency) {
             if (! $dependency instanceof Dependency) {
@@ -161,13 +155,8 @@ final class Container
 
     /**
      * Weave aspect to single dependency
-     *
-     * @param Compiler   $compiler
-     * @param Dependency $dependency
-     *
-     * @return $this
      */
-    public function weaveAspect(Compiler $compiler, Dependency $dependency)
+    public function weaveAspect(Compiler $compiler, Dependency $dependency) : self
     {
         $dependency->weaveAspects($compiler, $this->pointcuts);
 

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -10,6 +10,7 @@ namespace Ray\Di;
 
 use Ray\Aop\Bind as AopBind;
 use Ray\Aop\Compiler as AopCompiler;
+use Ray\Aop\MethodInterceptor;
 
 final class Dependency implements DependencyInterface
 {
@@ -96,7 +97,7 @@ final class Dependency implements DependencyInterface
     public function weaveAspects(AopCompiler $compiler, array $pointcuts)
     {
         $class = (string) $this->newInstance;
-        $isInterceptor = (new \ReflectionClass($class))->implementsInterface('Ray\Aop\MethodInterceptor');
+        $isInterceptor = (new \ReflectionClass($class))->implementsInterface(MethodInterceptor::class);
         if ($isInterceptor) {
             return;
         }

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -56,7 +56,7 @@ final class Dependency implements DependencyInterface
     /**
      * {@inheritdoc}
      */
-    public function register(array &$container, Bind $bind)
+    public function register(array &$container, Bind $bind) : void
     {
         $this->index = $index = (string) $bind;
         $container[$index] = $bind->getBound();
@@ -86,7 +86,7 @@ final class Dependency implements DependencyInterface
     /**
      * {@inheritdoc}
      */
-    public function setScope($scope)
+    public function setScope($scope) : void
     {
         if ($scope === Scope::SINGLETON) {
             $this->isSingleton = true;

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/DependencyFactory.php
+++ b/src/DependencyFactory.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/DependencyInterface.php
+++ b/src/DependencyInterface.php
@@ -23,7 +23,7 @@ interface DependencyInterface
      * @param DependencyInterface[] $container
      * @param Bind                  $bind
      */
-    public function register(array &$container, Bind $bind);
+    public function register(array &$container, Bind $bind) : void;
 
     /**
      * Set scope
@@ -32,5 +32,5 @@ interface DependencyInterface
      *
      * @return mixed
      */
-    public function setScope($scope);
+    public function setScope($scope) : void;
 }

--- a/src/DependencyProvider.php
+++ b/src/DependencyProvider.php
@@ -32,7 +32,7 @@ final class DependencyProvider implements DependencyInterface
      */
     private $instance;
 
-    public function __construct(Dependency $dependency, $context = null)
+    public function __construct(Dependency $dependency, string $context = null)
     {
         $this->dependency = $dependency;
         $this->context = $context;
@@ -46,7 +46,7 @@ final class DependencyProvider implements DependencyInterface
     /**
      * {@inheritdoc}
      */
-    public function register(array &$container, Bind $bind)
+    public function register(array &$container, Bind $bind) : void
     {
         $container[(string) $bind] = $bind->getBound();
     }
@@ -71,7 +71,7 @@ final class DependencyProvider implements DependencyInterface
     /**
      * {@inheritdoc}
      */
-    public function setScope($scope)
+    public function setScope($scope) : void
     {
         if ($scope === Scope::SINGLETON) {
             $this->isSingleton = true;

--- a/src/DependencyProvider.php
+++ b/src/DependencyProvider.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/DoctrineAnnotations.php
+++ b/src/DoctrineAnnotations.php
@@ -1,6 +1,0 @@
-<?php
-
-require_once __DIR__ . '/Di/Inject.php';
-require_once __DIR__ . '/Di/Named.php';
-require_once __DIR__ . '/Di/PostConstruct.php';
-require_once __DIR__ . '/Di/Qualifier.php';

--- a/src/EmptyModule.php
+++ b/src/EmptyModule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -63,7 +63,7 @@ final class InjectionPoint implements InjectionPointInterface
         foreach ($annotations as $annotation) {
             $qualifier = $this->reader->getClassAnnotation(
                 new \ReflectionClass($annotation),
-                'Ray\Di\Di\Qualifier'
+                Qualifier::class
             );
             if ($qualifier instanceof Qualifier) {
                 $qualifiers[] = $annotation;

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -31,7 +31,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritdoc}
      */
-    public function getParameter()
+    public function getParameter() : \ReflectionParameter
     {
         return $this->parameter;
     }
@@ -39,7 +39,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritdoc}
      */
-    public function getMethod()
+    public function getMethod() : \ReflectionFunctionAbstract
     {
         return $this->parameter->getDeclaringFunction();
     }
@@ -47,7 +47,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritdoc}
      */
-    public function getClass()
+    public function getClass() : \ReflectionClass
     {
         return $this->parameter->getDeclaringClass();
     }

--- a/src/InjectionPointInterface.php
+++ b/src/InjectionPointInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/InjectionPoints.php
+++ b/src/InjectionPoints.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/InjectionPoints.php
+++ b/src/InjectionPoints.php
@@ -21,7 +21,7 @@ final class InjectionPoints
      *
      * @return SetterMethods
      */
-    public function __invoke($class)
+    public function __invoke(string $class) : SetterMethods
     {
         $points = [];
         foreach ($this->points as $point) {
@@ -31,39 +31,21 @@ final class InjectionPoints
         return new SetterMethods($points);
     }
 
-    /**
-     * @param string $method setter method name
-     * @param string $name   binding name
-     *
-     * @return $this
-     */
-    public function addMethod($method, $name = Name::ANY)
+    public function addMethod(string $method, string $name = Name::ANY) : self
     {
         $this->points[] = [$method, $name, false];
 
         return $this;
     }
 
-    /**
-     * @param string $method setter method name
-     * @param string $name   binding name
-     *
-     * @return $this
-     */
-    public function addOptionalMethod($method, $name = Name::ANY)
+    public function addOptionalMethod(string $method, string $name = Name::ANY) : self
     {
         $this->points[] = [$method, $name, true];
 
         return $this;
     }
 
-    /**
-     * @param string $class
-     * @param array  $point
-     *
-     * @return SetterMethod
-     */
-    private function getSetterMethod($class, $point)
+    private function getSetterMethod(string $class, array $point) : SetterMethod
     {
         $setterMethod = new SetterMethod(new \ReflectionMethod($class, $point[0]), new Name($point[1]));
         if ($point[2]) {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -26,7 +26,7 @@ class Injector implements InjectorInterface
      * @param AbstractModule $module
      * @param string         $classDir
      */
-    public function __construct(AbstractModule $module = null, $classDir = null)
+    public function __construct(AbstractModule $module = null, string $classDir = null)
     {
         if (is_null($module)) {
             $module = new NullModule;
@@ -78,7 +78,7 @@ class Injector implements InjectorInterface
     /**
      * @param string $class
      */
-    private function bind($class)
+    private function bind(string $class) : void
     {
         new Bind($this->container, $class);
         /* @var $bound Dependency */

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -37,7 +37,7 @@ class Injector implements InjectorInterface
         $this->container->weaveAspects(new Compiler($this->classDir));
 
         // builtin injection
-        (new Bind($this->container, 'Ray\Di\InjectorInterface'))->toInstance($this);
+        (new Bind($this->container, InjectorInterface::class))->toInstance($this);
     }
 
     /**

--- a/src/InjectorInterface.php
+++ b/src/InjectorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Instance.php
+++ b/src/Instance.php
@@ -23,7 +23,7 @@ final class Instance implements DependencyInterface
     /**
      * {@inheritdoc}
      */
-    public function register(array &$container, Bind $bind)
+    public function register(array &$container, Bind $bind) : void
     {
         $index = (string) $bind;
         $container[$index] = $bind->getBound();
@@ -44,7 +44,7 @@ final class Instance implements DependencyInterface
      *
      * @codeCoverageIgnore
      */
-    public function setScope($scope)
+    public function setScope($scope) : void
     {
     }
 }

--- a/src/Instance.php
+++ b/src/Instance.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/MethodInvocationProvider.php
+++ b/src/MethodInvocationProvider.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Name.php
+++ b/src/Name.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Name.php
+++ b/src/Name.php
@@ -29,22 +29,14 @@ final class Name
      */
     private $names;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name)
+    public function __construct(string $name = null)
     {
         if (! is_null($name)) {
             $this->setName($name);
         }
     }
 
-    /**
-     * @param \ReflectionParameter $parameter
-     *
-     * @return string
-     */
-    public function __invoke(\ReflectionParameter $parameter)
+    public function __invoke(\ReflectionParameter $parameter) : string
     {
         // single variable named binding
         if ($this->name) {
@@ -65,10 +57,7 @@ final class Name
         return self::ANY;
     }
 
-    /**
-     * @param string $name
-     */
-    private function setName($name)
+    private function setName(string $name) : void
     {
         // annotation
         if (class_exists($name, false)) {
@@ -91,7 +80,7 @@ final class Name
     /**
      * @param string $name
      */
-    private function parseName($name)
+    private function parseName(string $name) : void
     {
         $keyValues = explode(',', $name);
         foreach ($keyValues as $keyValue) {

--- a/src/NewInstance.php
+++ b/src/NewInstance.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/NewInstance.php
+++ b/src/NewInstance.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/NullModule.php
+++ b/src/NullModule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/ProviderInterface.php
+++ b/src/ProviderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/SetContextInterface.php
+++ b/src/SetContextInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/SetterMethod.php
+++ b/src/SetterMethod.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/SetterMethod.php
+++ b/src/SetterMethod.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/SetterMethods.php
+++ b/src/SetterMethods.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/Untarget.php
+++ b/src/Untarget.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  */
 namespace Ray\Di;
 
-class Untarget
+final class Untarget
 {
     /**
      * @var \ReflectionClass
@@ -20,10 +20,7 @@ class Untarget
      */
     private $scope = Scope::PROTOTYPE;
 
-    /**
-     * @param string $class
-     */
-    public function __construct($class)
+    public function __construct(string $class)
     {
         $this->class = new \ReflectionClass($class);
     }
@@ -46,7 +43,7 @@ class Untarget
         }
     }
 
-    public function setScope($scope)
+    public function setScope(string $scope)
     {
         $this->scope = $scope;
     }

--- a/src/Untarget.php
+++ b/src/Untarget.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/UntargetedBind.php
+++ b/src/UntargetedBind.php
@@ -31,10 +31,6 @@ final class UntargetedBind
      */
     private function getTypeHint(\ReflectionParameter $parameter)
     {
-        if (defined('HHVM_VERSION')) {
-            /* @noinspection PhpUndefinedFieldInspection */
-            return $parameter->info['type_hint']; // @codeCoverageIgnore
-        }
         $typeHintClass = $parameter->getClass();
 
         return $typeHintClass ? $typeHintClass->name : '';

--- a/src/UntargetedBind.php
+++ b/src/UntargetedBind.php
@@ -1,6 +1,5 @@
 <?php
 
-declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/src/UntargetedBind.php
+++ b/src/UntargetedBind.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Ray.Di package.
  *

--- a/tests/AnnotatedClassTest.php
+++ b/tests/AnnotatedClassTest.php
@@ -2,8 +2,9 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
 
-class AnnotatedClassTest extends \PHPUnit_Framework_TestCase
+class AnnotatedClassTest extends TestCase
 {
     /**
      * @var AnnotatedClass

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class ArgumentTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ArgumentTest extends TestCase
 {
     /**
      * @var Argument

--- a/tests/ArgumentsTest.php
+++ b/tests/ArgumentsTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class ArgumentsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ArgumentsTest extends TestCase
 {
     /**
      * @var Arguments

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -2,9 +2,10 @@
 
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\MethodInvocationNotAvailable;
 
-class AssistedTest extends \PHPUnit_Framework_TestCase
+class AssistedTest extends TestCase
 {
     /**
      * @var InjectorInterface

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
@@ -59,7 +58,7 @@ class AssistedTest extends TestCase
 
     public function testAssistedMethodInvocationNotAvailable()
     {
-        $this->setExpectedException(MethodInvocationNotAvailable::class);
+        $this->expectException(MethodInvocationNotAvailable::class);
         $assistedDbProvider = (new Injector(new FakeAssistedDbModule))->getInstance(FakeAssistedDbProvider::class);
         /* @var $assistedDbProvider FakeAssistedDbProvider */
         $assistedDbProvider->get();

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -57,9 +57,11 @@ class AssistedTest extends TestCase
         $this->assertSame(1, $db->dbId);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\MethodInvocationNotAvailable
+     */
     public function testAssistedMethodInvocationNotAvailable()
     {
-        $this->setExpectedException(MethodInvocationNotAvailable::class);
         $assistedDbProvider = (new Injector(new FakeAssistedDbModule))->getInstance(FakeAssistedDbProvider::class);
         /* @var $assistedDbProvider FakeAssistedDbProvider */
         $assistedDbProvider->get();

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -57,11 +57,9 @@ class AssistedTest extends TestCase
         $this->assertSame(1, $db->dbId);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\MethodInvocationNotAvailable
-     */
     public function testAssistedMethodInvocationNotAvailable()
     {
+        $this->setExpectedException(MethodInvocationNotAvailable::class);
         $assistedDbProvider = (new Injector(new FakeAssistedDbModule))->getInstance(FakeAssistedDbProvider::class);
         /* @var $assistedDbProvider FakeAssistedDbProvider */
         $assistedDbProvider->get();

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -33,19 +33,19 @@ class BindTest extends TestCase
 
     public function testInvalidToTest()
     {
-        $this->setExpectedException(Notfound::class);
+        $this->expectException(Notfound::class);
         $this->bind->to('invalid-class');
     }
 
     public function testInvalidToProviderTest()
     {
-        $this->setExpectedException(Notfound::class);
+        $this->expectException(Notfound::class);
         $this->bind->toProvider('invalid-class');
     }
 
     public function testInValidInterfaceBinding()
     {
-        $this->setExpectedException(NotFound::class);
+        $this->expectException(NotFound::class);
         new Bind(new Container, 'invalid-interface');
     }
 
@@ -111,13 +111,13 @@ class BindTest extends TestCase
 
     public function testToValidation()
     {
-        $this->setExpectedException(InvalidType::class);
+        $this->expectException(InvalidType::class);
         (new Bind(new Container, FakeHandleInterface::class))->to(FakeEngine::class);
     }
 
     public function testToProvider()
     {
-        $this->setExpectedException(InvalidProvider::class);
+        $this->expectException(InvalidProvider::class);
         (new Bind(new Container, FakeHandleInterface::class))->toProvider(FakeEngine::class);
     }
 

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -72,7 +72,7 @@ class BindTest extends TestCase
     {
         return [
             ['tmpDir=tmp_dir,leg=left'],
-            [['tmpDir' => 'tmp_dir','leg' => 'left']]
+            [['tmpDir' => 'tmp_dir', 'leg' => 'left']]
         ];
     }
 

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -31,27 +31,21 @@ class BindTest extends TestCase
         $this->assertSame('Ray\Di\FakeTyreInterface-' . NAME::ANY, (string) $this->bind);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Notfound
-     */
     public function testInvalidToTest()
     {
+        $this->setExpectedException(Notfound::class);
         $this->bind->to('invalid-class');
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Notfound
-     */
     public function testInvalidToProviderTest()
     {
+        $this->setExpectedException(Notfound::class);
         $this->bind->toProvider('invalid-class');
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\NotFound
-     */
     public function testInValidInterfaceBinding()
     {
+        $this->setExpectedException(NotFound::class);
         new Bind(new Container, 'invalid-interface');
     }
 
@@ -115,19 +109,15 @@ class BindTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance->engine);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\InvalidType
-     */
     public function testToValidation()
     {
+        $this->setExpectedException(InvalidType::class);
         (new Bind(new Container, FakeHandleInterface::class))->to(FakeEngine::class);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\InvalidProvider
-     */
     public function testToProvider()
     {
+        $this->setExpectedException(InvalidProvider::class);
         (new Bind(new Container, FakeHandleInterface::class))->toProvider(FakeEngine::class);
     }
 

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -31,21 +31,27 @@ class BindTest extends TestCase
         $this->assertSame('Ray\Di\FakeTyreInterface-' . NAME::ANY, (string) $this->bind);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Notfound
+     */
     public function testInvalidToTest()
     {
-        $this->setExpectedException(Notfound::class);
         $this->bind->to('invalid-class');
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Notfound
+     */
     public function testInvalidToProviderTest()
     {
-        $this->setExpectedException(Notfound::class);
         $this->bind->toProvider('invalid-class');
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\NotFound
+     */
     public function testInValidInterfaceBinding()
     {
-        $this->setExpectedException(NotFound::class);
         new Bind(new Container, 'invalid-interface');
     }
 
@@ -109,15 +115,19 @@ class BindTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance->engine);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\InvalidType
+     */
     public function testToValidation()
     {
-        $this->setExpectedException(InvalidType::class);
         (new Bind(new Container, FakeHandleInterface::class))->to(FakeEngine::class);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\InvalidProvider
+     */
     public function testToProvider()
     {
-        $this->setExpectedException(InvalidProvider::class);
         (new Bind(new Container, FakeHandleInterface::class))->toProvider(FakeEngine::class);
     }
 

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\InvalidProvider;
 use Ray\Di\Exception\InvalidType;
 use Ray\Di\Exception\NotFound;
 
-class BindTest extends \PHPUnit_Framework_TestCase
+class BindTest extends TestCase
 {
     /**
      * @var Bind

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -122,7 +122,7 @@ class ContainerTest extends TestCase
 
     public function testMoveUnbound()
     {
-        $this->setExpectedException(Unbound::class);
+        $this->expectException(Unbound::class);
         $this->container->move(FakeEngineInterface::class, 'invalid', FakeEngineInterface::class, 'new');
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
 use Ray\Di\Exception\Unbound;
 
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends TestCase
 {
     /**
      * @var Container

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -120,9 +120,11 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Unbound
+     */
     public function testMoveUnbound()
     {
-        $this->setExpectedException(Unbound::class);
         $this->container->move(FakeEngineInterface::class, 'invalid', FakeEngineInterface::class, 'new');
     }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -120,11 +120,9 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Unbound
-     */
     public function testMoveUnbound()
     {
+        $this->setExpectedException(Unbound::class);
         $this->container->move(FakeEngineInterface::class, 'invalid', FakeEngineInterface::class, 'new');
     }
 

--- a/tests/ContextualProviderTest.php
+++ b/tests/ContextualProviderTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class ContextualProviderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ContextualProviderTest extends TestCase
 {
     public function testContextualProviderInjection()
     {

--- a/tests/DependencyTest.php
+++ b/tests/DependencyTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Aop\Compiler;
 use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
 use Ray\Aop\WeavedInterface;
 
-class DependencyTest extends \PHPUnit_Framework_TestCase
+class DependencyTest extends TestCase
 {
     /**
      * @var Dependency

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Compiler\DiCompiler;
 
-class DiCompilerTest extends \PHPUnit_Framework_TestCase
+class DiCompilerTest extends TestCase
 {
     public function testUntargetInject()
     {

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -2,8 +2,9 @@
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
 
-class InjectionPointTest extends \PHPUnit_Framework_TestCase
+class InjectionPointTest extends TestCase
 {
     /**
      * @var InjectionPointInterface

--- a/tests/InjectionPointsTest.php
+++ b/tests/InjectionPointsTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class InjectionPointsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class InjectionPointsTest extends TestCase
 {
     /**
      * @var InjectionPoints

--- a/tests/InjectionPointsTest.php
+++ b/tests/InjectionPointsTest.php
@@ -24,7 +24,7 @@ class InjectionPointsTest extends TestCase
     public function testInvoke()
     {
         $car = new FakeCar(new FakeEngine);
-        $setterMethods = $this->injectionPoints->__invoke($car);
+        $setterMethods = $this->injectionPoints->__invoke(get_class($car));
         $this->assertInstanceOf(SetterMethods::class, $setterMethods);
 
         return $setterMethods;

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -26,11 +26,9 @@ class InjectorTest extends TestCase
         $this->assertSame($engine, $injector->getInstance(FakeEngine::class));
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Unbound
-     */
     public function testUnbound()
     {
+        $this->setExpectedException(Unbound::class);
         $injector = new Injector(new FakeInstanceBindModule);
         $injector->getInstance('', 'invalid-binding-xxx');
     }
@@ -276,11 +274,9 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeRightLeg::class, $robot->rightLeg);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Unbound
-     */
     public function testNewAbstract()
     {
+        $this->setExpectedException(Unbound::class, FakeAbstractClass::class);
         (new Injector)->getInstance(FakeConcreteClass::class);
     }
 

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -26,9 +26,11 @@ class InjectorTest extends TestCase
         $this->assertSame($engine, $injector->getInstance(FakeEngine::class));
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Unbound
+     */
     public function testUnbound()
     {
-        $this->setExpectedException(Unbound::class);
         $injector = new Injector(new FakeInstanceBindModule);
         $injector->getInstance('', 'invalid-binding-xxx');
     }
@@ -274,9 +276,11 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeRightLeg::class, $robot->rightLeg);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Unbound
+     */
     public function testNewAbstract()
     {
-        $this->setExpectedException(Unbound::class, FakeAbstractClass::class);
         (new Injector)->getInstance(FakeConcreteClass::class);
     }
 

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -28,7 +28,7 @@ class InjectorTest extends TestCase
 
     public function testUnbound()
     {
-        $this->setExpectedException(Unbound::class);
+        $this->expectException(Unbound::class);
         $injector = new Injector(new FakeInstanceBindModule);
         $injector->getInstance('', 'invalid-binding-xxx');
     }
@@ -276,7 +276,7 @@ class InjectorTest extends TestCase
 
     public function testNewAbstract()
     {
-        $this->setExpectedException(Unbound::class, FakeAbstractClass::class);
+        $this->expectException(Unbound::class, FakeAbstractClass::class);
         (new Injector)->getInstance(FakeConcreteClass::class);
     }
 

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\Unbound;
 
-class InjectorTest extends \PHPUnit_Framework_TestCase
+class InjectorTest extends TestCase
 {
     public function testNew()
     {

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -20,7 +20,7 @@ class ModuleTest extends TestCase
 
     public function testToInvalidClass()
     {
-        $this->setExpectedException(NotFound::class);
+        $this->expectException(NotFound::class);
         new FakeToBindInvalidClassModule;
     }
 

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -18,11 +18,9 @@ class ModuleTest extends TestCase
         $this->assertInstanceOf(AbstractModule::class, $module);
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\NotFound
-     */
     public function testToInvalidClass()
     {
+        $this->setExpectedException(NotFound::class);
         new FakeToBindInvalidClassModule;
     }
 

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\NotFound;
 
-class ModuleTest extends \PHPUnit_Framework_TestCase
+class ModuleTest extends TestCase
 {
     public function testNew()
     {

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -18,9 +18,11 @@ class ModuleTest extends TestCase
         $this->assertInstanceOf(AbstractModule::class, $module);
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\NotFound
+     */
     public function testToInvalidClass()
     {
-        $this->setExpectedException(NotFound::class);
         new FakeToBindInvalidClassModule;
     }
 

--- a/tests/NameTest.php
+++ b/tests/NameTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class NameTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NameTest extends TestCase
 {
     public function testUnName()
     {

--- a/tests/NewInstanceTest.php
+++ b/tests/NewInstanceTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class NewInstanceTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NewInstanceTest extends TestCase
 {
     /**
      * @var NewInstance

--- a/tests/NullModuleTest.php
+++ b/tests/NullModuleTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class NullModuleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NullModuleTest extends TestCase
 {
     public function testNew()
     {

--- a/tests/SetterMethodTest.php
+++ b/tests/SetterMethodTest.php
@@ -30,11 +30,9 @@ class SetterMethodTest extends TestCase
         $this->assertNotSame(spl_object_hash($car->frontTyre), spl_object_hash($car->rearTyre));
     }
 
-    /**
-     * @expectedException \Ray\Di\Exception\Unbound
-     */
     public function testUnbound()
     {
+        $this->setExpectedException(Unbound::class);
         $container = new Container;
         $car = new FakeCar(new FakeEngine);
         $this->setterMethods->__invoke($car, $container);

--- a/tests/SetterMethodTest.php
+++ b/tests/SetterMethodTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\Unbound;
 
-class SetterMethodTest extends \PHPUnit_Framework_TestCase
+class SetterMethodTest extends TestCase
 {
     /**
      * @var SetterMethods

--- a/tests/SetterMethodTest.php
+++ b/tests/SetterMethodTest.php
@@ -32,7 +32,7 @@ class SetterMethodTest extends TestCase
 
     public function testUnbound()
     {
-        $this->setExpectedException(Unbound::class);
+        $this->expectException(Unbound::class);
         $container = new Container;
         $car = new FakeCar(new FakeEngine);
         $this->setterMethods->__invoke($car, $container);

--- a/tests/SetterMethodTest.php
+++ b/tests/SetterMethodTest.php
@@ -30,9 +30,11 @@ class SetterMethodTest extends TestCase
         $this->assertNotSame(spl_object_hash($car->frontTyre), spl_object_hash($car->rearTyre));
     }
 
+    /**
+     * @expectedException \Ray\Di\Exception\Unbound
+     */
     public function testUnbound()
     {
-        $this->setExpectedException(Unbound::class);
         $container = new Container;
         $car = new FakeCar(new FakeEngine);
         $this->setterMethods->__invoke($car, $container);

--- a/tests/SetterMethodsTest.php
+++ b/tests/SetterMethodsTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ray\Di;
 
-class SetterMethodsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SetterMethodsTest extends TestCase
 {
     /**
      * @var SetterMethod

--- a/tests/UnboundTest.php
+++ b/tests/UnboundTest.php
@@ -1,9 +1,10 @@
 <?php
 namespace Ray\Di;
 
+use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\Unbound;
 
-class UnboundTest extends \PHPUnit_Framework_TestCase
+class UnboundTest extends TestCase
 {
     public function testGetBound()
     {


### PR DESCRIPTION
* Version 2.6
* Drop PHP5.x, 7.0 and hhvm support since v2.5
* Update phpunit v6

PHP5.x, 7.0 and hhvm are continued to be **SUPPORTED** as version **2.5.x**. 