### PR TITLE
Add NoHint exception and improve Unbound error messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit --log-junit=build/junit.xm/m///..l",
+        "test": "phpunit --log-junit=build/junit.xml",
         "tests": ["@cs", "@sa", "@test"],
         "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
         "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage --coverage-xml=build/coverage-xml --coverage-clover=coverage.xml"],

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require-dev": {
         "ext-pdo": "*",
         "bamarni/composer-bin-plugin": "^1.4",
-        "phpunit/phpunit": "^8.5.40 || ^9.5"
+        "infection/infection": "*",
+        "phpunit/phpunit": "^9.6.31"
     },
     "suggest": {
         "ray/compiler": "For compiling dependency injection container to improve performance"
@@ -25,7 +26,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "bamarni/composer-bin-plugin": true
+            "bamarni/composer-bin-plugin": true,
+            "infection/extension-installer": true
         }
     },
     "autoload": {
@@ -39,10 +41,11 @@
         }
     },
     "scripts": {
-        "test": "phpunit --log-junit=build/junit.xml",
+        "test": "phpunit --log-junit=build/junit.xm/m///..l",
         "tests": ["@cs", "@sa", "@test"],
         "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
-        "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage  --coverage-clover=coverage.xml"],
+        "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage --coverage-xml=build/coverage-xml --coverage-clover=coverage.xml"],
+        "mutation": ["php -dextension=pcov.so -d pcov.enabled=1 vendor/bin/infection --coverage=build/coverage-xml --threads=2 --min-msi=80 --min-covered-msi=80 --no-progress"],
         "cs": ["vendor-bin/tools/vendor/squizlabs/php_codesniffer/bin/phpcs --standard=./phpcs.xml src tests"],
         "cs-fix": ["vendor-bin/tools/vendor/squizlabs/php_codesniffer/bin/phpcbf src tests"],
         "clean": ["vendor-bin/tools/vendor/phpstan/phpstan/phpstan clear-result-cache", "vendor-bin/tools/vendor/vimeo/psalm/psalm --clear-cache", "rm -rf tests/tmp/*.php"],

--- a/demo/chain-error/A.php
+++ b/demo/chain-error/A.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class A
 {
-    public function __construct(B $dep)
+    public function __construct(B $b)
     {
     }
 }

--- a/demo/chain-error/B.php
+++ b/demo/chain-error/B.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class B
 {
-    public function __construct(C $dep)
+    public function __construct(C $c)
     {
     }
 }

--- a/demo/chain-error/C.php
+++ b/demo/chain-error/C.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class C
 {
-    public function __construct(D $dep)
+    public function __construct(D $d)
     {
     }
 }

--- a/demo/chain-error/D.php
+++ b/demo/chain-error/D.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 class D
 {
-    public function __construct(EInterface $dep)
+    public function __construct(EInterface $e)
     {
     }
 }

--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -43,7 +43,7 @@ final class Argument implements AcceptInterface, Stringable
         $this->index = $type . '-' . $name;
         $this->reflection = $parameter;
         $this->meta = sprintf(
-            "dependency '%s' with name '%s' used in %s:%d ($%s)",
+            "'%s-%s' in %s:%d ($%s)",
             $type,
             $name,
             $this->reflection->getDeclaringFunction()->getFileName(),

--- a/src/di/Arguments.php
+++ b/src/di/Arguments.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use Ray\Di\Exception\NoHint;
 use Ray\Di\Exception\Unbound;
 use ReflectionMethod;
+
+use function sprintf;
 
 /**
  * @psalm-import-type ArgumentsList from Types
@@ -62,6 +65,10 @@ final class Arguments implements AcceptInterface
                 return $argument->getDefaultValue();
             }
 
+            if ($unbound instanceof NoHint) {
+                throw new NoHint($this->getNoHintMsg($argument), 0, $unbound);
+            }
+
             throw new Unbound($argument->getMeta(), 0, $unbound);
         }
     }
@@ -74,5 +81,17 @@ final class Arguments implements AcceptInterface
         }
 
         (new Bind($container, InjectionPointInterface::class))->toInstance(new InjectionPoint($argument->get()));
+    }
+
+    private function getNoHintMsg(Argument $argument): string
+    {
+        $ref = $argument->get();
+
+        return sprintf(
+            '$%s (%s:%d)',
+            $ref->getName(),
+            $ref->getDeclaringFunction()->getFileName(),
+            $ref->getDeclaringFunction()->getStartLine()
+        );
     }
 }

--- a/src/di/Arguments.php
+++ b/src/di/Arguments.php
@@ -86,12 +86,14 @@ final class Arguments implements AcceptInterface
     private function getNoHintMsg(Argument $argument): string
     {
         $ref = $argument->get();
+        $func = $ref->getDeclaringFunction();
+        $fileName = $func->getFileName();
 
         return sprintf(
             '$%s (%s:%d)',
             $ref->getName(),
-            $ref->getDeclaringFunction()->getFileName(),
-            $ref->getDeclaringFunction()->getStartLine()
+            $fileName !== false ? $fileName : 'unknown',
+            $func->getStartLine()
         );
     }
 }

--- a/src/di/Arguments.php
+++ b/src/di/Arguments.php
@@ -92,7 +92,7 @@ final class Arguments implements AcceptInterface
         return sprintf(
             '$%s (%s:%d)',
             $ref->getName(),
-            $fileName !== false ? $fileName : 'unknown',
+            $fileName !== false ? $fileName : 'unknown file',
             $func->getStartLine()
         );
     }

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Ray\Aop\Compiler;
 use Ray\Aop\CompilerInterface;
 use Ray\Aop\Pointcut;
+use Ray\Di\Exception\NoHint;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\Exception\Untargeted;
 use Ray\Di\MultiBinding\MultiBindings;
@@ -152,7 +153,11 @@ final class Container implements InjectorInterface
             return new Untargeted($class);
         }
 
-        return new Unbound(sprintf('%s-%s', $class, $name));
+        if ($class === '' && $name === '') {
+            return new NoHint();
+        }
+
+        return new Unbound(sprintf("'%s-%s'", $class, $name));
     }
 
     /**

--- a/src/di/Exception/NoHint.php
+++ b/src/di/Exception/NoHint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di\Exception;
+
+/**
+ * Exception thrown when a parameter has no type hint and no binding name
+ *
+ * Message format: ${var} (file:line)
+ *
+ * This occurs when Ray.Di cannot identify what to inject because
+ * the parameter has neither a class/interface type hint nor a #[Named] or #[Qualifier] attribute.
+ */
+final class NoHint extends Unbound
+{
+}

--- a/src/di/Exception/Unbound.php
+++ b/src/di/Exception/Unbound.php
@@ -12,6 +12,16 @@ use function array_reverse;
 use function implode;
 use function sprintf;
 
+/**
+ * Exception thrown when a binding is not found
+ *
+ * Message format: '{type}-{name}' in file:line ($var)
+ *
+ * Examples:
+ * - "'FooInterface-' in file.php:10 ($foo)" - FooInterface with no name
+ * - "'FooInterface-db' in file.php:10 ($foo)" - FooInterface with name 'db'
+ * - "'-db' in file.php:10 ($foo)" - no type with name 'db'
+ */
 class Unbound extends LogicException implements ExceptionInterface
 {
     public function __toString(): string

--- a/tests/di/Fake/FakeUnNamedClass.php
+++ b/tests/di/Fake/FakeUnNamedClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeUnNamedClass
+{
+    public function __construct(string $value)
+    {
+    }
+}

--- a/tests/di/Fake/FakeUnNamedModule.php
+++ b/tests/di/Fake/FakeUnNamedModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeUnNamedModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind(FakeUnNamedClass::class);
+    }
+}

--- a/tests/di/NoHintTest.php
+++ b/tests/di/NoHintTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\NoHint;
+use Ray\Di\Exception\Unbound;
+
+class NoHintTest extends TestCase
+{
+    public function testNoHintIsUnbound(): void
+    {
+        $e = new NoHint();
+        $this->assertInstanceOf(Unbound::class, $e);
+    }
+
+    public function testNoHintThrownForNoTypeNoName(): void
+    {
+        $this->expectException(NoHint::class);
+
+        $injector = new Injector(new FakeUnNamedModule());
+        $injector->getInstance(FakeUnNamedClass::class);
+    }
+}

--- a/tests/di/NoHintTest.php
+++ b/tests/di/NoHintTest.php
@@ -23,4 +23,22 @@ class NoHintTest extends TestCase
         $injector = new Injector(new FakeUnNamedModule());
         $injector->getInstance(FakeUnNamedClass::class);
     }
+
+    public function testNoHintMessageFormat(): void
+    {
+        $injector = new Injector(new FakeUnNamedModule());
+
+        try {
+            $injector->getInstance(FakeUnNamedClass::class);
+            $this->fail('NoHint exception should be thrown');
+        } catch (NoHint $e) {
+            // Message format: ${var} (file:line)
+            $this->assertMatchesRegularExpression(
+                '/^\$\w+ \(.+:\d+\)$/',
+                $e->getMessage(),
+            );
+            $this->assertStringContainsString('$value', $e->getMessage());
+            $this->assertStringContainsString('FakeUnNamedClass.php', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Motivation / モチベーション

従来のUnbound例外メッセージには以下の問題がありました：

1. **型もなく名前もない場合のエラーが不明瞭**
   - `dependency '' with name ''` という無意味なメッセージ
   - 「束縛がない」ではなく「識別できない」という本質が伝わらない

2. **メッセージ形式が冗長**
   - `dependency 'FooInterface' with name '' used in file.php:10 ($foo)` は長い
   - 末尾ハイフン `FooInterface-` がバグっぽく見える

3. **依存チェーンの可読性**
   - クラス名が左揃えでないとスキャンしにくい
   - ファイルパスが可変長だと視線移動が多くなる

## Design Decisions / 設計判断

### NoHint例外の追加

型ヒントも`#[Named]`も`#[Qualifier]`もない場合は`Unbound`とは本質的に異なる：
- `Unbound`: 識別子はあるが束縛がない
- `NoHint`: そもそも識別子がない（Ray.Diが解決しようがない）

セマンティック例外としてクラス名で意味を伝える。

### バインディングキー形式の採用

内部のバインディングキー `'{type}-{name}'` をそのまま使用：
- 一貫性がある
- DIの「型-名前」という概念が明確
- `(name: db)` のような括弧は補助情報だけになり不自然

### メッセージ形式

クラス名を左端に固定し、依存グラフの構造を一目で把握できるように：
```
- 'EInterface-' in D.php:7 ($e)
- 'D-' in C.php:7 ($d)
- 'C-' in B.php:7 ($c)
- 'B-' in A.php:7 ($b)
```

D.php:7の`$e`の`EInterface-`が **Unbound**

それは..（下から）
Aが `B-` を必要として
Bが `C-` を必要として
Cが `D-` を必要として

Dが `EInterface-`を必要としてそれが解決できなかったから！

`$injector->getInstance(A::class);`

とAを取得しようとして出たエラーでけど真の問題はAではなく、Eの問題だからEの例外として報告しています。

## Summary / 変更内容

- Add `NoHint` exception for parameters without type hint or binding name
- Improve `Unbound` exception message format using binding key notation
- Update demo chain-error files with distinct variable names

## Message Formats

**Unbound:** `'{type}-{name}' in file:line ($var)`
- `'FooInterface-'` for type only
- `'FooInterface-db'` for type with name  
- `'-db'` for name only

**NoHint:** `$var (file:line)`

## Test Plan

- [x] All existing tests pass
- [x] New `NoHintTest` added
- [x] Static analysis passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a NoHint exception to distinguish DI errors for parameters without a type hint or binding name.

* **Bug Fixes**
  * Improved unbound injection error handling and diagnostic messages; adjusted meta message formatting.
  * Renamed demo constructor parameters (no behavioral change).

* **Documentation**
  * Added docblock clarifying Unbound exception message format.

* **Tests**
  * Added tests and fixtures for NoHint behavior.

* **Chores**
  * Updated dev testing and mutation tooling configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->