### PR TITLE
Remove unused "nikic/php-parser" dependency

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3

--- a/.github/workflows/demo-php8.yml
+++ b/.github/workflows/demo-php8.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           tools: cs2pr
           coverage: none
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,6 @@
         "koriym/attributes": "^1.0.4",
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
-        "koriym/printo": "^1.0",
-        "nikic/php-parser": "^4.13.2",
         "ray/aop": "^2.14",
         "ray/compiler": "^1.10.3"
     },


### PR DESCRIPTION
The "nikic/php-parser" dependency is no longer needed in our

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated PHP version from 8.1 to 8.3 in workflow configurations.
- **Refactor**
	- Removed outdated dependencies from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->