### PR TITLE
Add early return in Container::weaveAspects when no pointcuts defined

### DIFF
--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -193,6 +193,10 @@ final class Container implements InjectorInterface
      */
     public function weaveAspects(CompilerInterface $compiler): void
     {
+        if (empty($this->pointcuts)) {
+            return;
+        }
+
         foreach ($this->container as $dependency) {
             if ($dependency instanceof Dependency) {
                 $dependency->weaveAspects($compiler, $this->pointcuts);

--- a/tests/di/ContainerTest.php
+++ b/tests/di/ContainerTest.php
@@ -6,12 +6,15 @@ namespace Ray\Di;
 
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\Compiler;
 use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
 use Ray\Di\Exception\Unbound;
 use Throwable;
 
+use function assert;
 use function get_class;
+use function sys_get_temp_dir;
 
 class ContainerTest extends TestCase
 {
@@ -172,5 +175,19 @@ class ContainerTest extends TestCase
     {
         $this->expectException(Unbound::class);
         (new Container())->getInstanceWithArgs(FakeEngineInterface::class, []);
+    }
+
+    public function testWeaveAspectsWithEmptyPointcuts(): void
+    {
+        $container = new Container();
+        (new Bind($container, FakeEngine::class));
+
+        // Should work fine even when no pointcuts are defined
+        $tmpDir = sys_get_temp_dir();
+        assert($tmpDir !== '');
+        $container->weaveAspects(new Compiler($tmpDir));
+
+        $instance = $container->getInstance(FakeEngine::class);
+        $this->assertInstanceOf(FakeEngine::class, $instance);
     }
 }


### PR DESCRIPTION
## Summary

Add defensive early return in `Container::weaveAspects()` to skip unnecessary iteration when no AOP pointcuts are configured.

## Changes

**File**: `src/di/Container.php`

```php
public function weaveAspects(CompilerInterface $compiler): void
{
+   if (empty($this->pointcuts)) {
+       return;
+   }

    foreach ($this->container as $dependency) {
        if ($dependency instanceof Dependency) {
            $dependency->weaveAspects($compiler, $this->pointcuts);
        }
    }
}
```

## Rationale

1. **Defensive coding** - Makes the intent explicit: no pointcuts = no work needed
2. **Logical correctness** - Avoid iterating when the result would be no-op anyway
3. **Code clarity** - Readers immediately understand "AOP disabled" path

## Testing

- ✅ All 168 tests passing (248 assertions)
- ✅ Added simple test for empty pointcuts scenario
- ✅ No mocks, just verifies container works correctly

## Impact

Minimal, focused change with clear intent. No performance claims, just cleaner defensive code.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary processing in the dependency container when no aspect pointcuts are present, improving efficiency in affected scenarios.
* **Tests**
  * Added a test to cover the empty-pointcut edge case in the dependency injection behavior, ensuring correct handling and retrieval of bound engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->