### PR TITLE
Add MultiBindings class to configuration in DI module

### DIFF
--- a/src/di/MultiBinding/MultiBindingModule.php
+++ b/src/di/MultiBinding/MultiBindingModule.php
@@ -13,6 +13,7 @@ class MultiBindingModule extends AbstractModule
 {
     protected function configure(): void
     {
+        $this->bind(MultiBindings::class);
         $this->bind(ParamReaderInterface::class)->to(ParamReader::class)->in(Scope::SINGLETON);
         $this->bind(Map::class)->toProvider(MapProvider::class);
     }


### PR DESCRIPTION
A line has been added in the configure() method of the MultiBindingModule class to bind the MultiBindings class. This is part of the dependency injection (DI) management for the project, ensuring that MultiBindings is properly initiated when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dependency injection by adding new bindings for improved modularity and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->