### PR TITLE
Create AbstractModule::rebind() method

### DIFF
--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -25,15 +25,21 @@ abstract class AbstractModule
     /** @var ?Container */
     private $container;
 
+    /** @var Rebind >*/
+    private $reBind;
+
     public function __construct(
         ?self $module = null
     ) {
+        $this->reBind = new Rebind();
         $this->lastModule = $module;
         $this->activate();
         assert($this->container instanceof Container);
         if ($module instanceof self) {
             $this->container->merge($module->getContainer());
         }
+
+        $this->reBind->commit($this->container);
     }
 
     public function __toString(): string
@@ -113,6 +119,8 @@ abstract class AbstractModule
      * @param string $newName         New binding name
      * @param string $sourceName      Original binding name
      * @param string $targetInterface Original interface
+     *
+     * @deprecated Use reBind() instead
      */
     public function rename(string $interface, string $newName, string $sourceName = Name::ANY, string $targetInterface = ''): void
     {
@@ -120,6 +128,15 @@ abstract class AbstractModule
         if ($this->lastModule instanceof self) {
             $this->lastModule->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
         }
+    }
+
+    /**
+     * Re-bind an existing binding
+     */
+    public function reBind(string $fromInterface, string $toName, string $fromName = '', string $toInterface = ''): void
+    {
+        $toInterface = $toInterface ?: $fromInterface;
+        $this->reBind->bind($fromInterface, $toName, $fromName, $toInterface);
     }
 
     /**

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -26,12 +26,12 @@ abstract class AbstractModule
     private $container;
 
     /** @var Rebind >*/
-    private $reBind;
+    private $rebind;
 
     public function __construct(
         ?self $module = null
     ) {
-        $this->reBind = new Rebind();
+        $this->rebind = new Rebind();
         $this->lastModule = $module;
         $this->activate();
         assert($this->container instanceof Container);
@@ -39,7 +39,7 @@ abstract class AbstractModule
             $this->container->merge($module->getContainer());
         }
 
-        $this->reBind->commit($this->container);
+        $this->rebind->commit($this->container);
     }
 
     public function __toString(): string
@@ -120,7 +120,7 @@ abstract class AbstractModule
      * @param string $sourceName      Original binding name
      * @param string $targetInterface Original interface
      *
-     * @deprecated Use reBind() instead
+     * @deprecated Use rebind() instead
      */
     public function rename(string $interface, string $newName, string $sourceName = Name::ANY, string $targetInterface = ''): void
     {
@@ -133,10 +133,10 @@ abstract class AbstractModule
     /**
      * Re-bind an existing binding
      */
-    public function reBind(string $fromInterface, string $toName, string $fromName = '', string $toInterface = ''): void
+    public function rebind(string $fromInterface, string $toName, string $fromName = '', string $toInterface = ''): void
     {
         $toInterface = $toInterface ?: $fromInterface;
-        $this->reBind->bind($fromInterface, $toName, $fromName, $toInterface);
+        $this->rebind->bind($fromInterface, $toName, $fromName, $toInterface);
     }
 
     /**

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -25,7 +25,7 @@ abstract class AbstractModule
     /** @var ?Container */
     private $container;
 
-    /** @var Rebind >*/
+    /** @var Rebind */
     private $rebind;
 
     public function __construct(

--- a/src/di/Rebind.php
+++ b/src/di/Rebind.php
@@ -7,19 +7,19 @@ namespace Ray\Di;
 final class Rebind
 {
     /** @var list<list<string>> */
-    private $reBind = [];
+    private $rebind = [];
 
     public function bind(string $fromInterface, string $toName, string $fromName = '', string $toInterface = ''): void
     {
-        $this->reBind[] = [$fromInterface, $toName, $fromName, $toInterface];
+        $this->rebind[] = [$fromInterface, $toName, $fromName, $toInterface];
     }
 
     public function commit(Container $container): void
     {
-        foreach ($this->reBind as [$fromInterface, $toName, $fromName, $toInterface]) {
+        foreach ($this->rebind as [$fromInterface, $toName, $fromName, $toInterface]) {
             $container->move($fromInterface, $fromName, $toInterface, $toName);
         }
 
-        $this->reBind = [];
+        $this->rebind = [];
     }
 }

--- a/src/di/Rebind.php
+++ b/src/di/Rebind.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+final class Rebind
+{
+    /** @var list<list<string>> */
+    private $reBind = [];
+
+    public function bind(string $fromInterface, string $toName, string $fromName = '', string $toInterface = ''): void
+    {
+        $this->reBind[] = [$fromInterface, $toName, $fromName, $toInterface];
+    }
+
+    public function commit(Container $container): void
+    {
+        foreach ($this->reBind as [$fromInterface, $toName, $fromName, $toInterface]) {
+            $container->move($fromInterface, $fromName, $toInterface, $toName);
+        }
+
+        $this->reBind = [];
+    }
+}

--- a/tests/di/Fake/FakeFoo.php
+++ b/tests/di/Fake/FakeFoo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeFoo implements FakeFooInterface
+{
+}

--- a/tests/di/Fake/FakeFooAlt.php
+++ b/tests/di/Fake/FakeFooAlt.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeFooAlt implements FakeFooInterface
+{
+}

--- a/tests/di/Fake/FakeFooInterface.php
+++ b/tests/di/Fake/FakeFooInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+interface FakeFooInterface
+{
+}

--- a/tests/di/RebindTest.php
+++ b/tests/di/RebindTest.php
@@ -64,4 +64,26 @@ class RebindTest extends TestCase
         $module1->install($module2);
         (new Injector($module1))->getInstance(FakeFooInterface::class, 'new');
     }
+
+    public function testRebindInTwoModule(): void
+    {
+        $module1 = new class extends AbstractModule{
+            protected function configure()
+            {
+                $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
+            }
+        };
+        $module2 = new class ($module1) extends AbstractModule{
+            protected function configure()
+            {
+                $this->rebind(FakeFooInterface::class, 'new');
+                $this->bind(FakeFooInterface::class)->to(FakeFooAlt::class);
+            }
+        };
+        $injector = new Injector($module2);
+        $foo = $injector->getInstance(FakeFooInterface::class, '');
+        $this->assertInstanceOf(FakeFooAlt::class, $foo);
+        $foo = $injector->getInstance(FakeFooInterface::class, 'new');
+        $this->assertInstanceOf(FakeFoo::class, $foo);
+    }
 }

--- a/tests/di/RebindTest.php
+++ b/tests/di/RebindTest.php
@@ -15,7 +15,7 @@ class RebindTest extends TestCase
             protected function configure()
             {
                 $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
-                $this->reBind(FakeFooInterface::class, 'new');
+                $this->rebind(FakeFooInterface::class, 'new');
             }
         };
         $foo = (new Injector($module))->getInstance(FakeFooInterface::class, 'new');
@@ -38,7 +38,7 @@ class RebindTest extends TestCase
 
             protected function configure()
             {
-                $this->reBind(FakeFooInterface::class, 'new');
+                $this->rebind(FakeFooInterface::class, 'new');
             }
         };
         $module1->install($module2);
@@ -58,7 +58,7 @@ class RebindTest extends TestCase
         $module2 = new class extends AbstractModule{
             protected function configure()
             {
-                $this->reBind(FakeFooInterface::class, 'new'); // no binding at this module
+                $this->rebind(FakeFooInterface::class, 'new'); // no binding at this module
             }
         };
         $module1->install($module2);

--- a/tests/di/RebindTest.php
+++ b/tests/di/RebindTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\Unbound;
+
+class RebindTest extends TestCase
+{
+    public function testRebind(): void
+    {
+        $module = new class extends AbstractModule{
+            protected function configure()
+            {
+                $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
+                $this->reBind(FakeFooInterface::class, 'new');
+            }
+        };
+        $foo = (new Injector($module))->getInstance(FakeFooInterface::class, 'new');
+        $this->assertInstanceOf(FakeFoo::class, $foo);
+    }
+
+    public function testRebindInOtherModule(): void
+    {
+        $module1 = new class extends AbstractModule{
+            protected function configure()
+            {
+                $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
+            }
+        };
+        $module2 = new class ($module1) extends AbstractModule{
+            public function __construct(?AbstractModule $module = null)
+            {
+                parent::__construct($module);
+            }
+
+            protected function configure()
+            {
+                $this->reBind(FakeFooInterface::class, 'new');
+            }
+        };
+        $module1->install($module2);
+        $foo = (new Injector($module1))->getInstance(FakeFooInterface::class, 'new');
+        $this->assertInstanceOf(FakeFoo::class, $foo);
+    }
+
+    public function testRebindInOtherModuleNotPossible(): void
+    {
+        $this->expectException(Unbound::class);
+        $module1 = new class extends AbstractModule{
+            protected function configure()
+            {
+                $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
+            }
+        };
+        $module2 = new class extends AbstractModule{
+            protected function configure()
+            {
+                $this->reBind(FakeFooInterface::class, 'new'); // no binding at this module
+            }
+        };
+        $module1->install($module2);
+        (new Injector($module1))->getInstance(FakeFooInterface::class, 'new');
+    }
+}


### PR DESCRIPTION
# Rebind dependency

*  Create AbstractModule::rebind()`, Replacement of undocumented method `rename()`
* rename() deprecated

```php
class Module extends AbstractModule{
    protected function configure(): v
    {
        $this->bind(FakeFooInterface::class)->to(FakeFoo::class);
        $this->rebind(FakeFooInterface::class, 'new');
    }
};
```
# What is the function for?

In 2014, I wrote an article called [Re-bundling Dependencies](https://qiita.com/koriym/items/58f629f1e8cfe3ec0a69).

Suppose you have an interface that reads annotations and attributes called `Reader $reader`. Suppose it is bound to `AnnotationReader` or `AttributeReader` or `DualReader` that can read both, depending on the project.

What if you want to bind a `Reader` to a `CachedReader` while taking advantage of that binding?

That's where re-binding comes in handy.

```php
$this->rebind(Reader::class, 'delegate');
```

In this way, the dependencies bound as `Reader` interface + unnamed are rebind as `Reader` interface + `delegate`.

Next, bind the Reader interface to `CachedReader`.

```php
$this->bind(Reader::class)->to(CachedReader);.
```

```php
final class CachedReader implements
{
    public function construct__(
        #[Named('delegate')] private readonly Reader $reader
...
    ){}

```

CachedReader injects a `Reader` reader originally bound by the identifier of the delegate; CachedReader uses the injected Cache and Reader to implement the caching functionality.


# 何のための機能なのか？

[プロキシーパターン](https://refactoring.guru/ja/design-patterns/proxy)のための機能です。

2014年に[依存の再束縛](https://qiita.com/koriym/items/58f629f1e8cfe3ec0a69)という記事にしています。

例えば`Reader $reader`というアノテーションやアトリビュートを読み込むインターフェイスがあったとします。プロジェクトに応じて`AnnotationReader`か、`AttributeReader`かあるいは双方が読み込める`DualReader`が束縛されているとします。

その束縛を活かしながら、`Reader`に`CachedReader`を束縛したいときはどうしたら良いでしょうか？

そこで再束縛が役に立ちます。

```php
$this->rebind(Reader::class, 'delegate');
```

このように`Reader`インターフェイス＋名前なし、として束縛していた依存を`Reader`インターフェイス+`delegate`として再束縛します。

次にReaderインターフェイスを`CachedReader`に束縛します。

```php
$this->bind(Reader::class)->to(CachedReader);
```

```php
final class CachedReader implements
{
    public function construct__(
        #[Named('delegate')] private readonly Reader $reader
...
    ){}
```

CachedReaderではdelegateの識別子で元々束縛されいた`Reader`リーダーがインジェクトされます。CachedReaderではインジェクトしたCacheとReaderを使ってキャッシュ機能を実装します。

## rename()との違い

`rename()`は行う時点ですでに存在する束縛しか再束縛できませんでした。つまり束縛を知るモジュールからinstall()されるモジュールでは再束縛は不可能でした。

`rebind()`はその点が改良され、installされるモジュールのコンストラクタに既存の束縛が渡されていると再束縛ができるようになりました。