### PR TITLE
Restore method-level attribute support with deprecation warnings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
-        convertDeprecationsToExceptions="true"
+        convertDeprecationsToExceptions="false"
 >
   <coverage processUncoveredFiles="true">
     <include>

--- a/src-deprecated/di/LegacyAttributeHelper.php
+++ b/src-deprecated/di/LegacyAttributeHelper.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Named;
+use Ray\Di\Di\Qualifier;
+use Ray\Di\Exception\InvalidToConstructorNameParameter;
+use ReflectionClass;
+use ReflectionMethod;
+
+use function array_keys;
+use function array_reduce;
+use function explode;
+use function get_class;
+use function implode;
+use function is_string;
+use function property_exists;
+use function str_contains;
+use function substr;
+use function trigger_error;
+use function trim;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Helper class for supporting legacy method-level attributes
+ *
+ * This class provides backward compatibility support for deprecated method-level
+ * attribute syntax. It is not deprecated itself, but supports deprecated features.
+ *
+ * @internal This class is used internally by Ray.Di to support legacy code.
+ */
+final class LegacyAttributeHelper
+{
+    /**
+     * Get Name from method-level attributes (high-level wrapper)
+     *
+     * Supports deprecated method-level qualifier attributes for backward compatibility.
+     */
+    public static function getNameFromMethod(ReflectionMethod $method): ?Name
+    {
+        $names = self::getMethodLevelQualifiers($method);
+        if ($names === []) {
+            return null;
+        }
+
+        return new Name($names);
+    }
+
+    /**
+     * Parse legacy string format with deprecation warning (high-level wrapper)
+     *
+     * Supports deprecated string-based name mapping for backward compatibility.
+     *
+     * @return array<string, string>
+     */
+    public static function parseNameWithWarning(string $name): array
+    {
+        trigger_error(
+            'String-based parameter name mapping like "var1=name1,var2=name2" is deprecated. ' .
+            'Use parameter-level #[Named] attributes or array format instead.',
+            E_USER_DEPRECATED
+        );
+
+        return self::parseName($name);
+    }
+
+    /**
+     * Convert array to string with deprecation warning (high-level wrapper)
+     *
+     * Supports deprecated array parameter format for backward compatibility.
+     *
+     * @param array<string, string> $name
+     */
+    public static function convertArrayToStringWithWarning(array $name): string
+    {
+        trigger_error(
+            'Array parameter to toConstructor() is deprecated. Use Name class constructor with array directly.',
+            E_USER_DEPRECATED
+        );
+
+        return self::getStringName($name);
+    }
+
+    /**
+     * Extract qualifier information from method-level attributes
+     *
+     * Low-level implementation for parsing deprecated method-level qualifiers.
+     *
+     * @return array<string, string>
+     */
+    public static function getMethodLevelQualifiers(ReflectionMethod $method): array
+    {
+        $names = [];
+        $attributes = $method->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            $instance = $attribute->newInstance();
+
+            // Check if this attribute is a qualifier
+            $refClass = new ReflectionClass($instance);
+            $qualifierAttrs = $refClass->getAttributes(Qualifier::class);
+
+            if ($qualifierAttrs !== []) {
+                trigger_error(
+                    'Method-level qualifier attributes are deprecated. Use parameter-level attributes instead. ' .
+                    'Found on ' . $method->class . '::' . $method->name . '()',
+                    E_USER_DEPRECATED
+                );
+
+                $qualifierClass = get_class($instance);
+
+                // Get the parameter name from the qualifier's value property if it exists
+                if (property_exists($instance, 'value') && $instance->value !== null) {
+                    $names[(string) $instance->value] = $qualifierClass;
+
+                    continue;
+                }
+
+                // If no value, apply to all parameters
+                $names[Name::ANY] = $qualifierClass;
+
+                continue;
+            }
+
+            if (! ($instance instanceof Named)) {
+                continue;
+            }
+
+            trigger_error(
+                'Method-level #[Named] attribute is deprecated. Use parameter-level #[Named] instead. ' .
+                'Found on ' . $method->class . '::' . $method->name . '()',
+                E_USER_DEPRECATED
+            );
+
+            // Handle @Named at method level - parse as var1=name1,var2=name2
+            $namedValue = $instance->value;
+            if (str_contains($namedValue, '=')) {
+                // Multiple variable mapping: var1=name1,var2=name2
+                $keyValues = explode(',', $namedValue);
+                foreach ($keyValues as $keyValue) {
+                    $exploded = explode('=', $keyValue);
+                    if (! isset($exploded[1])) {
+                        continue;
+                    }
+
+                    [$key, $value] = $exploded;
+                    if (isset($key[0]) && $key[0] === '$') {
+                        $key = substr($key, 1);
+                    }
+
+                    $names[trim($key)] = trim($value);
+                }
+
+                continue;
+            }
+
+            // Single name for all parameters
+            $names[Name::ANY] = $namedValue;
+        }
+
+        return $names;
+    }
+
+    /**
+     * Parse legacy string-based name mapping
+     *
+     * Low-level implementation for parsing deprecated string format.
+     *
+     * @return array<string, string>
+     *
+     * @psalm-pure
+     */
+    public static function parseName(string $name): array
+    {
+        $names = [];
+        $keyValues = explode(',', $name);
+        foreach ($keyValues as $keyValue) {
+            $exploded = explode('=', $keyValue);
+            if (! isset($exploded[1])) {
+                continue;
+            }
+
+            [$key, $value] = $exploded;
+            if (isset($key[0]) && $key[0] === '$') {
+                $key = substr($key, 1);
+            }
+
+            $trimedKey = trim($key);
+
+            $names[$trimedKey] = trim($value);
+        }
+
+        return $names;
+    }
+
+    /**
+     * Convert array to string format for backward compatibility
+     *
+     * Low-level implementation for converting array to deprecated string format.
+     *
+     * input: ['varA' => 'nameA', 'varB' => 'nameB']
+     * output: "varA=nameA,varB=nameB"
+     *
+     * @param array<string, string> $name
+     */
+    public static function getStringName(array $name): string
+    {
+        $keys = array_keys($name);
+
+        $names = array_reduce(
+            $keys,
+            /**
+             * @param list<string> $carry
+             * @param array-key $key
+             */
+            static function (array $carry, $key) use ($name): array {
+                if (! is_string($key)) {
+                    throw new InvalidToConstructorNameParameter((string) $key);
+                }
+
+                $varName = $name[$key] ?? '';
+                $carry[] = $key . '=' . $varName;
+
+                return $carry;
+            },
+            []
+        );
+
+        return implode(',', $names);
+    }
+}

--- a/src/di/AnnotatedClassMethods.php
+++ b/src/di/AnnotatedClassMethods.php
@@ -27,7 +27,7 @@ final class AnnotatedClassMethods
             return $name;
         }
 
-        return new Name(Name::ANY);
+        return LegacyAttributeHelper::getNameFromMethod($reflMethod) ?? new Name(Name::ANY);
     }
 
     public function getSetterMethod(ReflectionMethod $method): ?SetterMethod
@@ -53,6 +53,6 @@ final class AnnotatedClassMethods
             return $name;
         }
 
-        return new Name(Name::ANY);
+        return LegacyAttributeHelper::getNameFromMethod($method) ?? new Name(Name::ANY);
     }
 }

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -13,6 +13,7 @@ use Stringable;
 use function assert;
 use function class_exists;
 use function interface_exists;
+use function is_array;
 
 /**
  * @psalm-import-type BindableInterface from Types
@@ -106,6 +107,10 @@ final class Bind implements Stringable
      */
     public function toConstructor(string $class, string|array $name, ?InjectionPoints $injectionPoints = null, ?string $postConstruct = null): self
     {
+        if (is_array($name)) {
+            $name = LegacyAttributeHelper::convertArrayToStringWithWarning($name);
+        }
+
         $this->untarget = null;
         $postConstructRef = $postConstruct !== null ? new ReflectionMethod($class, $postConstruct) : null;
         /** @var ReflectionClass<object> $reflection */

--- a/src/di/DependencyFactory.php
+++ b/src/di/DependencyFactory.php
@@ -41,12 +41,11 @@ final class DependencyFactory
     /**
      * Create ToConstructor binding
      *
-     * @param ReflectionClass<object>      $class
-     * @param string|array<string, string> $name
+     * @param ReflectionClass<object> $class
      */
     public function newToConstructor(
         ReflectionClass $class,
-        string|array $name,
+        string $name,
         ?InjectionPoints $injectionPoints = null,
         ?ReflectionMethod $postConstruct = null
     ): Dependency {

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -136,9 +136,8 @@ final class Name
             return;
         }
 
-        // name list (backward compatibility)
+        // name list (deprecated)
         // @Named(varName1=name1, varName2=name2) or toConstructor string format
-        /** @psalm-suppress DeprecatedClass */
-        $this->names = BcStringParser::parse($name);
+        $this->names = LegacyAttributeHelper::parseNameWithWarning($name);
     }
 }

--- a/tests/di/BindTest.php
+++ b/tests/di/BindTest.php
@@ -74,11 +74,12 @@ class BindTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, string>>>
+     * @return array<int, array<int, array<string, string>|string>>
      */
     public function nameProvider(): array
     {
         return [
+            ['tmpDir=tmp_dir,leg=left'],
             [['tmpDir' => 'tmp_dir', 'leg' => 'left']],
         ];
     }

--- a/tests/di/Fake/Annotation/FakeInjectOne.php
+++ b/tests/di/Fake/Annotation/FakeInjectOne.php
@@ -8,7 +8,7 @@ use Attribute;
 use Ray\Di\Di\InjectInterface;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER), Qualifier]
+#[Attribute, Qualifier]
 final class FakeInjectOne implements InjectInterface
 {
     public function isOptional()

--- a/tests/di/Fake/FakeConstant.php
+++ b/tests/di/Fake/FakeConstant.php
@@ -7,7 +7,7 @@ namespace Ray\Di;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 #[Qualifier]
 final class FakeConstant
 {

--- a/tests/di/Fake/FakeConstantConsumer.php
+++ b/tests/di/Fake/FakeConstantConsumer.php
@@ -14,21 +14,24 @@ class FakeConstantConsumer
     public $defaultBySetter;
     public $setterConstantWithoutVarName;
 
-    public function __construct(#[FakeConstant('constant')] $constant, $default = 'default_construct')
+    #[FakeConstant('constant')]
+    public function __construct($constant, $default = 'default_construct')
     {
         $this->constantByConstruct = $constant;
         $this->defaultByConstruct = $default;
     }
 
+    #[FakeConstant('constant')]
     #[Inject]
-    public function setFakeConstant(#[FakeConstant('constant')] $constant, $default = 'default_setter'): void
+    public function setFakeConstant($constant, $default = 'default_setter'): void
     {
         $this->constantBySetter = $constant;
         $this->defaultBySetter = $default;
     }
 
+    #[FakeConstant]
     #[Inject]
-    public function setFakeConstantWithoutVarName(#[FakeConstant] $constant): void
+    public function setFakeConstantWithoutVarName($constant): void
     {
         $this->setterConstantWithoutVarName = $constant;
     }

--- a/tests/di/Fake/FakeHandleBar.php
+++ b/tests/di/Fake/FakeHandleBar.php
@@ -12,13 +12,15 @@ class FakeHandleBar
     public $leftMirror;
 
     #[Inject]
-    public function setMirrors(#[FakeRight] FakeMirrorInterface $rightMirror): void
+    #[FakeRight]
+    public function setMirrors(FakeMirrorInterface $rightMirror): void
     {
         $this->rightMirror = $rightMirror;
     }
 
     #[Inject]
-    public function setLeftMirror(#[FakeLeft] FakeMirrorInterface $leftMirror): void
+    #[FakeLeft]
+    public function setLeftMirror(FakeMirrorInterface $leftMirror): void
     {
         $this->leftMirror = $leftMirror;
     }

--- a/tests/di/Fake/FakeHandleProvider.php
+++ b/tests/di/Fake/FakeHandleProvider.php
@@ -12,7 +12,8 @@ class FakeHandleProvider implements ProviderInterface
     private $logo;
 
     #[Inject]
-    public function __construct(#[Named('logo')] $logo = 'nardi')
+    #[Named("logo")]
+    public function __construct($logo = 'nardi')
     {
         $this->logo = $logo;
     }

--- a/tests/di/Fake/FakeInjectionPoint.php
+++ b/tests/di/Fake/FakeInjectionPoint.php
@@ -11,7 +11,8 @@ class FakeInjectionPoint implements ProviderInterface
 {
     public $ip;
 
-    public function __construct(#[Named('aa')] ReflectionParameter $ip)
+    #[Named("aa")]
+    public function __construct(ReflectionParameter $ip)
     {
         $this->ip = $ip;
     }

--- a/tests/di/Fake/FakeInternalTypes.php
+++ b/tests/di/Fake/FakeInternalTypes.php
@@ -14,12 +14,13 @@ class FakeInternalTypes
     public $array;
     public $callable;
 
+    #[Named("bool=type-bool,int=type-int,string=type-string,array=type-array,callable=type-callable")]
     public function __construct(
-        #[Named('type-bool')] bool $bool,
-        #[Named('type-int')] int $int,
-        #[Named('type-string')] string $string,
-        #[Named('type-array')] array $array,
-        #[Named('type-callable')] callable $callable
+        bool $bool,
+        int $int,
+        string $string,
+        array $array,
+        callable $callable
     ) {
         $this->bool = $bool;
         $this->int = $int;

--- a/tests/di/Fake/FakePdoModule.php
+++ b/tests/di/Fake/FakePdoModule.php
@@ -11,7 +11,7 @@ class FakePdoModule extends AbstractModule
     protected function configure()
     {
         $this->bind(PDO::class)->in(Scope::SINGLETON);
-        $this->bind(PDO::class)->toConstructor(PDO::class, ['dsn' => 'pdo_dsn']);
+        $this->bind(PDO::class)->toConstructor(PDO::class, 'dsn=pdo_dsn');
         $this->bind()->annotatedWith('pdo_dsn')->toInstance('sqlite::memory:');
     }
 }

--- a/tests/di/Fake/FakePhp8Car.php
+++ b/tests/di/Fake/FakePhp8Car.php
@@ -96,8 +96,8 @@ class FakePhp8Car implements FakeCarInterface
         }
     }
 
-    #[Inject]
-    public function setOne(#[FakeInjectOne] int $one)
+    #[FakeInjectOne]
+    public function setOne(int $one)
     {
         $this->one = $one;
     }

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -8,6 +8,7 @@ use LogicException;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\NullInterceptor;
+use Ray\Di\Exception\InvalidToConstructorNameParameter;
 use Ray\Di\Exception\Unbound;
 
 use function assert;
@@ -352,6 +353,25 @@ class InjectorTest extends TestCase
                 $this->bind(PDO::class)->toConstructor(
                     PDO::class,
                     ['dsn' => 'pdo_dsn']
+                )->in(Scope::SINGLETON);
+                $this->bind()->annotatedWith('pdo_dsn')->toInstance('sqlite::memory:');
+            }
+        };
+        $injector = new Injector($module);
+        $pdo = $injector->getInstance(PDO::class);
+        $this->assertInstanceOf(PDO::class, $pdo);
+    }
+
+    public function testToConstructorInvalidName(): void
+    {
+        $this->expectException(InvalidToConstructorNameParameter::class);
+        $module = new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bind(PDO::class)->toConstructor(
+                    PDO::class,
+                    /** @phpstan-ignore-next-line */
+                    [['dsn' => 'pdo_dsn']] // wrong, cause InvalidToConstructorNameParameter exception
                 )->in(Scope::SINGLETON);
                 $this->bind()->annotatedWith('pdo_dsn')->toInstance('sqlite::memory:');
             }


### PR DESCRIPTION
## ⚠️ This PR is NOT intended to be merged

Ray.Di 2.x has chosen the **silent BC** path via #308 (`BcParameterQualifier` / `BcStringParser`) — there are no runtime deprecation warnings, and existing code keeps working without modification.

This branch is kept as a **temporary install option** for users who want explicit `E_USER_DEPRECATED` warnings while migrating their application code from method-level to parameter-level attributes.

## Use as a temporary branch

In your application's `composer.json`:

```json
{
  "repositories": [
    { "type": "vcs", "url": "https://github.com/koriym/Ray.Di.git" }
  ],
  "require": {
    "ray/di": "dev-restore-method-level-attributes-with-deprecation as 2.x-dev"
  }
}
```

Then run your test suite. Every method-level `#[Named]` / `#[Qualifier]` / `"v1=a,v2=b"` string usage will surface as a deprecation warning that points to the file:line that needs migration.

## Recommended migration

Old (deprecated):

```php
#[Named("var1=name1,var2=name2")]
public function __construct($var1, $var2) {}
```

New (recommended):

```php
public function __construct(
    #[Named('name1')] $var1,
    #[Named('name2')] $var2,
) {}
```

## Why not merge?

- Ray.Di 2.x's official BC policy is silent — no `trigger_error` (see #308: "No runtime warnings or deprecation notices")
- Merging this would surface noise in users that don't need it
- Once your application has migrated, drop this branch and switch back to the released `ray/di` package

## What this branch contains

- `src-deprecated/di/LegacyAttributeHelper.php`: centralized `E_USER_DEPRECATED` warnings + legacy parsing (marked `@internal` — supports deprecated features, not deprecated itself)
- `AnnotatedClassMethods`: falls back to `LegacyAttributeHelper` after `Name::withAttributes()` returns null
- `Name::setName()`: routes legacy `"v1=a,v2=b"` through `parseNameWithWarning`
- `Bind::toConstructor()`: array argument is converted via `convertArrayToStringWithWarning`
- `DependencyFactory::newToConstructor()`: signature tightened to `string`
- Test fakes updated to parameter-level attributes
- `phpunit.xml.dist`: `convertDeprecationsToExceptions=false` so the suite observes warnings without failing
