### PR TITLE
Restore backward compatibility for toConstructor string format

### DIFF
--- a/src-deprecated/di/LegacyStringParser.php
+++ b/src-deprecated/di/LegacyStringParser.php
@@ -32,16 +32,16 @@ final class LegacyStringParser
         $names = [];
         $keyValues = explode(',', $name);
         foreach ($keyValues as $keyValue) {
-            $exploded = explode('=', $keyValue);
+            $exploded = explode('=', $keyValue, 2);
             if (isset($exploded[1])) {
                 [$key, $value] = $exploded;
                 if (isset($key[0]) && $key[0] === '$') {
                     $key = substr($key, 1);
                 }
 
-                $trimedKey = trim($key);
+                $trimmedKey = trim($key);
 
-                $names[$trimedKey] = trim($value);
+                $names[$trimmedKey] = trim($value);
             }
         }
 

--- a/src-deprecated/di/LegacyStringParser.php
+++ b/src-deprecated/di/LegacyStringParser.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use function explode;
+use function substr;
+use function trigger_error;
+use function trim;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Legacy string format parser for toConstructor() method
+ *
+ * Parses "key=value,key=value" string format for backward compatibility.
+ * This format is deprecated. Use parameter-level attributes or array format instead.
+ *
+ * @deprecated Use parameter-level attributes (#[Named('name')]) or array format (['param' => 'name'])
+ *
+ * @internal
+ */
+final class LegacyStringParser
+{
+    /**
+     * Parse "key=value,key=value" format
+     *
+     * @return array<string, string>
+     *
+     * @psalm-pure
+     */
+    public static function parse(string $name): array
+    {
+        trigger_error(
+            'String format in toConstructor() is deprecated. Use parameter-level attributes (#[Named(\'name\')]) or array format ([\'param\' => \'name\']) instead.',
+            E_USER_DEPRECATED,
+        );
+
+        $names = [];
+        $keyValues = explode(',', $name);
+        foreach ($keyValues as $keyValue) {
+            $exploded = explode('=', $keyValue);
+            if (isset($exploded[1])) {
+                [$key, $value] = $exploded;
+                if (isset($key[0]) && $key[0] === '$') {
+                    $key = substr($key, 1);
+                }
+
+                $trimedKey = trim($key);
+
+                $names[$trimedKey] = trim($value);
+            }
+        }
+
+        return $names;
+    }
+}

--- a/src-deprecated/di/LegacyStringParser.php
+++ b/src-deprecated/di/LegacyStringParser.php
@@ -40,6 +40,9 @@ final class LegacyStringParser
                 }
 
                 $trimmedKey = trim($key);
+                if ($trimmedKey === '') {
+                    continue;
+                }
 
                 $names[$trimmedKey] = trim($value);
             }

--- a/src-deprecated/di/LegacyStringParser.php
+++ b/src-deprecated/di/LegacyStringParser.php
@@ -6,10 +6,7 @@ namespace Ray\Di;
 
 use function explode;
 use function substr;
-use function trigger_error;
 use function trim;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Legacy string format parser for toConstructor() method
@@ -32,11 +29,6 @@ final class LegacyStringParser
      */
     public static function parse(string $name): array
     {
-        trigger_error(
-            'String format in toConstructor() is deprecated. Use parameter-level attributes (#[Named(\'name\')]) or array format ([\'param\' => \'name\']) instead.',
-            E_USER_DEPRECATED,
-        );
-
         $names = [];
         $keyValues = explode(',', $name);
         foreach ($keyValues as $keyValue) {

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -13,7 +13,11 @@ use ReflectionMethod;
 use ReflectionParameter;
 
 use function class_exists;
+use function explode;
 use function is_string;
+use function preg_match;
+use function substr;
+use function trim;
 
 /**
  * @psalm-import-type ParameterNameMapping from Types
@@ -123,6 +127,42 @@ final class Name
 
         // single name
         // @Named(name)
-        $this->name = $name;
+        if ($name === self::ANY || preg_match('/^\w+$/', $name)) {
+            $this->name = $name;
+
+            return;
+        }
+
+        // name list (backward compatibility)
+        // @Named(varName1=name1, varName2=name2) or toConstructor string format
+        $this->names = $this->parseName($name);
+    }
+
+    /**
+     * Parse "key=value,key=value" format (backward compatibility)
+     *
+     * @return ParameterNameMapping
+     *
+     * @psalm-pure
+     */
+    private function parseName(string $name): array
+    {
+        $names = [];
+        $keyValues = explode(',', $name);
+        foreach ($keyValues as $keyValue) {
+            $exploded = explode('=', $keyValue);
+            if (isset($exploded[1])) {
+                [$key, $value] = $exploded;
+                if (isset($key[0]) && $key[0] === '$') {
+                    $key = substr($key, 1);
+                }
+
+                $trimedKey = trim($key);
+
+                $names[$trimedKey] = trim($value);
+            }
+        }
+
+        return $names;
     }
 }

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -132,6 +132,7 @@ final class Name
 
         // name list (backward compatibility)
         // @Named(varName1=name1, varName2=name2) or toConstructor string format
+        /** @psalm-suppress DeprecatedClass */
         $this->names = LegacyStringParser::parse($name);
     }
 }

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -13,11 +13,8 @@ use ReflectionMethod;
 use ReflectionParameter;
 
 use function class_exists;
-use function explode;
 use function is_string;
 use function preg_match;
-use function substr;
-use function trim;
 
 /**
  * @psalm-import-type ParameterNameMapping from Types
@@ -135,34 +132,6 @@ final class Name
 
         // name list (backward compatibility)
         // @Named(varName1=name1, varName2=name2) or toConstructor string format
-        $this->names = $this->parseName($name);
-    }
-
-    /**
-     * Parse "key=value,key=value" format (backward compatibility)
-     *
-     * @return ParameterNameMapping
-     *
-     * @psalm-pure
-     */
-    private function parseName(string $name): array
-    {
-        $names = [];
-        $keyValues = explode(',', $name);
-        foreach ($keyValues as $keyValue) {
-            $exploded = explode('=', $keyValue);
-            if (isset($exploded[1])) {
-                [$key, $value] = $exploded;
-                if (isset($key[0]) && $key[0] === '$') {
-                    $key = substr($key, 1);
-                }
-
-                $trimedKey = trim($key);
-
-                $names[$trimedKey] = trim($value);
-            }
-        }
-
-        return $names;
+        $this->names = LegacyStringParser::parse($name);
     }
 }

--- a/tests/di/LegacyStringParserTest.php
+++ b/tests/di/LegacyStringParserTest.php
@@ -6,55 +6,26 @@ namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
 
-use function error_reporting;
-use function restore_error_handler;
-use function set_error_handler;
-
-use const E_USER_DEPRECATED;
-
 class LegacyStringParserTest extends TestCase
 {
     public function testParseStringFormat(): void
     {
-        $result = @LegacyStringParser::parse('engine=engine_name,var=var_name');
+        $result = LegacyStringParser::parse('engine=engine_name,var=var_name');
         $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
         $this->assertSame($expected, $result);
     }
 
     public function testParseStringFormatWithSpaces(): void
     {
-        $result = @LegacyStringParser::parse('engine=engine_name, var=var_name');
+        $result = LegacyStringParser::parse('engine=engine_name, var=var_name');
         $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
         $this->assertSame($expected, $result);
     }
 
     public function testParseStringFormatWithDollarPrefix(): void
     {
-        $result = @LegacyStringParser::parse('$engine=engine_name,$var=var_name');
+        $result = LegacyStringParser::parse('$engine=engine_name,$var=var_name');
         $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
         $this->assertSame($expected, $result);
-    }
-
-    public function testDeprecationWarning(): void
-    {
-        $errorTriggered = false;
-        $errorMessage = '';
-
-        set_error_handler(static function (int $errno, string $errstr) use (&$errorTriggered, &$errorMessage): bool {
-            if ($errno === E_USER_DEPRECATED) {
-                $errorTriggered = true;
-                $errorMessage = $errstr;
-            }
-
-            return true;
-        });
-
-        LegacyStringParser::parse('engine=engine_name');
-
-        restore_error_handler();
-
-        $this->assertTrue($errorTriggered, 'Deprecation warning was not triggered');
-        $this->assertStringContainsString('deprecated', $errorMessage);
-        $this->assertStringContainsString('parameter-level attributes', $errorMessage);
     }
 }

--- a/tests/di/LegacyStringParserTest.php
+++ b/tests/di/LegacyStringParserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+
+use function error_reporting;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+class LegacyStringParserTest extends TestCase
+{
+    public function testParseStringFormat(): void
+    {
+        $result = @LegacyStringParser::parse('engine=engine_name,var=var_name');
+        $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
+        $this->assertSame($expected, $result);
+    }
+
+    public function testParseStringFormatWithSpaces(): void
+    {
+        $result = @LegacyStringParser::parse('engine=engine_name, var=var_name');
+        $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
+        $this->assertSame($expected, $result);
+    }
+
+    public function testParseStringFormatWithDollarPrefix(): void
+    {
+        $result = @LegacyStringParser::parse('$engine=engine_name,$var=var_name');
+        $expected = ['engine' => 'engine_name', 'var' => 'var_name'];
+        $this->assertSame($expected, $result);
+    }
+
+    public function testDeprecationWarning(): void
+    {
+        $errorTriggered = false;
+        $errorMessage = '';
+
+        set_error_handler(static function (int $errno, string $errstr) use (&$errorTriggered, &$errorMessage): bool {
+            if ($errno === E_USER_DEPRECATED) {
+                $errorTriggered = true;
+                $errorMessage = $errstr;
+            }
+
+            return true;
+        });
+
+        LegacyStringParser::parse('engine=engine_name');
+
+        restore_error_handler();
+
+        $this->assertTrue($errorTriggered, 'Deprecation warning was not triggered');
+        $this->assertStringContainsString('deprecated', $errorMessage);
+        $this->assertStringContainsString('parameter-level attributes', $errorMessage);
+    }
+}

--- a/tests/di/NameTest.php
+++ b/tests/di/NameTest.php
@@ -33,4 +33,37 @@ class NameTest extends TestCase
         $expected = FakeMirrorRight::class;
         $this->assertSame($expected, $boundName);
     }
+
+    /**
+     * @dataProvider keyPairStringProvider
+     */
+    public function testKeyValuePairName(string $keyPairValueString): void
+    {
+        $name = new Name($keyPairValueString);
+        $parameter = new ReflectionParameter([FakeCar::class, '__construct'], 'engine');
+        $boundName = $name($parameter);
+        $this->assertSame('engine_name', $boundName);
+    }
+
+    /**
+     * @return string[][]
+     * @psalm-return array{0: array{0: string}, 1: array{0: string}, 2: array{0: string}, 3: array{0: string}}
+     */
+    public function keyPairStringProvider(): array
+    {
+        return [
+            ['engine=engine_name,var=va_name'],
+            ['engine=engine_name, var=va_name'],
+            ['var=var_name,engine=engine_name'],
+            ['var=var_name, engine=engine_name'],
+        ];
+    }
+
+    public function testKeyValuePairButNotFound(): void
+    {
+        $name = new Name('foo=bar');
+        $parameter = new ReflectionParameter([FakeCar::class, '__construct'], 'engine');
+        $boundName = $name($parameter);
+        $this->assertSame(Name::ANY, $boundName);
+    }
 }

--- a/tests/di/NameTest.php
+++ b/tests/di/NameTest.php
@@ -66,4 +66,12 @@ class NameTest extends TestCase
         $boundName = $name($parameter);
         $this->assertSame(Name::ANY, $boundName);
     }
+
+    public function testKeyValuePairWithDollarPrefix(): void
+    {
+        $name = new Name('$engine=engine_name,$var=var_name');
+        $parameter = new ReflectionParameter([FakeCar::class, '__construct'], 'engine');
+        $boundName = $name($parameter);
+        $this->assertSame('engine_name', $boundName);
+    }
 }

--- a/tests/di/NameTest.php
+++ b/tests/di/NameTest.php
@@ -52,8 +52,8 @@ class NameTest extends TestCase
     public function keyPairStringProvider(): array
     {
         return [
-            ['engine=engine_name,var=va_name'],
-            ['engine=engine_name, var=va_name'],
+            ['engine=engine_name,var=var_name'],
+            ['engine=engine_name, var=var_name'],
             ['var=var_name,engine=engine_name'],
             ['var=var_name, engine=engine_name'],
         ];


### PR DESCRIPTION
## Summary

This PR restores support for the `"key=value,key=value"` string format in `toConstructor()` method, which was removed in commit da864a5.

## Background

Commit da864a5 ("Remove legacy method-level attribute support") removed the `parseName()` method that parsed string format parameter bindings, breaking backward compatibility with external libraries that depend on this feature.

## Impact

External libraries like **ray/aura-sql-module** depend on the string format:

```php
$this->bind(ExtendedPdoInterface::class)->toConstructor(
    ExtendedPdo::class,
    'dsn=pdo_dsn,username=pdo_user,password=pdo_pass,options=pdo_options,queries=pdo_queries',
);
```

Without this fix, these libraries fail with `Unbound` exceptions when used with Ray.Di 2.19.

## Solution

Restored the `parseName()` method and string format detection in `Name.php` for backward compatibility while maintaining support for modern approaches:

✅ **Recommended: Parameter-level attributes**
```php
public function __construct(
    #[Named('pdo_dsn')] string $dsn,
    #[Named('pdo_user')] string $username,
)
```

✅ **Recommended: Array format**
```php
$this->bind(...)->toConstructor(ClassName::class, [
    'dsn' => 'pdo_dsn',
    'username' => 'pdo_user',
]);
```

⚠️ **Legacy: String format** (backward compatibility only)
```php
$this->bind(...)->toConstructor(
    ClassName::class,
    'dsn=pdo_dsn,username=pdo_user'
);
```

## Changes

- Restored `parseName()` method in `src/di/Name.php`
- Added required imports (`explode`, `preg_match`, `substr`, `trim`)
- Added string format detection in `setName()` method

## Testing

- Tested with ray/media-query package (all 83 tests pass)
- Tested with ray/aura-sql-module integration
- No breaking changes to existing functionality

## Related Issues

Fixes compatibility with:
- ray/aura-sql-module
- ray/media-query
- Other packages using the string format

## Migration Path

While this PR restores backward compatibility, new code should prefer:
1. Parameter-level attributes (most recommended)
2. Array format in toConstructor
3. String format (only for legacy code)

## Summary by Sourcery

Restore backward compatibility for the legacy "key=value,..." string format in toConstructor by reintroducing parseName and updating setName logic.

Enhancements:
- Reintroduce parseName method to parse comma-separated key=value pairs into parameter mappings
- Enhance setName to detect and delegate string-based parameter bindings to parseName for legacy support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supports comma-separated key=value name lists while preserving single-name and simple-word handling.
* **Chores**
  * Adds a deprecated, internal legacy parsing path for backward compatibility.
* **Tests**
  * Adds unit tests for key=value variants, spacing variants, dollar-prefixed keys, and unmatched-pair handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->