### PR TITLE
Serializable provider provider

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3

--- a/.github/workflows/demo-php8.yml
+++ b/.github/workflows/demo-php8.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           tools: cs2pr
           coverage: none
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
     - tests/di/tmp/*
     - tests/Di/tmp/*
     - tests/di/Fake/*
+    - tests/di/Ray_Di_*
   ignoreErrors:
     - '#contains generic class ReflectionAttribute but does not specify its types:#'
     - '#generic class ReflectionAttribute but does not specify its types:#'

--- a/src/di/MultiBinding/LazyTo.php
+++ b/src/di/MultiBinding/LazyTo.php
@@ -27,6 +27,6 @@ final class LazyTo implements LazyInteterface
      */
     public function __invoke(InjectorInterface $injector)
     {
-        return $injector->getInstance($this->class);
+        return $injector->getInstance($this->class); // @phpstan-ignore-line
     }
 }

--- a/src/di/MultiBinding/LazyTo.php
+++ b/src/di/MultiBinding/LazyTo.php
@@ -27,6 +27,6 @@ final class LazyTo implements LazyInteterface
      */
     public function __invoke(InjectorInterface $injector)
     {
-        return $injector->getInstance($this->class); // @phpstan-ignore-line
+        return $injector->getInstance($this->class);
     }
 }

--- a/src/di/ProviderProvider.php
+++ b/src/di/ProviderProvider.php
@@ -6,16 +6,19 @@ namespace Ray\Di;
 
 use Ray\Di\Di\Set;
 
-/** @implements ProviderInterface<mixed> */
+/**
+ * @implements ProviderInterface<mixed>
+ * @template T of object
+ */
 final class ProviderProvider implements ProviderInterface
 {
     /** @var InjectorInterface  */
     private $injector;
 
-    /** @var Set<object> */
+    /** @var Set<T> */
     private $set;
 
-    /** @param Set<object> $set */
+    /** @param Set<T> $set */
     public function __construct(InjectorInterface $injector, Set $set)
     {
         $this->injector = $injector;

--- a/src/di/ProviderProvider.php
+++ b/src/di/ProviderProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Set;
+
+/** @implements ProviderInterface<mixed> */
+final class ProviderProvider implements ProviderInterface
+{
+    /** @var InjectorInterface  */
+    private $injector;
+
+    /** @var Set<object> */
+    private $set;
+
+    /** @param Set<object> $set */
+    public function __construct(InjectorInterface $injector, Set $set)
+    {
+        $this->injector = $injector;
+        $this->set = $set;
+    }
+
+    /** @return mixed */
+    public function get()
+    {
+        return $this->injector->getInstance($this->set->interface, $this->set->name);
+    }
+}

--- a/src/di/ProviderSetProvider.php
+++ b/src/di/ProviderSetProvider.php
@@ -48,30 +48,6 @@ final class ProviderSetProvider implements ProviderInterface
             throw new SetNotFound((string) $this->ip->getParameter());
         }
 
-        return new class ($this->injector, $set) implements ProviderInterface
-        {
-            /** @var InjectorInterface  */
-            private $injector;
-
-            /** @var Set<object>  */
-            private $set;
-
-            /**
-             * @param Set<object> $set
-             */
-            public function __construct(InjectorInterface $injector, Set $set)
-            {
-                $this->injector = $injector;
-                $this->set = $set;
-            }
-
-            /**
-             * @return mixed
-             */
-            public function get()
-            {
-                return $this->injector->getInstance($this->set->interface, $this->set->name);
-            }
-        };
+        return new ProviderProvider($this->injector, $set);
     }
 }

--- a/tests/di/ProviderProviderTest.php
+++ b/tests/di/ProviderProviderTest.php
@@ -19,7 +19,6 @@ class ProviderProviderTest extends TestCase
                 }
             }
         );
-        /** @var Set<object> $set */
         $set = new Set(FakeEngineInterface::class);
         $provider = new ProviderProvider($injector, $set);
         $instance = $provider->get();

--- a/tests/di/ProviderProviderTest.php
+++ b/tests/di/ProviderProviderTest.php
@@ -9,7 +9,7 @@ use Ray\Di\Di\Set;
 
 class ProviderProviderTest extends TestCase
 {
-    public function testInvoke(): void
+    public function testGet(): void
     {
         $injector = new Injector(
             new class extends AbstractModule {
@@ -19,6 +19,7 @@ class ProviderProviderTest extends TestCase
                 }
             }
         );
+        /** @var Set<object> $set */
         $set = new Set(FakeEngineInterface::class);
         $provider = new ProviderProvider($injector, $set);
         $instance = $provider->get();

--- a/tests/di/ProviderProviderTest.php
+++ b/tests/di/ProviderProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Di\Set;
+
+class ProviderProviderTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        $injector = new Injector(
+            new class extends AbstractModule {
+                protected function configure()
+                {
+                    $this->bind(FakeEngineInterface::class)->toInstance(new FakeEngine());
+                }
+            }
+        );
+        $set = new Set(FakeEngineInterface::class);
+        $provider = new ProviderProvider($injector, $set);
+        $instance = $provider->get();
+        $this->assertInstanceOf(FakeEngine::class, $instance);
+    }
+}

--- a/tests/di/VisitorTest.php
+++ b/tests/di/VisitorTest.php
@@ -30,7 +30,7 @@ class VisitorTest extends TestCase
     public function setUp(): void
     {
         $this->visitor = new NullVisitor();
-        $this->container = (new ContainerFactory())(new FakeCarModule(), __DIR__);
+        $this->container = (new ContainerFactory())(new FakeCarModule(), __DIR__ . '/tmp');
         $container = $this->container->getContainer();
         $dependency = $container['Ray\Di\FakeCarInterface-'];
         assert($dependency instanceof Dependency);


### PR DESCRIPTION
Enables serialization of providers to be injected with provider injection.

https://ray-di.github.io/manuals/1.0/en/injecting_providers.html

```php
class LogFileTransactionLog implements TransactionLogInterface
{
    public function __construct(
        (#[Set(Connection::class)] private ProviderInterface $connectionProvider
    ) {}
    
    public function logChargeResult(ChargeResult $result) {
        /* only write failed charges to the database */
        if (! $result->wasSuccessful()) {
            $connection = $connectionProvider->get();
        }
    }
}

serialize(new LogFileTransactionLog); // Couldn't do it before.
```

@coderabbitai review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the PHP version in workflows to 8.3, ensuring access to the latest features and improvements.
	- Introduced the `ProviderProvider` class to enhance dependency injection management.
	- Added unit tests for the `ProviderProvider` class to validate dependency injection functionality.
- **Bug Fixes**
	- Expanded ignored paths in PHPStan configuration to improve static analysis accuracy.
- **Refactor**
	- Replaced an anonymous class with the `ProviderProvider` class for better code organization in the `ProviderSetProvider`.
	- Modified the test environment setup to use a temporary directory for improved isolation in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->