### PR TITLE
Bump ray/aop and nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
         "koriym/printo": "^1.0",
-        "nikic/php-parser": "^4.13",
+        "nikic/php-parser": "^4.13.2",
         "ray/aop": "^2.12.3",
         "ray/compiler": "^1.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "koriym/printo": "^1.0",
         "nikic/php-parser": "^4.13.2",
         "ray/aop": "^2.12.3",
-        "ray/compiler": "^1.7"
+        "ray/compiler": "^1.9.1"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,8 @@
         "koriym/param-reader": "^1.0",
         "koriym/printo": "^1.0",
         "nikic/php-parser": "^4.13",
-        "ray/aop": "^2.10",
+        "ray/aop": "^2.12.3",
         "ray/compiler": "^1.7"
-
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        bootstrap="tests/bootstrap.php"
+        convertDeprecationsToExceptions="true"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src/di</directory>


### PR DESCRIPTION
8.2 lowest の CI で deprecated のエラーが出ていたので Aop と php-parser のバージョンを更新しました
https://github.com/ray-di/Ray.Di/actions/runs/3815120920/jobs/6489907647