### PR TITLE
require ray/aop ^2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "ray/aop": "^2.5",
+        "ray/aop": "^2.6",
         "ray/compiler": "^1.1.5"
     },
     "require-dev": {
@@ -34,7 +34,7 @@
         }
     },
     "scripts" :{
-        "test": ["@cs", "phpunit"],
+        "test": ["@cs", "phpunit", "phpstan analyse -l max src tests -c phpstan.neon --no-progress"],
         "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
         "cs": ["php-cs-fixer fix -v --dry-run", "phpcs --standard=./phpcs.xml src"],
         "cs-fix": ["php-cs-fixer fix -v", "phpcbf src"]

--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -6,10 +6,6 @@ declare(strict_types=1);
  *
  * @license http://opensource.org/licenses/MIT MIT
  */
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 /* @var $loader \Composer\Autoload\ClassLoader */
 $loader->addPsr4('Ray\Di\Demo\\', __DIR__ . '/src/');
-// annotation loader
-AnnotationRegistry::registerLoader('class_exists');

--- a/src/AssistedInterceptor.php
+++ b/src/AssistedInterceptor.php
@@ -40,6 +40,7 @@ final class AssistedInterceptor implements MethodInterceptor
      */
     public function invoke(MethodInvocation $invocation)
     {
+        /** @var ReflectionMethod $method */
         $method = $invocation->getMethod();
         $assisted = $method->getAnnotation(Assisted::class);
         /* @var \Ray\Di\Di\Assisted $assisted */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,10 +6,7 @@ declare(strict_types=1);
  *
  * @license http://opensource.org/licenses/MIT MIT
  */
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 $_ENV['TMP_DIR'] = __DIR__ . '/tmp';
-AnnotationRegistry::registerLoader('class_exists');
 // cleanup tmp directory
 $unlink = function ($path) use (&$unlink) {
     foreach (glob(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {


### PR DESCRIPTION
 * [update] no `AnnotationRegistry::registerLoader` needed any more in user code. https://github.com/ray-di/Ray.Aop/pull/83