### PR TITLE
Use Ray.Aop's new binding injector _setBindings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "koriym/attributes": "^1.0.4",
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
-        "ray/aop": "^2.16",
+        "ray/aop": "^2.x-dev",
         "ray/compiler": "^1.10.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "sa": ["psalm -m -c psalm.xml --show-info=true", "phpstan analyse -c phpstan.neon --no-progress "],
         "metrics": ["@test", "phpmetrics --report-html=build/metrics --exclude=Exception --log-junit=build/junit.xml --junit=build/junit.xml src"],
         "phpmd": ["phpmd src/di text ./phpmd.xml"],
-        "build": ["@cs", "@sa", "@pcov", "@metrics"]
+        "build": ["@cs", "@sa", "@pcov", "@metrics"],
+        "baseline": ["phpstan analyse -c phpstan.neon --generate-baseline", "psalm --set-baseline=psalm-baseline.xml"]
     },
     "extra": {
         "bamarni-bin": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "cs": ["phpcs --standard=./phpcs.xml src tests"],
         "cs-fix": ["phpcbf src tests"],
         "clean": ["phpstan clear-result-cache", "psalm --clear-cache", "rm -rf tests/tmp/*.php"],
-        "sa": ["psalm -m -c psalm.xml --show-info=true", "phpstan analyse -c phpstan.neon --no-progress "],
+        "sa": ["psalm -m -c psalm.xml --show-info=false", "phpstan analyse -c phpstan.neon --no-progress "],
         "metrics": ["@test", "phpmetrics --report-html=build/metrics --exclude=Exception --log-junit=build/junit.xml --junit=build/junit.xml src"],
         "phpmd": ["phpmd src/di text ./phpmd.xml"],
         "build": ["@cs", "@sa", "@pcov", "@metrics"],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method ReflectionMethod\:\:getAnnotation\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: src/di/AnnotatedClassMethods.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method ReflectionMethod\:\:getAnnotation\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/di/AnnotatedClassMethods.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+  <file src="src/di/AnnotatedClassMethods.php">
+    <MixedAssignment occurrences="1">
+      <code>$named</code>
+    </MixedAssignment>
+    <UndefinedMethod occurrences="1">
+      <code>getAnnotation</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/di/AspectBind.php">
+    <MixedArrayOffset occurrences="1">
+      <code>$instantiatedBindings[$methodName]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="3">
+      <code>$interceptorClassName</code>
+      <code>$interceptorClassNames</code>
+      <code>$methodName</code>
+    </MixedAssignment>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$instantiatedBindings</code>
+      <code>array&lt;string, list&lt;MethodInterceptor&gt;&gt;</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/di/Dependency.php">
+    <InvalidArgument occurrences="1">
+      <code>$pointcuts</code>
+    </InvalidArgument>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/di/AnnotatedClassMethods.php">
-    <MixedAssignment occurrences="1">
-      <code>$named</code>
-    </MixedAssignment>
-    <UndefinedMethod occurrences="1">
-      <code>getAnnotation</code>
-    </UndefinedMethod>
+    <DocblockTypeContradiction occurrences="2">
+      <code>! $constructor</code>
+      <code>$constructor</code>
+    </DocblockTypeContradiction>
   </file>
   <file src="src/di/AspectBind.php">
     <MixedArrayOffset occurrences="1">
@@ -19,12 +17,17 @@
     </MixedAssignment>
     <MixedReturnTypeCoercion occurrences="2">
       <code>$instantiatedBindings</code>
-      <code>array&lt;string, list&lt;MethodInterceptor&gt;&gt;</code>
+      <code>array&lt;non-empty-string, list&lt;MethodInterceptor&gt;&gt;</code>
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/di/Dependency.php">
     <InvalidArgument occurrences="1">
       <code>$pointcuts</code>
+    </InvalidArgument>
+  </file>
+  <file src="src/di/NewInstance.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;bind-&gt;inject($container)</code>
     </InvalidArgument>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config https://psalm.dev/schema/config"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src/di"/>

--- a/src/di/AnnotatedClassMethods.php
+++ b/src/di/AnnotatedClassMethods.php
@@ -9,6 +9,7 @@ use Ray\Aop\ReflectionMethod;
 use Ray\Di\Di\InjectInterface;
 use Ray\Di\Di\Named;
 
+use function assert;
 use const PHP_VERSION_ID;
 
 final class AnnotatedClassMethods
@@ -38,6 +39,7 @@ final class AnnotatedClassMethods
             }
         }
 
+        assert($constructor instanceof ReflectionMethod);
         $named = $constructor->getAnnotation(Named::class);
         if ($named instanceof Named) {
             return new Name($named->value);

--- a/src/di/AnnotatedClassMethods.php
+++ b/src/di/AnnotatedClassMethods.php
@@ -10,6 +10,7 @@ use Ray\Di\Di\InjectInterface;
 use Ray\Di\Di\Named;
 
 use function assert;
+
 use const PHP_VERSION_ID;
 
 final class AnnotatedClassMethods

--- a/src/di/AspectBind.php
+++ b/src/di/AspectBind.php
@@ -22,7 +22,7 @@ final class AspectBind implements AcceptInterface
     /**
      * Instantiate interceptors
      *
-     * @return array<string, list<MethodInterceptor>>
+     * @return array<non-empty-string, list<MethodInterceptor>>
      */
     public function inject(Container $container): array
     {

--- a/src/di/BindValidator.php
+++ b/src/di/BindValidator.php
@@ -42,7 +42,7 @@ final class BindValidator
             throw new InvalidType("[{$class}] is no implemented [{$interface}] interface");
         }
 
-        return new ReflectionClass($class); // @phpstan-ignore-line
+        return new ReflectionClass($class);
     }
 
     /**

--- a/src/di/NewInstance.php
+++ b/src/di/NewInstance.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use Ray\Aop\Bind as AopBind;
+use Ray\Aop\WeavedInterface;
 use ReflectionClass;
 use ReflectionException;
 
@@ -94,15 +95,22 @@ final class NewInstance
 
     private function postNewInstance(Container $container, object $instance): object
     {
-        // bind dependency injected interceptors
-        if ($this->bind instanceof AspectBind) {
-            assert(isset($instance->bindings));
-            $instance->bindings = $this->bind->inject($container);
-        }
+        $this->enableAop($instance, $container);
 
         // setter injection
         ($this->setterMethods)($instance, $container);
 
         return $instance;
+    }
+
+    public function enableAop(object $instance, Container $container): void
+    {
+        if (! $this->bind instanceof AspectBind) {
+            return;
+        }
+
+        assert($instance instanceof WeavedInterface);
+
+        $instance->_setBindings($this->bind->inject($container));  // Ray.Aop ^2.18
     }
 }

--- a/tests/di/AnnotatedClassTest.php
+++ b/tests/di/AnnotatedClassTest.php
@@ -21,7 +21,7 @@ class AnnotatedClassTest extends TestCase
 
     public function testInvoke(): void
     {
-        $newInstance = $this->annotatedClass->getNewInstance(new ReflectionClass(FakeCar::class));
+        $newInstance = $this->annotatedClass->getNewInstance(new ReflectionClass(FakeCar::class)); // @phpstan-ignore-line
         $this->assertInstanceOf(NewInstance::class, $newInstance);
         $container = new Container();
         (new Bind($container, FakeTyreInterface::class))->to(FakeTyre::class);

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -7,6 +7,8 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\NotFound;
 
+use function str_replace;
+
 class ModuleTest extends TestCase
 {
     public function testNew(): void
@@ -50,7 +52,10 @@ class ModuleTest extends TestCase
     public function testtoString(): void
     {
         $string = (string) new FakeLogStringModule();
-        $this->assertSame('-array => (array)
+        $normalize = static function (string $str): string {
+            return str_replace(["\r\n", "\r"], "\n", $str);
+        };
+        $this->assertSame($normalize('-array => (array)
 -bool => (boolean) 1
 -int => (integer) 1
 -null => (NULL)
@@ -58,6 +63,6 @@ class ModuleTest extends TestCase
 -string => (string) 1
 Ray\Di\FakeAopInterface- => (dependency) Ray\Di\FakeAop (aop) +returnSame(Ray\Di\FakeDoubleInterceptor)
 Ray\Di\FakeDoubleInterceptor- => (dependency) Ray\Di\FakeDoubleInterceptor
-Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider', $string);
+Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider'), $normalize($string));
     }
 }

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -267,13 +267,13 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -635,29 +635,27 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
+                "doctrine/coding-standard": "^9 || ^12",
+                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -665,7 +663,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -676,9 +674,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2024-12-07T21:18:45+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1059,16 +1057,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c"
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/f3558a4c23426d12bffeaab463f8a8d8b681193c",
-                "reference": "f3558a4c23426d12bffeaab463f8a8d8b681193c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
                 "shasum": ""
             },
             "require": {
@@ -1117,9 +1115,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
             },
-            "time": "2024-11-12T11:25:25+00:00"
+            "time": "2024-12-07T09:39:29+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1379,16 +1377,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.0.3",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4"
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/46b4d3529b12178112d9008337beda0cc2a1a6b4",
-                "reference": "46b4d3529b12178112d9008337beda0cc2a1a6b4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
                 "shasum": ""
             },
             "require": {
@@ -1433,25 +1431,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-28T22:19:37+00:00"
+            "time": "2025-02-19T15:46:42+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475"
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
-                "reference": "4b6ad7fab8683ff4efd7887ba26ef8ee171c7475",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d09e152f403c843998d7a52b5d87040c937525dd",
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.0.4"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -1482,9 +1480,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.1"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.4"
             },
-            "time": "2024-11-12T12:48:00+00:00"
+            "time": "2025-01-22T13:07:38+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -1778,16 +1776,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
                 "shasum": ""
             },
             "require": {
@@ -1852,22 +1850,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-11-16T12:02:36+00:00"
+            "time": "2025-01-23T17:04:15+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.2.0",
+            "version": "v7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055"
+                "reference": "7716594aaae91d9141be080240172a92ecca4d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/bcd3c4adf0144dee5011bb35454728c38adec055",
-                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7716594aaae91d9141be080240172a92ecca4d44",
+                "reference": "7716594aaae91d9141be080240172a92ecca4d44",
                 "shasum": ""
             },
             "require": {
@@ -1913,7 +1915,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.2.0"
+                "source": "https://github.com/symfony/config/tree/v7.2.3"
             },
             "funding": [
                 {
@@ -1929,20 +1931,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T11:36:24+00:00"
+            "time": "2025-01-22T12:07:01+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.15",
+            "version": "v6.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd"
+                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
-                "reference": "f1fc6f47283e27336e7cebb9e8946c8de7bff9bd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/799445db3f15768ecc382ac5699e6da0520a0a04",
+                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04",
                 "shasum": ""
             },
             "require": {
@@ -2007,7 +2009,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.15"
+                "source": "https://github.com/symfony/console/tree/v6.4.17"
             },
             "funding": [
                 {
@@ -2023,20 +2025,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:19:14+00:00"
+            "time": "2024-12-07T12:07:30+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.2.0",
+            "version": "v7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a475747af1a1c98272a5471abc35f3da81197c5d"
+                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a475747af1a1c98272a5471abc35f3da81197c5d",
-                "reference": "a475747af1a1c98272a5471abc35f3da81197c5d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
+                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
                 "shasum": ""
             },
             "require": {
@@ -2087,7 +2089,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.0"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.3"
             },
             "funding": [
                 {
@@ -2103,7 +2105,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T15:45:00+00:00"
+            "time": "2025-01-17T10:56:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2124,12 +2126,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2264,8 +2266,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2340,8 +2342,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2418,8 +2420,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2502,8 +2504,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2576,8 +2578,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2660,12 +2662,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2954,10 +2956,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
- Change from the method of setting directly to the $bindings property to the method of using the new method
- Adjustments to pass the CI

## Summary by Sourcery

This pull request updates the dependency injection mechanism to use Ray.Aop's new binding injector, enhancing the framework's capabilities and preparing it for future development. It also includes updates to the build and CI configurations, as well as improvements to the test suite.

Enhancements:
- Replaced direct property setting with the `_setBindings` method in `Ray\Di\NewInstance` to inject dependencies, leveraging the new binding injector in Ray.Aop.
- Improved code quality by adding assertions to ensure type safety and prevent potential errors.

Build:
- Updated the `ray/aop` dependency to the `^2.x-dev` version to utilize the latest features and improvements.

CI:
- Added a baseline for Psalm to track and manage static analysis errors over time.

Tests:
- Improved test robustness by normalizing line endings in string comparisons to avoid failures due to different operating system conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined mechanism for enabling aspect-oriented programming enhancements, providing a clearer and more maintainable integration approach.
- **Chores**
	- Updated dependency configurations and analysis scripts to improve overall quality and error tracking.
	- Added baseline support for enhanced static analysis and error management.
- **Tests**
	- Improved test stability by standardizing output comparisons and refining analysis annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->