### PR TITLE
Update CI to support PHP 8.4 and include PHP 8.3 in old_stable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,6 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      current_stable: 8.4
       script: demo/run.php

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "koriym/attributes": "^1.0.4",
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
-        "ray/aop": "^2.14",
+        "ray/aop": "^2.16",
         "ray/compiler": "^1.10.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "phpunit/phpunit": "^8.5.24 || ^9.5",
+        "phpunit/phpunit": "^8.5.40 || ^9.5",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "config": {

--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -91,7 +91,7 @@ final class Argument implements Serializable, AcceptInterface
     /**
      * {@inheritDoc}
      */
-    public function serialize(): ?string
+    public function serialize(): ?string // @phpstan-ignore-line
     {
         return serialize($this->__serialize());
     }

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -218,7 +218,7 @@ final class Bind
              * @param array-key $key
              */
             static function (array $carry, $key) use ($name): array {
-                if (! is_string($key)) {
+                if (! is_string($key)) { // @phpstan-ignore-line
                     throw new InvalidToConstructorNameParameter((string) $key);
                 }
 

--- a/src/di/Di/Inject.php
+++ b/src/di/Di/Inject.php
@@ -25,7 +25,7 @@ final class Inject implements InjectInterface
     public $optional = false;
 
     /**
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) // @phpstan-ignore-line
      */
     public function __construct(bool $optional = false)
     {

--- a/src/di/InjectionPoint.php
+++ b/src/di/InjectionPoint.php
@@ -107,7 +107,7 @@ final class InjectionPoint implements InjectionPointInterface, Serializable
         [$this->pClass, $this->pFunction, $this->pName] = $array;
     }
 
-    public function serialize(): ?string
+    public function serialize(): ?string // @phpstan-ignore-line
     {
         return serialize($this->__serialize());
     }

--- a/src/di/MultiBinding/LazyProvider.php
+++ b/src/di/MultiBinding/LazyProvider.php
@@ -31,7 +31,6 @@ final class LazyProvider implements LazyInteterface
     public function __invoke(InjectorInterface $injector)
     {
         $provider = $injector->getInstance($this->class);
-        assert($provider instanceof ProviderInterface);
 
         return $provider->get();
     }

--- a/src/di/MultiBinding/LazyProvider.php
+++ b/src/di/MultiBinding/LazyProvider.php
@@ -7,8 +7,6 @@ namespace Ray\Di\MultiBinding;
 use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
 
-use function assert;
-
 /**
  * @template T of ProviderInterface
  */

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -150,7 +150,6 @@ final class Name
             $exploded = explode('=', $keyValue);
             if (isset($exploded[1])) {
                 [$key, $value] = $exploded;
-                assert(is_string($key));
                 if (isset($key[0]) && $key[0] === '$') {
                     $key = substr($key, 1);
                 }

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -151,9 +151,11 @@ final class Name
             if (isset($exploded[1])) {
                 [$key, $value] = $exploded;
                 if (isset($key[0]) && $key[0] === '$') {
+                    assert(is_string($key)); // @phpstan-ignore-line
                     $key = substr($key, 1);
                 }
 
+                /** @psalm-suppress MixedArgument */
                 $names[trim($key)] = trim($value);
             }
         }

--- a/tests/di/ArgumentsTest.php
+++ b/tests/di/ArgumentsTest.php
@@ -8,8 +8,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionParameter;
 
-use function assert;
-use function is_object;
 use function spl_object_hash;
 
 class ArgumentsTest extends TestCase

--- a/tests/di/ArgumentsTest.php
+++ b/tests/di/ArgumentsTest.php
@@ -29,7 +29,6 @@ class ArgumentsTest extends TestCase
         $this->assertInstanceOf(FakeTyre::class, $parameters[0]);
         $this->assertInstanceOf(FakeTyre::class, $parameters[1]);
         $param0 = $parameters[0];
-        assert(is_object($param0));
         $this->assertNotSame(spl_object_hash($param0), $parameters[1]);
     }
 

--- a/tests/di/DependencyTest.php
+++ b/tests/di/DependencyTest.php
@@ -115,7 +115,7 @@ class DependencyTest extends TestCase
         $isWeave = (new ReflectionClass($instance))->implementsInterface(WeavedInterface::class);
         $this->assertTrue($isWeave);
         assert(property_exists($instance, 'bindings'));
-        $this->assertArrayHasKey('returnSame', $instance->bindings);
+        $this->assertArrayHasKey('returnSame', (array) $instance->bindings);
     }
 
     /**

--- a/tests/di/Fake/FakePhp8Car.php
+++ b/tests/di/Fake/FakePhp8Car.php
@@ -63,7 +63,7 @@ class FakePhp8Car implements FakeCarInterface
     }
 
     #[Inject]
-    public function notQualifer(#[FakeNotQualifer] FakeMirrorInterface $rightMirror =  null): void
+    public function notQualifer(#[FakeNotQualifer] ?FakeMirrorInterface $rightMirror =  null): void
     {
     }
 

--- a/tests/di/GrapherTest.php
+++ b/tests/di/GrapherTest.php
@@ -9,10 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 use function assert;
 use function file_get_contents;
-use function is_object;
 use function is_string;
 use function passthru;
-use function property_exists;
 use function unserialize;
 
 class GrapherTest extends TestCase
@@ -28,7 +26,6 @@ class GrapherTest extends TestCase
         $grapher = new Grapher(new FakeUntargetModule(), __DIR__ . '/tmp');
         $instance = $grapher->newInstanceArgs(FakeUntargetChild::class, ['1']);
         $this->assertInstanceOf(FakeUntargetChild::class, $instance);
-        assert(property_exists($instance, 'val'));
         $this->assertSame('1', $instance->val);
     }
 

--- a/tests/di/GrapherTest.php
+++ b/tests/di/GrapherTest.php
@@ -28,7 +28,6 @@ class GrapherTest extends TestCase
         $grapher = new Grapher(new FakeUntargetModule(), __DIR__ . '/tmp');
         $instance = $grapher->newInstanceArgs(FakeUntargetChild::class, ['1']);
         $this->assertInstanceOf(FakeUntargetChild::class, $instance);
-        assert(is_object($instance));
         assert(property_exists($instance, 'val'));
         $this->assertSame('1', $instance->val);
     }

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -16,7 +16,6 @@ use function defined;
 use function file_get_contents;
 use function is_string;
 use function passthru;
-use function property_exists;
 use function serialize;
 use function spl_object_hash;
 use function unlink;
@@ -184,7 +183,6 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeMirrorInterface::class, $car->spareMirror);
         $this->assertSame(spl_object_hash($car->rightMirror), spl_object_hash($car->spareMirror));
         $this->assertInstanceOf(FakeHandle::class, $car->handle);
-        assert($car->handle instanceof FakeHandle);
         $this->assertSame($car->handle->logo, 'momo');
 
         return $injector;
@@ -242,7 +240,6 @@ class InjectorTest extends TestCase
         $injector = unserialize(serialize(new Injector()));
         assert($injector instanceof InjectorInterface);
         $instance = $injector->getInstance(FakeBuiltin::class);
-        assert(property_exists($instance, 'injector'));
         $this->assertInstanceOf(Injector::class, $instance->injector);
     }
 
@@ -430,9 +427,7 @@ class InjectorTest extends TestCase
         $instance = $injector->getInstance(FakeAop::class);
         $result = $instance->returnSame(2);
         $this->assertSame(2, $result);
-        assert(property_exists($instance, 'bindings'));
-        assert(isset($instance->bindings['returnSame'][0]));
-        $this->assertInstanceOf(NullInterceptor::class, $instance->bindings['returnSame'][0]);
+        $this->assertInstanceOf(NullInterceptor::class, $instance->bindings['returnSame'][0]); // @phpstan-ignore-line
     }
 
     public function testModuleArray(): void

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -3,10 +3,10 @@
         "doctrine/coding-standard": "^9.0",
         "phpmd/phpmd": "^2.9",
         "phpmetrics/phpmetrics": "^2.7",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^2.0",
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^4.2",
-        "phpstan/phpstan-phpunit": "^1.1",
+        "phpstan/phpstan-phpunit": "^2.0",
         "psalm/plugin-phpunit": "^0.17.0"
     },
     "config": {

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e88026ed8a880171d6cf5a75c3d27f3c",
+    "content-hash": "c253260b0da10b0df776aa26107bee4e",
     "packages": [],
     "packages-dev": [
         {
@@ -1379,20 +1379,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.11",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733"
+                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
-                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46b4d3529b12178112d9008337beda0cc2a1a6b4",
+                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -1433,34 +1433,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-17T14:08:01+00:00"
+            "time": "2024-11-28T22:19:37+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.4.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "11d4235fbc6313ecbf93708606edfd3222e44949"
+                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/11d4235fbc6313ecbf93708606edfd3222e44949",
-                "reference": "11d4235fbc6313ecbf93708606edfd3222e44949",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
+                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.12"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-strict-rules": "^1.5.1",
-                "phpunit/phpunit": "^9.5"
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -1483,9 +1482,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.1"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.1"
             },
-            "time": "2024-11-12T12:43:59+00:00"
+            "time": "2024-11-12T12:48:00+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -1859,16 +1858,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.1.7",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "dc373a5cbd345354696f5dfd39c5c7a8ea23f4c8"
+                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/dc373a5cbd345354696f5dfd39c5c7a8ea23f4c8",
-                "reference": "dc373a5cbd345354696f5dfd39c5c7a8ea23f4c8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/bcd3c4adf0144dee5011bb35454728c38adec055",
+                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055",
                 "shasum": ""
             },
             "require": {
@@ -1914,7 +1913,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.1.7"
+                "source": "https://github.com/symfony/config/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -1930,7 +1929,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T11:34:07+00:00"
+            "time": "2024-11-04T11:36:24+00:00"
         },
         {
             "name": "symfony/console",
@@ -2028,16 +2027,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.1.9",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "900d2eac6e33aef743bdc10dd8c75d012215fd08"
+                "reference": "a475747af1a1c98272a5471abc35f3da81197c5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/900d2eac6e33aef743bdc10dd8c75d012215fd08",
-                "reference": "900d2eac6e33aef743bdc10dd8c75d012215fd08",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a475747af1a1c98272a5471abc35f3da81197c5d",
+                "reference": "a475747af1a1c98272a5471abc35f3da81197c5d",
                 "shasum": ""
             },
             "require": {
@@ -2088,7 +2087,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.1.9"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -2104,7 +2103,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T15:44:54+00:00"
+            "time": "2024-11-25T15:45:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2175,16 +2174,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.6",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4"
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c835867b3c62bb05c7fe3d637c871c7ae52024d4",
-                "reference": "c835867b3c62bb05c7fe3d637c871c7ae52024d4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
                 "shasum": ""
             },
             "require": {
@@ -2221,7 +2220,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -2237,7 +2236,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:11:02+00:00"
+            "time": "2024-10-25T15:15:23+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2722,16 +2721,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.8",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "591ebd41565f356fcd8b090fe64dbb5878f50281"
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/591ebd41565f356fcd8b090fe64dbb5878f50281",
-                "reference": "591ebd41565f356fcd8b090fe64dbb5878f50281",
+                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
                 "shasum": ""
             },
             "require": {
@@ -2789,7 +2788,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.8"
+                "source": "https://github.com/symfony/string/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -2805,20 +2804,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:21+00:00"
+            "time": "2024-11-13T13:31:26+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.1.6",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "90173ef89c40e7c8c616653241048705f84130ef"
+                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/90173ef89c40e7c8c616653241048705f84130ef",
-                "reference": "90173ef89c40e7c8c616653241048705f84130ef",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1a6a89f95a46af0f142874c9d650a6358d13070d",
+                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d",
                 "shasum": ""
             },
             "require": {
@@ -2865,7 +2864,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.1.6"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -2881,7 +2880,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-10-18T07:58:17+00:00"
         },
         {
             "name": "vimeo/psalm",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated continuous integration workflow to support PHP version 8.3 and shifted current stable version to 8.4.
	- Updated PHPStan and PHPUnit dependencies to more recent versions.
	- Updated `ray/aop` dependency version in `composer.json`.
- **Tests**
	- Enhanced test assertions for clarity and consistency in `ArgumentsTest`, `GrapherTest`, and `InjectorTest`.
	- Updated assertions in `DependencyTest` to ensure correct type checking of bindings.
- **New Features**
	- Modified method parameters in `FakePhp8Car` to allow for optional values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->