### PR TITLE
Hotfix scalar type binding

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -10,7 +10,7 @@ return \PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules(array(
         '@PSR2' => true,
-//        'header_comment' => ['header' => $header, 'commentType' => 'PHPDoc', 'separate' => 'none'],
+        'header_comment' => ['header' => $header, 'commentType' => 'PHPDoc', 'separate' => 'none'],
         'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => ['align_equals' => false, 'align_double_arrow' => false],
         'blank_line_after_opening_tag' => true,

--- a/docs/demo/01-linked-binding-setter-injection.php
+++ b/docs/demo/01-linked-binding-setter-injection.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Inject;
 use Ray\Di\Injector;

--- a/docs/demo/01-linked-binding.php
+++ b/docs/demo/01-linked-binding.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 

--- a/docs/demo/02-provider-binding.php
+++ b/docs/demo/02-provider-binding.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectionPointInterface;
 use Ray\Di\Injector;

--- a/docs/demo/02a-named-by-qualifier.php
+++ b/docs/demo/02a-named-by-qualifier.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Qualifier;
 use Ray\Di\Injector;

--- a/docs/demo/02b-named-by-named.php
+++ b/docs/demo/02b-named-by-named.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Named;
 use Ray\Di\Injector;

--- a/docs/demo/03-injection-point.php
+++ b/docs/demo/03-injection-point.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectionPointInterface;
 use Ray\Di\Injector;

--- a/docs/demo/04-untarget-binding.php
+++ b/docs/demo/04-untarget-binding.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 use Ray\Di\Scope;

--- a/docs/demo/05a-constructor-binding.php
+++ b/docs/demo/05a-constructor-binding.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 require __DIR__ . '/bootstrap.php';
 
 use Ray\Di\AbstractModule;

--- a/docs/demo/05b-constructor-binding-setter-injection.php
+++ b/docs/demo/05b-constructor-binding-setter-injection.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di\Demo;
 
 use Ray\Di\AbstractModule;

--- a/docs/demo/06-install.php
+++ b/docs/demo/06-install.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 

--- a/docs/demo/07-assisted-injection.php
+++ b/docs/demo/07-assisted-injection.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Assisted;
 use Ray\Di\Injector;

--- a/docs/demo/10-cache.php
+++ b/docs/demo/10-cache.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\Injector;
 
 require __DIR__ . '/bootstrap.php';

--- a/docs/demo/11-script-injector.php
+++ b/docs/demo/11-script-injector.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Compiler\DiCompiler;
 use Ray\Compiler\ScriptInjector;
 use Ray\Di\Injector;

--- a/docs/demo/12-dependency-chain-error-message.php
+++ b/docs/demo/12-dependency-chain-error-message.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\Injector;

--- a/docs/demo/bootstrap.php
+++ b/docs/demo/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = require dirname(dirname(__DIR__)) . '/vendor/autoload.php';

--- a/docs/demo/finder_module.php
+++ b/docs/demo/finder_module.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Inject;
 use Ray\Di\Di\PostConstruct;

--- a/docs/demo/run.php
+++ b/docs/demo/run.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 passthru('php ' . __DIR__ . '/01-linked-binding.php');
 passthru('php ' . __DIR__ . '/01-linked-binding-setter-injection.php');
 passthru('php ' . __DIR__ . '/02-provider-binding.php');

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -37,7 +37,7 @@ final class Argument
 
     public function __construct(\ReflectionParameter $parameter, string $name)
     {
-        $type = $parameter->getType();
+        $type = $this->getType($parameter);
         $isOptional = $parameter->isOptional();
         $this->isDefaultAvailable = $parameter->isDefaultValueAvailable() || $isOptional;
         if ($isOptional) {
@@ -104,5 +104,15 @@ final class Argument
             // probably it is internal class like \PDO
             $this->default = null;
         }
+    }
+
+    private function getType(\ReflectionParameter $parameter) : string
+    {
+        $type = $parameter->getType();
+        if ($type instanceof \ReflectionType && in_array((string) $type, ['bool', 'int', 'string', 'array'], true)) {
+            return '';
+        }
+
+        return (string) $type;
     }
 }

--- a/tests/AnnotatedClassTest.php
+++ b/tests/AnnotatedClassTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ArgumentsTest.php
+++ b/tests/ArgumentsTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/BindTest.php
+++ b/tests/BindTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ContextualProviderTest.php
+++ b/tests/ContextualProviderTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/DependencyTest.php
+++ b/tests/DependencyTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/InjectionPointTest.php
+++ b/tests/InjectionPointTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/tests/InjectionPointsTest.php
+++ b/tests/InjectionPointsTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/NameTest.php
+++ b/tests/NameTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/NewInstanceTest.php
+++ b/tests/NewInstanceTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/NullModuleTest.php
+++ b/tests/NullModuleTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/SetterMethodTest.php
+++ b/tests/SetterMethodTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/SetterMethodsTest.php
+++ b/tests/SetterMethodsTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UnboundTest.php
+++ b/tests/UnboundTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/annotations.php
+++ b/tests/annotations.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 require_once __DIR__ . '/Fake/FakeGearStickInject.php';
 require_once __DIR__ . '/Fake/FakeLeft.php';
 require_once __DIR__ . '/Fake/FakeRight.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 /* @var $loader \Composer\Autoload\ClassLoader */
 \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);

--- a/tests/script/aop.php
+++ b/tests/script/aop.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the *** package
+ * This file is part of the Ray.Di package.
  *
  * @license http://opensource.org/licenses/MIT MIT
  */

--- a/tests/script/bench.php
+++ b/tests/script/bench.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This file is part of the Ray.Di package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
 namespace Ray\Di;
 
 use Ray\Compiler\DiCompiler;


### PR DESCRIPTION
The return value of getType () since php7 now includes "array".
Ignore it to maintain backwards compatibility.

php7からgetType()の戻り値に"array"も含まれるようになった。
後方互換性を維持するためにそれを無視。

