### PR TITLE
Parent class binding

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -165,4 +165,13 @@ class ContainerTest extends TestCase
         (new Bind($container, FakeEngineInterface::class))->toInstance(new FakeEngine);
         $container->getInstanceWithArgs(FakeEngineInterface::class, []);
     }
+
+    public function testParentClassBinding() : void
+    {
+        $container = new Container;
+        (new Bind($container, FakeAbstractClass::class))->toProvider(FakeExtendedProvider::class);
+        // note: FakeExtendedClass is not bound to FakeAbstractClass but FakeExtendedProvider
+        $instance = $container->getDependency(FakeExtendedClass::class . '-');
+        $this->assertInstanceOf(FakeExtendedClass::class, $instance);
+    }
 }

--- a/tests/Fake/FakeExtendedClass.php
+++ b/tests/Fake/FakeExtendedClass.php
@@ -1,0 +1,6 @@
+<?php
+namespace Ray\Di;
+
+class FakeExtendedClass extends FakeAbstractClass
+{
+}

--- a/tests/Fake/FakeExtendedProvider.php
+++ b/tests/Fake/FakeExtendedProvider.php
@@ -1,0 +1,10 @@
+<?php
+namespace Ray\Di;
+
+class FakeExtendedProvider implements ProviderInterface
+{
+    public function get()
+    {
+        return new FakeExtendedClass;
+    }
+}


### PR DESCRIPTION
If the no bindings found for the class, try to find its parent class  and use it as a binding.