### PR TITLE
Fix built-in scalar type issue

### DIFF
--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -18,6 +18,8 @@ use function unserialize;
 
 final class Argument implements Serializable
 {
+    public const UNBOUND_TYPE = ['bool', 'int', 'float', 'string', 'array', 'resource', 'callable', 'iterable'];
+
     /** @var string */
     private $index;
 
@@ -141,14 +143,7 @@ final class Argument implements Serializable
     private function getType(ReflectionParameter $parameter): string
     {
         $type = $parameter->getType();
-        if (! $type instanceof ReflectionNamedType) {
-            return '';
-        }
 
-        if (in_array($type->getName(), ['bool', 'int', 'string', 'array', 'resource', 'callable'], true)) {
-            return '';
-        }
-
-        return $type->getName();
+        return $type instanceof ReflectionNamedType && ! in_array($type->getName(), self::UNBOUND_TYPE, true) ? $type->getName() : '';
     }
 }

--- a/src/di/AssistedInterceptor.php
+++ b/src/di/AssistedInterceptor.php
@@ -9,8 +9,8 @@ use Ray\Aop\MethodInvocation;
 use Ray\Aop\ReflectionMethod;
 use Ray\Di\Di\Assisted;
 use Ray\Di\Di\Named;
+use ReflectionNamedType;
 use ReflectionParameter;
-use ReflectionType;
 
 use function in_array;
 use function parse_str;
@@ -66,8 +66,8 @@ final class AssistedInterceptor implements MethodInterceptor
                 continue;
             }
 
-            $hint = $parameter->getType();
-            $interface = $hint instanceof ReflectionType ? $hint->getName() : ''; // @phpstan-ignore-line
+            $type = $parameter->getType();
+            $interface = $type instanceof ReflectionNamedType && ! in_array($type->getName(), Argument::UNBOUND_TYPE, true) ? $type->getName() : '';
             $name = $this->getName($method, $parameter);
             $pos = $parameter->getPosition();
             /** @psalm-suppress MixedAssignment */

--- a/src/di/UntargetedBind.php
+++ b/src/di/UntargetedBind.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
-use ReflectionType;
 
 use function class_exists;
+use function in_array;
 
 final class UntargetedBind
 {
@@ -22,16 +23,16 @@ final class UntargetedBind
 
     private function addConcreteClass(Container $container, ReflectionParameter $parameter): void
     {
-        $class = $this->getTypeHint($parameter);
+        $class = $this->getType($parameter);
         if (class_exists($class)) {
             new Bind($container, $class);
         }
     }
 
-    private function getTypeHint(ReflectionParameter $parameter): string
+    private function getType(ReflectionParameter $parameter): string
     {
-        $typeHintClass = $parameter->getType();
+        $type = $parameter->getType();
 
-        return $typeHintClass instanceof ReflectionType ? $typeHintClass->getName() : ''; // @phpstan-ignore-line
+        return $type instanceof ReflectionNamedType && ! in_array($type->getName(), Argument::UNBOUND_TYPE, true) ? $type->getName() : '';
     }
 }


### PR DESCRIPTION
*  Scalar type (like 'string' ) should not bind for BC. 
* This PR clarify witch type can not be bound (Argument::UNBOUND_TYPE) 

