### PR TITLE
Fix BcParameterQualifier to support multi-parameter constructors

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.3
+      php_version: 8.4

--- a/src-deprecated/di/BcParameterQualifier.php
+++ b/src-deprecated/di/BcParameterQualifier.php
@@ -9,15 +9,17 @@ use Ray\Di\Di\Qualifier;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionParameter;
 
 use function count;
 
 /**
- * Backward compatible parameter qualifier for single-parameter methods
+ * Backward compatible parameter qualifier for method-level Qualifier attributes
  *
  * Automatically applies method-level Qualifier attributes to parameters when:
- * - Method has exactly one parameter
- * - Parameter has no explicit qualifier
+ * - Parameters have no explicit qualifier
+ * - For single-parameter methods: Qualifier is applied to the only parameter
+ * - For multi-parameter methods: Qualifier's value property specifies the target parameter name
  * - For constructors: Method has a Qualifier attribute (InjectInterface is implicit)
  * - For setters: Method has an attribute implementing both InjectInterface and Qualifier
  *
@@ -44,12 +46,6 @@ final class BcParameterQualifier
     /**
      * Get parameter qualifier names from method-level attribute if applicable
      *
-     * Returns parameter name mapping if:
-     * 1. Method has exactly one parameter
-     * 2. Parameter has no qualifier attribute
-     * 3. For setters: Method has an attribute implementing both InjectInterface and Qualifier
-     * 4. For constructors: Method has a Qualifier attribute (InjectInterface is implicit)
-     *
      * @param ReflectionMethod $method The method to analyze
      *
      * @return array<string, string> Parameter name to qualifier mapping (empty if not applicable)
@@ -57,75 +53,68 @@ final class BcParameterQualifier
     public static function getNames(ReflectionMethod $method): array
     {
         $params = $method->getParameters();
-
-        // Only for single-parameter methods
-        if (count($params) !== 1) {
+        if ($params === []) {
             return [];
-        }
-
-        $qualifier = self::getQualifier($method);
-        if ($qualifier === '') {
-            return [];
-        }
-
-        return [$params[0]->name => $qualifier];
-    }
-
-    /**
-     * Get parameter qualifier from method-level attribute if applicable
-     *
-     * Returns the qualifier name if:
-     * 1. Method has exactly one parameter
-     * 2. Parameter has no qualifier attribute
-     * 3. For setters: Method has an attribute implementing both InjectInterface and Qualifier
-     * 4. For constructors: Method has a Qualifier attribute (InjectInterface is implicit)
-     *
-     * @param ReflectionMethod $method The method to analyze
-     *
-     * @return string The qualifier class name, or empty string if not applicable
-     */
-    private static function getQualifier(ReflectionMethod $method): string
-    {
-        $params = $method->getParameters();
-
-        // Only for single-parameter methods
-        if (count($params) !== 1) {
-            return '';
-        }
-
-        $param = $params[0];
-
-        // Check if parameter already has a qualifier
-        if (self::hasParameterQualifier($param->getAttributes())) {
-            return '';
         }
 
         $isConstructor = $method->name === '__construct';
-
-        // Check method-level attributes for Qualifier
         $methodAttributes = $method->getAttributes();
-        foreach ($methodAttributes as $attr) {
-            $instance = $attr->newInstance();
-            $attrClass = new ReflectionClass($attr->getName());
-            $qualifierAttr = $attrClass->getAttributes(Qualifier::class);
+        $names = [];
 
-            // Skip if not a Qualifier
-            if ($qualifierAttr === []) {
+        foreach ($methodAttributes as $attr) {
+            $attrClass = new ReflectionClass($attr->getName());
+            if ($attrClass->getAttributes(Qualifier::class) === []) {
                 continue;
             }
 
-            // For constructors: Qualifier alone is sufficient (InjectInterface is implicit)
-            if ($isConstructor) {
-                return $attr->getName();
-            }
+            $instance = $attr->newInstance();
 
             // For setters: Must also implement InjectInterface
-            if ($instance instanceof InjectInterface) {
-                return $attr->getName();
+            if (! $isConstructor && ! $instance instanceof InjectInterface) {
+                continue;
+            }
+
+            $targetParam = self::resolveTargetParam($instance, $params);
+            if ($targetParam === null) {
+                continue;
+            }
+
+            // Skip if parameter already has a qualifier
+            if (self::hasParameterQualifier($targetParam->getAttributes())) {
+                continue;
+            }
+
+            $names[$targetParam->name] = $attr->getName();
+        }
+
+        return $names;
+    }
+
+    /**
+     * Resolve which parameter a Qualifier targets
+     *
+     * If the Qualifier has a value property matching a parameter name, use that.
+     * Otherwise, if there is exactly one parameter, use it.
+     *
+     * @param object                 $qualifier The Qualifier attribute instance
+     * @param array<ReflectionParameter> $params    Method parameters
+     */
+    private static function resolveTargetParam(object $qualifier, array $params): ?ReflectionParameter
+    {
+        if (count($params) === 1) {
+            return $params[0];
+        }
+
+        // For multi-parameter methods, use qualifier's value property to find target
+        if (isset($qualifier->value) && $qualifier->value !== '') {
+            foreach ($params as $param) {
+                if ($param->name === $qualifier->value) {
+                    return $param;
+                }
             }
         }
 
-        return '';
+        return null;
     }
 
     /**

--- a/tests/di/BcParameterQualifierTest.php
+++ b/tests/di/BcParameterQualifierTest.php
@@ -7,6 +7,7 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Annotation\FakeInjectOne;
 use Ray\Di\Annotation\FakeQualifierOnly;
+use Ray\Di\Annotation\FakeQualifierWithValue;
 use ReflectionMethod;
 
 class BcParameterQualifierTest extends TestCase
@@ -20,13 +21,31 @@ class BcParameterQualifierTest extends TestCase
         $this->assertSame(['param' => FakeInjectOne::class], $names);
     }
 
-    public function testNoNamesForMultipleParameters(): void
+    public function testNoNamesForMultipleParametersWithNonMatchingValue(): void
     {
         $method = new ReflectionMethod(FakeBcParameterQualifierClass::class, 'setMultipleParams');
         /** @psalm-suppress DeprecatedClass */
         $names = BcParameterQualifier::getNames($method);
 
         $this->assertSame([], $names);
+    }
+
+    public function testNamesForMultipleParametersWithMatchingValue(): void
+    {
+        $method = new ReflectionMethod(FakeBcParameterQualifierClass::class, 'setMultipleParamsWithMatchingValue');
+        /** @psalm-suppress DeprecatedClass */
+        $names = BcParameterQualifier::getNames($method);
+
+        $this->assertSame(['param1' => FakeGearStickInject::class], $names);
+    }
+
+    public function testConstructorMultiParamWithMatchingValue(): void
+    {
+        $method = new ReflectionMethod(FakeBcConstructorMultiParamClass::class, '__construct');
+        /** @psalm-suppress DeprecatedClass */
+        $names = BcParameterQualifier::getNames($method);
+
+        $this->assertSame(['param2' => FakeQualifierWithValue::class], $names);
     }
 
     public function testNoNamesWhenParameterHasQualifier(): void

--- a/tests/di/Fake/Annotation/FakeQualifierWithValue.php
+++ b/tests/di/Fake/Annotation/FakeQualifierWithValue.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di\Annotation;
+
+use Attribute;
+use Ray\Di\Di\Qualifier;
+
+/**
+ * Qualifier-only attribute with value property for testing multi-parameter resolution
+ */
+#[Attribute(Attribute::TARGET_METHOD), Qualifier]
+final class FakeQualifierWithValue
+{
+    public function __construct(public string $value = '')
+    {
+    }
+}

--- a/tests/di/Fake/FakeBcConstructorMultiParamClass.php
+++ b/tests/di/Fake/FakeBcConstructorMultiParamClass.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Annotation\FakeQualifierWithValue;
+
+class FakeBcConstructorMultiParamClass
+{
+    /**
+     * Constructor with multiple parameters and method-level Qualifier with value
+     * BcParameterQualifier should apply to the parameter matching the value
+     */
+    #[FakeQualifierWithValue('param2')]
+    public function __construct(public $param1, public $param2)
+    {
+    }
+}

--- a/tests/di/Fake/FakeBcParameterQualifierClass.php
+++ b/tests/di/Fake/FakeBcParameterQualifierClass.php
@@ -27,10 +27,20 @@ class FakeBcParameterQualifierClass
     }
 
     /**
-     * Multiple parameters - should NOT infer
+     * Multiple parameters with value not matching any param name - should NOT infer
      */
     #[FakeGearStickInject('test')]
     public function setMultipleParams(FakeGearStickInterface $param1, FakeTyreInterface $param2): void
+    {
+        $this->multipleParams1 = $param1;
+        $this->multipleParams2 = $param2;
+    }
+
+    /**
+     * Multiple parameters with value matching a param name - should infer for that param
+     */
+    #[FakeGearStickInject('param1')]
+    public function setMultipleParamsWithMatchingValue(FakeGearStickInterface $param1, FakeTyreInterface $param2): void
     {
         $this->multipleParams1 = $param1;
         $this->multipleParams2 = $param2;


### PR DESCRIPTION
## Summary / 概要

Fix `BcParameterQualifier` to support multi-parameter constructors when the Qualifier attribute specifies a target parameter name via its `value` property.

Qualifier の `value` プロパティでターゲットパラメータ名が指定されている場合、マルチパラメータのコンストラクタでも `BcParameterQualifier` が動作するよう修正。

## Problem / 問題

`BcParameterQualifier` is limited to single-parameter methods only. This breaks backward compatibility for classes like `AuraSqlPager` in `ray/aura-sql-module` 1.13.x that have multi-parameter constructors with method-level Qualifier attributes:

`BcParameterQualifier` がシングルパラメータに限定されており、`ray/aura-sql-module` 1.13.x の `AuraSqlPager` 等、メソッドレベル Qualifier を持つマルチパラメータのコンストラクタの後方互換性が破壊されている：

```php
#[PagerViewOption('viewOptions')]
public function __construct(ViewInterface $view, array $viewOptions)
```

`ray/aura-sql-module` 1.13.x declares `ray/di ^2.13.1` as a dependency, so backward compatibility should be maintained.

## Solution / 解決策

In `resolveTargetParam()`:

1. Single-parameter methods: apply Qualifier to the only parameter (existing behavior)
2. Multi-parameter methods: use the Qualifier's `value` property to find the target parameter by name

## Additional fix / 追加修正

Updated `.github/workflows/static-analysis.yml` to use PHP 8.4 — `composer-require-checker.phar` requires PHP 8.4+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support method-level Qualifier attributes on multi-parameter methods and constructors while maintaining backward compatibility, and update static analysis PHP version.

New Features:
- Allow BcParameterQualifier to resolve target parameters on multi-parameter methods and constructors using the Qualifier attribute's value property.

Bug Fixes:
- Restore backward-compatible qualifier inference for legacy classes that use method-level Qualifier attributes on multi-parameter constructors.

Enhancements:
- Broaden BcParameterQualifier from single-parameter-only handling to a more general mechanism that inspects method-level Qualifier attributes and skips parameters with existing qualifiers.

CI:
- Bump the static analysis workflow to run against PHP 8.4 to satisfy composer-require-checker requirements.

Tests:
- Add tests and fixtures covering multi-parameter setter and constructor scenarios, including value-matching and non-matching Qualifier attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated static analysis workflow to use PHP 8.4.

* **New Features**
  * Improved handling of qualifiers for methods and constructors with multiple parameters: qualifiers can now target a specific parameter by name.

* **Tests**
  * Added tests and test doubles covering matching/non-matching qualifier values and multi-parameter constructor scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->