### PR TITLE
Allow NullInterceptor to be bound

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,6 +20,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
         dependencies:
           - lowest
           - highest

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,10 +1,10 @@
 filter:
     paths: ["src/*"]
+
 tools:
     php_sim: true
     php_pdepend: true
     php_analyzer: true
-    php_cpd: true
     php_mess_detector:
         enabled: true
         config:
@@ -13,3 +13,9 @@ tools:
         enabled: true
         config:
             ruleset: ./phpcs.xml
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run --enable-security-analysis

--- a/README.ja.md
+++ b/README.ja.md
@@ -594,6 +594,18 @@ class AopMatcherModule extends AbstractModule
 }
 ```
 
+インターセプターを無効にするにはNullInterceptorを束縛します。
+
+```php
+use Ray\Aop\NullInterceptor;
+
+protected function configure()
+{
+    // ...
+    $this->bind(LoggerInterface::class)->to(NullInterceptor::class);
+}
+```
+
 # ベストプラクティス
 
 可能な限りインジェクターを直接使わないコードにします。その代わりアプリケーションのbootstrapで **ルートオブジェクト** をインジェクトするようにします。

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Call Stack:
     0.0056     318784   5. Ray\Aop\Sample\WeekendBlocker->invoke() /libs/Ray.Aop/src/ReflectiveMethodInvocation.php:65
 ```
 
-You can bind interceptors in variouas ways as follows.
+You can bind interceptors in various ways as follows.
 
 ```php
 
@@ -677,18 +677,32 @@ class TaxModule extends AbstractModule
 
 ```php
 
-use Ray\Di\AbstractModule;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;use Ray\Aop\NullInterceptor;use Ray\Di\AbstractModule;
 
 class AopMatcherModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(LoggerInterface::class)->to(DatabeseLogger::class);
         $this->bindInterceptor(
             $this->matcher->any(),                 // In any class and
             $this->matcher->startWith('delete'),   // ..the method start with "delete"
-            [Logger::class]
+            [LoggerInterface::class]
         );
     }
+}
+```
+
+To disable the interceptor, bind NullInterceptor.
+
+```php
+use Ray\Aop\NullInterceptor;
+
+protected function configure()
+{
+    // ...
+    $this->bind(LoggerInterface::class)->to(NullInterceptor::class);
 }
 ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,5 +10,3 @@ coverage:
     patch:
       default:
         target: 100%
-
-comment: false

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ray/aop": "^2.10"
     },
     "require-dev": {
+        "ext-pdo": "*",
         "phpunit/phpunit": "^9.5",
         "bamarni/composer-bin-plugin": "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "ray/aop": "^2.10"
     },
     "require-dev": {
-        "ext-pdo": "*",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.10",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "config": {

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -74,7 +74,7 @@ abstract class AbstractModule
     /**
      * Bind interceptor
      *
-     * @param array<class-string<MethodInterceptor>|interface-string<MethodInterceptor>> $interceptors
+     * @param array<class-string<MethodInterceptor>> $interceptors
      */
     public function bindInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors): void
     {

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -11,6 +11,7 @@ use Ray\Aop\Pointcut;
 use Ray\Aop\PriorityPointcut;
 
 use function assert;
+use function class_exists;
 
 abstract class AbstractModule
 {
@@ -79,7 +80,13 @@ abstract class AbstractModule
         $pointcut = new Pointcut($classMatcher, $methodMatcher, $interceptors);
         $this->getContainer()->addPointcut($pointcut);
         foreach ($interceptors as $interceptor) {
-            (new Bind($this->getContainer(), $interceptor))->to($interceptor)->in(Scope::SINGLETON);
+            if (class_exists($interceptor)) {
+                (new Bind($this->getContainer(), $interceptor))->to($interceptor)->in(Scope::SINGLETON);
+
+                return;
+            }
+
+            (new Bind($this->getContainer(), $interceptor))->in(Scope::SINGLETON);
         }
     }
 

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -12,6 +12,7 @@ use Ray\Aop\PriorityPointcut;
 
 use function assert;
 use function class_exists;
+use function interface_exists;
 
 abstract class AbstractModule
 {
@@ -73,7 +74,7 @@ abstract class AbstractModule
     /**
      * Bind interceptor
      *
-     * @param array<class-string<MethodInterceptor>> $interceptors
+     * @param array<class-string<MethodInterceptor>|interface-string<MethodInterceptor>> $interceptors
      */
     public function bindInterceptor(AbstractMatcher $classMatcher, AbstractMatcher $methodMatcher, array $interceptors): void
     {
@@ -86,6 +87,7 @@ abstract class AbstractModule
                 return;
             }
 
+            assert(interface_exists($interceptor));
             (new Bind($this->getContainer(), $interceptor))->in(Scope::SINGLETON);
         }
     }

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -169,7 +169,7 @@ final class Bind
      */
     public function in(string $scope): self
     {
-        if ($this->bound instanceof Dependency || $this->bound instanceof DependencyProvider) {
+        if ($this->bound instanceof Dependency || $this->bound instanceof DependencyProvider || $this->bound instanceof NullDependency) {
             $this->bound->setScope($scope);
         }
 

--- a/src/di/BindValidator.php
+++ b/src/di/BindValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\NullInterceptor;
 use Ray\Di\Exception\InvalidProvider;
 use Ray\Di\Exception\InvalidType;
 use Ray\Di\Exception\NotFound;
@@ -36,7 +38,7 @@ final class BindValidator
             throw new NotFound($class);
         }
 
-        if (interface_exists($interface) && ! (new ReflectionClass($class))->implementsInterface($interface)) {
+        if (! $this->isNullInterceptorBinding($class, $interface) && interface_exists($interface) && ! (new ReflectionClass($class))->implementsInterface($interface)) {
             throw new InvalidType("[{$class}] is no implemented [{$interface}] interface");
         }
 
@@ -64,5 +66,10 @@ final class BindValidator
         }
 
         return new ReflectionClass($provider);
+    }
+
+    private function isNullInterceptorBinding(string $class, string $interface): bool
+    {
+        return $class === NullInterceptor::class && interface_exists($interface) && (new ReflectionClass($interface))->implementsInterface(MethodInterceptor::class);
     }
 }

--- a/tests/compiler/Fake/FakeDoubleInterceptorInterface.php
+++ b/tests/compiler/Fake/FakeDoubleInterceptorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+interface FakeDoubleInterceptorInterface extends MethodInterceptor
+{
+}

--- a/tests/di/Fake/FakeAnnoInterceptorInterface.php
+++ b/tests/di/Fake/FakeAnnoInterceptorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+interface FakeAnnoInterceptorInterface extends MethodInterceptor
+{
+}

--- a/tests/di/Fake/FakeDoubleInterceptor.php
+++ b/tests/di/Fake/FakeDoubleInterceptor.php
@@ -7,7 +7,7 @@ namespace Ray\Di;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 
-class FakeDoubleInterceptor implements MethodInterceptor
+class FakeDoubleInterceptor implements MethodInterceptor, FakeDoubleInterceptorInterface
 {
     public function invoke(MethodInvocation $invocation)
     {

--- a/tests/di/Fake/FakeDoubleInterceptorInterface.php
+++ b/tests/di/Fake/FakeDoubleInterceptorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+interface FakeDoubleInterceptorInterface extends MethodInterceptor
+{
+}

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -248,16 +248,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.2.5",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+                "reference": "83e511e247de329283478496f7a1e114c9517506"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
-                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/83e511e247de329283478496f7a1e114c9517506",
+                "reference": "83e511e247de329283478496f7a1e114c9517506",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +309,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.5"
+                "source": "https://github.com/composer/semver/tree/3.2.6"
             },
             "funding": [
                 {
@@ -325,7 +325,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-24T12:41:47+00:00"
+            "time": "2021-10-25T11:34:17+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -943,16 +943,16 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.10.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "1fd30f4352b630ad53fec3fd5e8b8ba760f85596"
+                "reference": "30452fdabb3dfca89f4bf977abc44adc5391e062"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1fd30f4352b630ad53fec3fd5e8b8ba760f85596",
-                "reference": "1fd30f4352b630ad53fec3fd5e8b8ba760f85596",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/30452fdabb3dfca89f4bf977abc44adc5391e062",
+                "reference": "30452fdabb3dfca89f4bf977abc44adc5391e062",
                 "shasum": ""
             },
             "require": {
@@ -988,7 +988,7 @@
             "description": "Official version of pdepend to be handled with Composer",
             "support": {
                 "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.10.0"
+                "source": "https://github.com/pdepend/pdepend/tree/2.10.1"
             },
             "funding": [
                 {
@@ -996,7 +996,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-20T09:56:09+00:00"
+            "time": "2021-10-11T12:15:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1164,16 +1164,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -1184,7 +1184,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1214,9 +1215,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1487,16 +1488,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.5.6",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8"
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fac86158ffc7392e49636f77e63684c026df43b8",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
                 "shasum": ""
             },
             "require": {
@@ -1505,15 +1506,15 @@
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.87",
-                "phpstan/phpstan-strict-rules": "^0.12.5",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.5-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -1530,9 +1531,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.6"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
             },
-            "time": "2021-08-31T08:08:22+00:00"
+            "time": "2021-09-16T20:46:02+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3139,32 +3140,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.15",
+            "version": "7.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80"
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
-                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "0.5.1 - 0.5.6",
-                "squizlabs/php_codesniffer": "^3.6.0"
+                "phpstan/phpdoc-parser": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
             },
             "require-dev": {
                 "phing/phing": "2.17.0",
                 "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "0.12.98",
+                "phpstan/phpstan": "0.12.99",
                 "phpstan/phpstan-deprecation-rules": "0.12.6",
                 "phpstan/phpstan-phpunit": "0.12.22",
                 "phpstan/phpstan-strict-rules": "0.12.11",
-                "phpunit/phpunit": "7.5.20|8.5.5|9.5.9"
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.10"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3184,7 +3185,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.15"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.16"
             },
             "funding": [
                 {
@@ -3196,20 +3197,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-09T10:29:09+00:00"
+            "time": "2021-10-22T06:56:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -3252,7 +3253,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/config",
@@ -4428,16 +4429,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.10.0",
+            "version": "4.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa"
+                "reference": "6fba5eb554f9507b72932f9c75533d8af593688d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/916b098b008f6de4543892b1e0651c1c3b92cbfa",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6fba5eb554f9507b72932f9c75533d8af593688d",
+                "reference": "6fba5eb554f9507b72932f9c75533d8af593688d",
                 "shasum": ""
             },
             "require": {
@@ -4457,7 +4458,7 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.12",
+                "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
@@ -4527,9 +4528,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.10.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.11.2"
             },
-            "time": "2021-09-04T21:00:09+00:00"
+            "time": "2021-10-26T17:28:17+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
NullInterceptor can be bound to invalidate the interceptor bound by the interface.
Normally, only the class that implements the interface can be bound.

```php
$this->bind(FooInterceptorInterface::bind)->to(NullInterceptor::class);
```

In order to make the NullInterceptor bindable, it is necessary to inherit from MethodInterceptor as shown below.


```php
interface FooInterceptorInterface extends MethodInterceptor
{
    /**
     * {@inheritDoc}
     */
    public function invoke(MethodInvocation $invocation);
}
```


インターフェイスでbindされたインターセプターを無効にするためにNullInterceptorをbind可能にします。
通常はインターフェイスを実装したクラスしかバインドできません。

NullInterceptorを束縛可能にするためには、下記のようにMethodInterceptorを継承する必要があります。
