### PR TITLE
Save context property

### DIFF
--- a/src/DependencyProvider.php
+++ b/src/DependencyProvider.php
@@ -36,7 +36,7 @@ final class DependencyProvider implements DependencyInterface
 
     public function __sleep()
     {
-        return ['dependency', 'isSingleton'];
+        return ['context', 'dependency', 'isSingleton'];
     }
 
     public function __toString()

--- a/src/NewInstance.php
+++ b/src/NewInstance.php
@@ -44,6 +44,7 @@ final class NewInstance
 
     /**
      * @throws \ReflectionException
+     *
      * @return object
      */
     public function __invoke(Container $container)

--- a/src/SetterMethod.php
+++ b/src/SetterMethod.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-use Ray\Di\Exception\Unbound;
 use function is_callable;
+use Ray\Di\Exception\Unbound;
 
 final class SetterMethod
 {


### PR DESCRIPTION
Fix the issue that context in Provider is not saved in cached module. This bug is appeared when DI is compiled with ray/compiler. 

https://github.com/bearsunday/BEAR.Package/pull/294