### PR TITLE
Improve DI hot path performance

### DIFF
--- a/src-deprecated/di/BcParameterQualifier.php
+++ b/src-deprecated/di/BcParameterQualifier.php
@@ -105,8 +105,8 @@ final class BcParameterQualifier
         // Check method-level attributes for Qualifier
         $methodAttributes = $method->getAttributes();
         foreach ($methodAttributes as $attr) {
-            $instance = $attr->newInstance();
-            $attrClass = new ReflectionClass($attr->getName());
+            $attributeName = $attr->getName();
+            $attrClass = new ReflectionClass($attributeName);
             $qualifierAttr = $attrClass->getAttributes(Qualifier::class);
 
             // Skip if not a Qualifier
@@ -116,12 +116,12 @@ final class BcParameterQualifier
 
             // For constructors: Qualifier alone is sufficient (InjectInterface is implicit)
             if ($isConstructor) {
-                return $attr->getName();
+                return $attributeName;
             }
 
             // For setters: Must also implement InjectInterface
-            if ($instance instanceof InjectInterface) {
-                return $attr->getName();
+            if ($attrClass->implementsInterface(InjectInterface::class)) {
+                return $attributeName;
             }
         }
 

--- a/src/di/Arguments.php
+++ b/src/di/Arguments.php
@@ -80,7 +80,7 @@ final class Arguments implements AcceptInterface
             return;
         }
 
-        (new Bind($container, InjectionPointInterface::class))->toInstance(new InjectionPoint($argument->get()));
+        $container->setInjectionPoint(new InjectionPoint($argument->get()));
     }
 
     private function getNoHintMsg(Argument $argument): string

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -61,6 +61,14 @@ final class Container implements InjectorInterface
     }
 
     /**
+     * @internal
+     */
+    public function setInjectionPoint(InjectionPointInterface $ip): void
+    {
+        $this->container[InjectionPointInterface::class . '-' . Name::ANY] = new Instance($ip);
+    }
+
+    /**
      * Add Pointcut to container
      */
     public function addPointcut(Pointcut $pointcut): void

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -72,15 +72,18 @@ final class Dependency implements DependencyInterface, AcceptInterface
         }
 
         // create dependency injected instance
-        $this->instance = ($this->newInstance)($container);
+        $instance = ($this->newInstance)($container);
+        if ($this->isSingleton) {
+            $this->instance = $instance;
+        }
 
         // @PostConstruct
         if ($this->postConstruct !== null) {
-            assert(method_exists($this->instance, $this->postConstruct));
-            $this->instance->{$this->postConstruct}();
+            assert(method_exists($instance, $this->postConstruct));
+            $instance->{$this->postConstruct}();
         }
 
-        return $this->instance;
+        return $instance;
     }
 
     /**
@@ -96,15 +99,18 @@ final class Dependency implements DependencyInterface, AcceptInterface
         }
 
         // create dependency injected instance
-        $this->instance = $this->newInstance->newInstanceArgs($container, $params);
+        $instance = $this->newInstance->newInstanceArgs($container, $params);
+        if ($this->isSingleton) {
+            $this->instance = $instance;
+        }
 
         // @PostConstruct
         if ($this->postConstruct !== null) {
-            assert(method_exists($this->instance, $this->postConstruct));
-            $this->instance->{$this->postConstruct}();
+            assert(method_exists($instance, $this->postConstruct));
+            $instance->{$this->postConstruct}();
         }
 
-        return $this->instance;
+        return $instance;
     }
 
     /**
@@ -123,12 +129,13 @@ final class Dependency implements DependencyInterface, AcceptInterface
     public function weaveAspects(CompilerInterface $compiler, array $pointcuts): void
     {
         $class = (string) $this->newInstance;
-        if ((new ReflectionClass($class))->isFinal()) {
+        $reflection = new ReflectionClass($class);
+        if ($reflection->isFinal()) {
             return;
         }
 
-        $isInterceptor = (new ReflectionClass($class))->implementsInterface(MethodInterceptor::class);
-        $isWeaved = (new ReflectionClass($class))->implementsInterface(WeavedInterface::class);
+        $isInterceptor = $reflection->implementsInterface(MethodInterceptor::class);
+        $isWeaved = $reflection->implementsInterface(WeavedInterface::class);
         if ($isInterceptor || $isWeaved) {
             return;
         }

--- a/src/di/DependencyProvider.php
+++ b/src/di/DependencyProvider.php
@@ -62,9 +62,13 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
             $this->setContext($provider);
         }
 
-        $this->instance = $provider->get();
+        /** @psalm-suppress MixedAssignment */
+        $instance = $provider->get();
+        if ($this->isSingleton) {
+            $this->instance = $instance;
+        }
 
-        return $this->instance;
+        return $instance;
     }
 
     /**

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -12,6 +12,7 @@ use ReflectionException;
 use ReflectionMethod;
 use ReflectionParameter;
 
+use function assert;
 use function class_exists;
 use function is_string;
 use function preg_match;
@@ -93,14 +94,18 @@ final class Name
     private static function getName(array $attributes): string
     {
         $refAttribute = $attributes[0];
-        $attribute = $refAttribute->newInstance();
-        if ($attribute instanceof Named) {
+        /** @var class-string $attributeName */
+        $attributeName = $refAttribute->getName();
+        if ($attributeName === Named::class) {
+            $attribute = $refAttribute->newInstance();
+            assert($attribute instanceof Named);
+
             return $attribute->value;
         }
 
-        $isQualifier = (bool) (new ReflectionClass($attribute))->getAttributes(Qualifier::class);
+        $isQualifier = (bool) (new ReflectionClass($attributeName))->getAttributes(Qualifier::class);
         if ($isQualifier) {
-            return $attribute::class;
+            return $attributeName;
         }
 
         return '';

--- a/src/di/NewInstance.php
+++ b/src/di/NewInstance.php
@@ -7,7 +7,6 @@ namespace Ray\Di;
 use Ray\Aop\Bind as AopBind;
 use Ray\Aop\WeavedInterface;
 use ReflectionClass;
-use ReflectionException;
 use Stringable;
 
 use function assert;
@@ -43,14 +42,12 @@ final class NewInstance implements Stringable
         $this->setterMethods = $setterMethods;
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function __invoke(Container $container): object
     {
-        $reflection = new ReflectionClass($this->class);
+        /** @var class-string $class */
+        $class = $this->class;
         /** @psalm-suppress MixedMethodCall */
-        $instance = $this->arguments instanceof Arguments ? $reflection->newInstanceArgs($this->arguments->inject($container)) : new $this->class();
+        $instance = $this->arguments instanceof Arguments ? new $class(...$this->arguments->inject($container)) : new $class();
 
         return $this->postNewInstance($container, $instance);
     }
@@ -65,12 +62,13 @@ final class NewInstance implements Stringable
 
     /**
      * @param MethodArguments $params
-     *
-     * @throws ReflectionException
      */
     public function newInstanceArgs(Container $container, array $params): object
     {
-        $instance = (new ReflectionClass($this->class))->newInstanceArgs($params);
+        /** @var class-string $class */
+        $class = $this->class;
+        /** @psalm-suppress MixedMethodCall */
+        $instance = new $class(...$params);
 
         return $this->postNewInstance($container, $instance);
     }

--- a/src/di/SetterMethod.php
+++ b/src/di/SetterMethod.php
@@ -9,7 +9,6 @@ use LogicException;
 use Ray\Di\Exception\Unbound;
 use ReflectionMethod;
 
-use function call_user_func_array;
 use function is_callable;
 
 final class SetterMethod implements AcceptInterface
@@ -51,7 +50,7 @@ final class SetterMethod implements AcceptInterface
             throw new LogicException(); // @codeCoverageIgnore
         }
 
-        call_user_func_array($callable, $parameters);
+        $instance->{$this->method}(...$parameters);
     }
 
     public function setOptional(): void


### PR DESCRIPTION
## Summary
- reduce DI hot-path overhead for `InjectionPointInterface` binding by setting the internal container entry directly
- use direct variadic construction / method calls instead of reflection and `call_user_func_array()` on hot paths
- avoid unnecessary `ReflectionClass` creation and attribute instantiation
- avoid retaining prototype instances in dependency objects

## Benchmark
Recorded at `/private/tmp/raydi-benchmark-20260607-081725.md`.

| Case | Before median | After median | Change |
| --- | ---: | ---: | ---: |
| existing injector `getInstance()` | 38.417 us/op | 30.661 us/op | +20.19% |
| `Injector` construction + `getInstance()` | 268.263 us/op | 260.015 us/op | +3.07% |

## Checks
- `composer test`
- `composer cs`
- Psalm via PHP 8.4: `/opt/homebrew/opt/php@8.4/bin/php vendor-bin/tools/vendor/vimeo/psalm/psalm -m -c psalm.xml --show-info=false`
- PHPStan via PHP 8.4: `/opt/homebrew/opt/php@8.4/bin/php vendor-bin/tools/vendor/phpstan/phpstan/phpstan analyse -c phpstan.neon --no-progress --memory-limit=1G`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a method to register injection points directly.

* **Refactor**
  * Reduced runtime overhead when resolving attributes and creating instances for improved performance.
  * Adjusted instance caching to respect singleton behavior, improving memory use and predictability.
  * Simplified setter invocation and direct instantiation to streamline object creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->