### PR TITLE
Raise mutation MSI to 90% and ratchet the floor to 90

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "pcov": ["php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage --coverage-xml=build/coverage-xml --coverage-clover=coverage.xml"],
         "mutation": [
             "php -dextension=pcov.so -r \"extension_loaded('pcov') || (fwrite(STDERR, 'pcov required for mutation testing (dev-only). Install: pecl install pcov'.PHP_EOL) && exit(1));\"",
-            "php -dextension=pcov.so -d pcov.enabled=1 vendor/bin/infection --threads=2 --min-msi=80 --min-covered-msi=80 --no-progress"
+            "php -dextension=pcov.so -d pcov.enabled=1 vendor/bin/infection --threads=2 --min-msi=90 --min-covered-msi=90 --no-progress"
         ],
         "cs": ["vendor-bin/tools/vendor/squizlabs/php_codesniffer/bin/phpcs --standard=./phpcs.xml src tests"],
         "cs-fix": ["vendor-bin/tools/vendor/squizlabs/php_codesniffer/bin/phpcbf src tests"],

--- a/infection.json5
+++ b/infection.json5
@@ -14,8 +14,8 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 80,
-    "minCoveredMsi": 80,
+    "minMsi": 90,
+    "minCoveredMsi": 90,
     "testFramework": "phpunit",
     "phpUnit": {
         "customPath": "vendor/bin/phpunit"

--- a/tests/di/AbstractModuleTest.php
+++ b/tests/di/AbstractModuleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Aop\Matcher;
+
+class AbstractModuleTest extends TestCase
+{
+    /**
+     * override() merges THIS module's bindings into the target module and then
+     * adopts that merged container. Both modules' bindings must resolve, and in
+     * particular this module's own binding must survive the merge. If the merge
+     * step is skipped, this module's binding is lost.
+     *
+     * @covers \Ray\Di\AbstractModule::override
+     */
+    public function testOverrideMergesThisModuleIntoTarget(): void
+    {
+        $base = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+            }
+        };
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeEngineInterface::class)->toInstance(new FakeEngine());
+            }
+        };
+
+        $module->override($base);
+        $container = $module->getContainer();
+
+        // the target module's binding is visible through the merged container
+        $this->assertInstanceOf(FakeRobot::class, $container->getInstance(FakeRobotInterface::class, Name::ANY));
+        // and this module's own binding survived the merge
+        $this->assertInstanceOf(FakeEngine::class, $container->getInstance(FakeEngineInterface::class, Name::ANY));
+    }
+
+    /**
+     * bindInterceptor() registers each interceptor in the container as a
+     * singleton so the woven proxy can resolve it.
+     *
+     * @covers \Ray\Di\AbstractModule::bindInterceptor
+     */
+    public function testBindInterceptorRegistersInterceptor(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+        $module->bindInterceptor((new Matcher())->any(), (new Matcher())->any(), [FakeDoubleInterceptor::class]);
+
+        $interceptor = $module->getContainer()->getInstance(FakeDoubleInterceptor::class, Name::ANY);
+        $this->assertInstanceOf(FakeDoubleInterceptor::class, $interceptor);
+    }
+
+    /**
+     * bindPriorityInterceptor() likewise registers each interceptor as a
+     * singleton in the container.
+     *
+     * @covers \Ray\Di\AbstractModule::bindPriorityInterceptor
+     */
+    public function testBindPriorityInterceptorRegistersInterceptor(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+        $module->bindPriorityInterceptor((new Matcher())->any(), (new Matcher())->any(), [FakeDoubleInterceptor::class]);
+
+        $interceptor = $module->getContainer()->getInstance(FakeDoubleInterceptor::class, Name::ANY);
+        $this->assertInstanceOf(FakeDoubleInterceptor::class, $interceptor);
+    }
+}

--- a/tests/di/ArgumentTest.php
+++ b/tests/di/ArgumentTest.php
@@ -40,4 +40,37 @@ class ArgumentTest extends TestCase
         $class = $argument->get()->getDeclaringFunction();
         $this->assertInstanceOf(ReflectionMethod::class, $class);
     }
+
+    /**
+     * A required (non-optional, no default) parameter has no default available.
+     */
+    public function testRequiredParameterHasNoDefault(): void
+    {
+        $argument = new Argument(new ReflectionParameter([FakeCar::class, '__construct'], 'engine'), Name::ANY);
+        $this->assertFalse($argument->isDefaultAvailable());
+    }
+
+    /**
+     * A parameter with an explicit default value exposes that default.
+     */
+    public function testParameterWithDefaultValue(): void
+    {
+        $argument = new Argument(new ReflectionParameter([FakeHandleProvider::class, '__construct'], 'logo'), Name::ANY);
+        $this->assertTrue($argument->isDefaultAvailable());
+        $this->assertSame('nardi', $argument->getDefaultValue());
+    }
+
+    /**
+     * A variadic parameter is optional yet has no retrievable default value.
+     *
+     * This pins the `isDefaultValueAvailable() || isOptional()` contract: a
+     * variadic is optional (so the default must be considered available) even
+     * though isDefaultValueAvailable() is false. Replacing the OR with an AND
+     * would wrongly report the default as unavailable.
+     */
+    public function testVariadicParameterIsDefaultAvailable(): void
+    {
+        $argument = new Argument(new ReflectionParameter([FakeVariadicConstructor::class, '__construct'], 'engines'), Name::ANY);
+        $this->assertTrue($argument->isDefaultAvailable());
+    }
 }

--- a/tests/di/BindTest.php
+++ b/tests/di/BindTest.php
@@ -63,6 +63,28 @@ class BindTest extends TestCase
         $this->assertArrayHasKey(FakeEngine::class . '-' . Name::ANY, $container);
     }
 
+    /**
+     * A concrete class that is already registered must NOT be re-bound as an
+     * untargeted binding. The constructor checks isRegistered("{interface}-ANY")
+     * to detect this. If the registry key is computed wrongly, the existing
+     * explicit binding would be silently overwritten by an auto-constructed one.
+     *
+     * @covers \Ray\Di\Bind::__construct
+     */
+    public function testAlreadyRegisteredConcreteClassIsNotOverwritten(): void
+    {
+        $container = new Container();
+        $engine = new FakeEngine();
+        (new Bind($container, FakeEngine::class))->toInstance($engine);
+
+        // Re-declaring a Bind for the same already-registered concrete class
+        // must be a no-op (no untargeted binding overwrites the instance).
+        $bind = new Bind($container, FakeEngine::class);
+        unset($bind);
+
+        $this->assertSame($engine, $container->getInstance(FakeEngine::class, Name::ANY));
+    }
+
     public function testUntargetedBindSingleton(): void
     {
         $container = new Container();

--- a/tests/di/ContainerTest.php
+++ b/tests/di/ContainerTest.php
@@ -12,8 +12,10 @@ use Ray\Aop\Pointcut;
 use Ray\Di\Exception\Unbound;
 use Throwable;
 
+use function array_keys;
 use function assert;
 use function get_class;
+use function sort;
 use function sys_get_temp_dir;
 
 class ContainerTest extends TestCase
@@ -134,6 +136,53 @@ class ContainerTest extends TestCase
     {
         $this->expectException(Unbound::class);
         $this->container->move(FakeEngineInterface::class, 'invalid', FakeEngineInterface::class, 'new');
+    }
+
+    /**
+     * move() must build the source index as "{interface}-{name}". With a
+     * non-empty source name the order of interface, separator and name matters:
+     * a wrong key format would fail to locate the existing named binding.
+     *
+     * @covers \Ray\Di\Container::move
+     */
+    public function testMoveNamedBinding(): void
+    {
+        $engine = new FakeEngine();
+        (new Bind($this->container, FakeEngineInterface::class))->annotatedWith('source')->toInstance($engine);
+        $this->container->move(FakeEngineInterface::class, 'source', FakeEngineInterface::class, 'target');
+
+        // moved to the new index
+        $moved = $this->container->getInstance(FakeEngineInterface::class, 'target');
+        $this->assertSame($engine, $moved);
+
+        // and removed from the old index
+        $array = $this->container->getContainer();
+        $this->assertArrayNotHasKey(FakeEngineInterface::class . '-source', $array);
+        $this->assertArrayHasKey(FakeEngineInterface::class . '-target', $array);
+    }
+
+    /**
+     * sort() must order the container by key (ksort). Bindings added out of
+     * lexicographic order must end up sorted afterwards.
+     *
+     * @covers \Ray\Di\Container::sort
+     */
+    public function testSort(): void
+    {
+        $container = new Container();
+        (new Bind($container, FakeRobotInterface::class))->to(FakeRobot::class);
+        (new Bind($container, FakeEngineInterface::class))->toInstance(new FakeEngine());
+        (new Bind($container, FakeCarInterface::class))->to(FakeCar::class);
+
+        $beforeKeys = array_keys($container->getContainer());
+        $container->sort();
+        $afterKeys = array_keys($container->getContainer());
+
+        $sorted = $beforeKeys;
+        sort($sorted);
+        $this->assertSame($sorted, $afterKeys);
+        // guard: the fixture is genuinely out of order so the test can detect a no-op sort()
+        $this->assertNotSame($beforeKeys, $afterKeys);
     }
 
     public function testAbstractClassUnbound(): void

--- a/tests/di/DependencyTest.php
+++ b/tests/di/DependencyTest.php
@@ -122,24 +122,66 @@ class DependencyTest extends TestCase
     }
 
     /**
+     * @PostConstruct must run on the assisted-injection (args) path.
+     *
+     * FakeCar::postConstruct() sets isConstructed = true only when both the
+     * constructor-injected engine and the setter-injected front tyre are present.
+     * If the postConstruct call in injectWithArgs() is removed, isConstructed
+     * stays false.
      * @dataProvider containerProvider
      * @covers \Ray\Di\Dependency::injectWithArgs
      */
     public function testInjectWithArgsPostConstruct(Container $container): void
     {
         $car = $this->dependency->injectWithArgs($container, [new FakeEngine()]);
+        assert($car instanceof FakeCar);
         $this->assertInstanceOf(FakeCar::class, $car);
+        $this->assertTrue($car->isConstructed);
     }
 
     /**
+     * The singleton fast-path of injectWithArgs() must return the very same
+     * instance on repeated calls. If the early `return $this->instance` is
+     * removed, a fresh instance is built every time and the two differ.
+     *
      * @dataProvider containerProvider
      * @covers \Ray\Di\Dependency::injectWithArgs
      */
     public function testInjectWithArgsSingleton(Container $container): void
     {
         $this->dependency->setScope(Scope::SINGLETON);
-        $this->dependency->injectWithArgs($container, [new FakeEngine()]);
-        $car = $this->dependency->injectWithArgs($container, [new FakeEngine()]);
-        $this->assertInstanceOf(FakeCar::class, $car);
+        $car1 = $this->dependency->injectWithArgs($container, [new FakeEngine()]);
+        $car2 = $this->dependency->injectWithArgs($container, [new FakeEngine()]);
+        assert(is_object($car1) && is_object($car2));
+        $this->assertInstanceOf(FakeCar::class, $car2);
+        $this->assertSame($car1, $car2);
+    }
+
+    /**
+     * @PostConstruct must run exactly once for a singleton on the args path,
+     * even though injectWithArgs() is called repeatedly. The recorded
+     * postConstruct invocation count proves the cached instance short-circuits
+     * before postConstruct runs again.
+     * @covers \Ray\Di\Dependency::injectWithArgs
+     */
+    public function testInjectWithArgsSingletonPostConstructRunsOnce(): void
+    {
+        /** @var ReflectionClass<object> $class */
+        $class = new ReflectionClass(FakePostConstructCounter::class);
+        $newInstance = new NewInstance($class, new SetterMethods([]));
+        $dependency = new Dependency($newInstance, new ReflectionMethod(FakePostConstructCounter::class, 'onPostConstruct'));
+        $dependency->setScope(Scope::SINGLETON);
+        $container = new Container();
+
+        $first = $dependency->injectWithArgs($container, ['first']);
+        $second = $dependency->injectWithArgs($container, ['second']);
+        assert($first instanceof FakePostConstructCounter);
+        assert($second instanceof FakePostConstructCounter);
+
+        $this->assertSame($first, $second);
+        // value comes from the FIRST call's arg, proving the second call was short-circuited
+        $this->assertSame('first', $second->value);
+        // postConstruct ran exactly once, not on every injectWithArgs() call
+        $this->assertSame(1, $second->postConstructCount);
     }
 }

--- a/tests/di/Fake/FakeMultiQualifierConsumer.php
+++ b/tests/di/Fake/FakeMultiQualifierConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeMultiQualifierConsumer
+{
+    #[FakeLeft]
+    #[FakeRight]
+    public function __construct(FakeEngineInterface $engine)
+    {
+    }
+}

--- a/tests/di/Fake/FakePostConstructCounter.php
+++ b/tests/di/Fake/FakePostConstructCounter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\PostConstruct;
+
+class FakePostConstructCounter
+{
+    public int $postConstructCount = 0;
+
+    public function __construct(public string $value)
+    {
+    }
+
+    #[PostConstruct]
+    public function onPostConstruct(): void
+    {
+        $this->postConstructCount++;
+    }
+}

--- a/tests/di/Fake/FakeVariadicConstructor.php
+++ b/tests/di/Fake/FakeVariadicConstructor.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeVariadicConstructor
+{
+    /** @var array<FakeEngineInterface> */
+    public array $engines;
+
+    public function __construct(FakeEngineInterface ...$engines)
+    {
+        $this->engines = $engines;
+    }
+}

--- a/tests/di/InjectionPointTest.php
+++ b/tests/di/InjectionPointTest.php
@@ -45,4 +45,19 @@ class InjectionPointTest extends TestCase
         $this->assertCount(1, $annotations);
         $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
     }
+
+    /**
+     * getQualifiers() must return every qualifier annotation on the method, not
+     * just the first one. With two qualifier attributes both must be returned.
+     */
+    public function testGetQualifiersReturnsAllQualifiers(): void
+    {
+        $parameter = new ReflectionParameter([FakeMultiQualifierConsumer::class, '__construct'], 'engine');
+        $ip = new InjectionPoint($parameter);
+        $qualifiers = $ip->getQualifiers();
+        $this->assertCount(2, $qualifiers);
+        $classes = [$qualifiers[0]::class, $qualifiers[1]::class];
+        $this->assertContains(FakeLeft::class, $classes);
+        $this->assertContains(FakeRight::class, $classes);
+    }
 }

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -42,6 +42,20 @@ class InjectorTest extends TestCase
         $this->assertSame($engine, $injector->getInstance(FakeEngine::class));
     }
 
+    /**
+     * An unbound concrete class is auto-registered as an untargeted binding:
+     * getInstance() catches Untargeted, binds the class on the fly, then
+     * resolves it. Removing that self-bind makes the retry recurse endlessly.
+     *
+     * @covers \Ray\Di\Injector::getInstance
+     */
+    public function testGetUnboundConcreteClassIsAutoBound(): void
+    {
+        $injector = new Injector(new FakeInstanceBindModule());
+        $instance = $injector->getInstance(FakeEngine::class);
+        $this->assertInstanceOf(FakeEngine::class, $instance);
+    }
+
     public function testUnbound(): void
     {
         $this->expectException(Unbound::class);

--- a/tests/di/NameTest.php
+++ b/tests/di/NameTest.php
@@ -74,4 +74,30 @@ class NameTest extends TestCase
         $boundName = $name($parameter);
         $this->assertSame('engine_name', $boundName);
     }
+
+    /**
+     * When a parameter has its own named binding, that specific name wins over
+     * the catch-all (Name::ANY) entry. This pins the lookup order of
+     * names[$parameterName] ?? names[ANY] ?? ANY.
+     */
+    public function testSpecificNameWinsOverAnyFallback(): void
+    {
+        $name = new Name(['engine' => 'specific_engine', Name::ANY => 'fallback']);
+        $parameter = new ReflectionParameter([FakeCar::class, '__construct'], 'engine');
+        $boundName = $name($parameter);
+        $this->assertSame('specific_engine', $boundName);
+    }
+
+    /**
+     * When a parameter has no specific named binding, the Name::ANY entry is
+     * used as the fallback (not the empty Name::ANY constant). This pins the
+     * middle term of names[$parameterName] ?? names[ANY] ?? ANY.
+     */
+    public function testAnyEntryUsedAsFallbackForUnnamedParameter(): void
+    {
+        $name = new Name(['gear' => 'specific_gear', Name::ANY => 'fallback']);
+        $parameter = new ReflectionParameter([FakeCar::class, '__construct'], 'engine');
+        $boundName = $name($parameter);
+        $this->assertSame('fallback', $boundName);
+    }
 }


### PR DESCRIPTION
## Summary
Builds on #315 (mutation-testing wiring). Raises the Infection mutation score on `src/di` and ratchets the gate from 80 to 90.

- Covered MSI ~87.6% → ~90.9% (100% mutation code coverage)
- Floor raised 80 → 90 in both the `composer mutation` script and `infection.json5`
- **Tests only — no `src/di` production changes**

## Notable tests added
- **`Dependency::injectWithArgs()`** — singleton identity + `@PostConstruct` runs exactly once on the assisted-injection path (the path #316 fixed, but which no test covered).
- **`Injector::getInstance()`** — an unbound concrete class is auto-registered (untargeted binding).
- **`AbstractModule` `override()` / `bindInterceptor()` / `bindPriorityInterceptor()`** — first direct tests of these public module APIs (there was no `AbstractModuleTest`).
- `Argument` variadic default (OR vs AND), `Container` move/sort, `Name` lookup precedence, `InjectionPoint` qualifier collection, `Bind` no-overwrite.

## Deliberately not killed
Equivalent mutants (`Name::ANY=''` concat variants) and contrived ones (`__wakeup` autoloaders) were left unkilled — the goal is meaningful tests, not gaming the score.

## Notes
- Buffer over the 90 floor is modest (~0.6%); if CI timeout variance ever dips below 90, kill 1–2 more or set the floor to 89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)