### PR TITLE
Refine interceptor binding logic and update ray/aop dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "koriym/attributes": "^1.0.4",
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
-        "ray/aop": "^2.16",
+        "ray/aop": "dev-bc as 2.17.3",
         "ray/compiler": "^1.10.3"
     },
     "require-dev": {

--- a/src/di/NewInstance.php
+++ b/src/di/NewInstance.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use Ray\Aop\Bind as AopBind;
+use Ray\Aop\WeavedInterface;
 use ReflectionClass;
 use ReflectionException;
 
@@ -95,9 +96,8 @@ final class NewInstance
     private function postNewInstance(Container $container, object $instance): object
     {
         // bind dependency injected interceptors
-        if ($this->bind instanceof AspectBind) {
-            assert(isset($instance->bindings));
-            $instance->bindings = $this->bind->inject($container);
+        if ($this->bind instanceof AspectBind && $instance instanceof WeavedInterface) {
+            $instance->_setBindings($this->bind->inject($container));
         }
 
         // setter injection


### PR DESCRIPTION
**Description:**
- Refactor binding logic to only affect instances implementing WeavedInterface.
- Update ray/aop dependency to "dev-bc as 2.17.3" for compatibility and alignment with project requirements.

## Summary by Sourcery

Refine the interceptor binding logic and update the ray/aop dependency. Apply interceptor bindings only to instances that implement the `WeavedInterface`. Update the ray/aop dependency to `dev-bc as 2.17.3`.

Enhancements:
- Refine interceptor binding logic to only apply to instances implementing `WeavedInterface`.

Build:
- Update ray/aop dependency to "dev-bc as 2.17.3".