### PR TITLE
Fix 3 DI bugs + 3 cleanups (extracted from #314)

### DIFF
--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -87,7 +87,7 @@ abstract class AbstractModule implements Stringable
             if (class_exists($interceptor)) {
                 (new Bind($this->getContainer(), $interceptor))->to($interceptor)->in(Scope::SINGLETON);
 
-                return;
+                continue;
             }
 
             assert(interface_exists($interceptor));

--- a/src/di/BindValidator.php
+++ b/src/di/BindValidator.php
@@ -63,12 +63,12 @@ final class BindValidator
             throw new NotFound($provider);
         }
 
-        $reflectioClass = new ReflectionClass($provider);
-        if (! $reflectioClass->implementsInterface(ProviderInterface::class)) {
+        $reflectionClass = new ReflectionClass($provider);
+        if (! $reflectionClass->implementsInterface(ProviderInterface::class)) {
             throw new InvalidProvider($provider);
         }
 
-        return $reflectioClass;
+        return $reflectionClass;
     }
 
     private function isNullInterceptorBinding(string $class, string $interface): bool

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -156,7 +156,8 @@ final class Container implements InjectorInterface
      */
     public function unbound(string $index): Untargeted|Unbound
     {
-        [$class, $name] = explode('-', $index);
+        /** @psalm-suppress PossiblyUndefinedArrayOffset -- $index is always "{interface}-{name}" */
+        [$class, $name] = explode('-', $index, 2);
         if (class_exists($class) && ! (new ReflectionClass($class))->isAbstract()) {
             return new Untargeted($class);
         }

--- a/src/di/DependencyProvider.php
+++ b/src/di/DependencyProvider.php
@@ -10,6 +10,7 @@ use function sprintf;
 final class DependencyProvider implements DependencyInterface, AcceptInterface
 {
     private bool $isSingleton = false;
+    private bool $isInstantiated = false;
 
     /** @var ?mixed */
     private $instance;
@@ -52,7 +53,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
      */
     public function inject(Container $container)
     {
-        if ($this->isSingleton && $this->instance !== null) {
+        if ($this->isSingleton && $this->isInstantiated) {
             return $this->instance;
         }
 
@@ -66,6 +67,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
         $instance = $provider->get();
         if ($this->isSingleton) {
             $this->instance = $instance;
+            $this->isInstantiated = true;
         }
 
         return $instance;

--- a/src/di/InjectionPoint.php
+++ b/src/di/InjectionPoint.php
@@ -7,6 +7,7 @@ namespace Ray\Di;
 use Ray\Aop\ReflectionClass;
 use Ray\Aop\ReflectionMethod;
 use Ray\Di\Di\Qualifier;
+use ReflectionClass as CoreReflectionClass;
 use ReflectionParameter;
 
 use function assert;
@@ -26,7 +27,7 @@ final class InjectionPoint implements InjectionPointInterface
     {
         $this->pFunction = $this->parameter->getDeclaringFunction()->name;
         $class = $this->parameter->getDeclaringClass();
-        $this->pClass = $class instanceof ReflectionClass ? $class->name : '';
+        $this->pClass = $class instanceof CoreReflectionClass ? $class->name : '';
         $this->pName = $this->parameter->name;
     }
 
@@ -43,7 +44,6 @@ final class InjectionPoint implements InjectionPointInterface
      */
     public function getMethod(): ReflectionMethod
     {
-        $this->parameter = $this->getParameter();
         $class = $this->parameter->getDeclaringClass();
         $method = $this->parameter->getDeclaringFunction()->getShortName();
         assert($class instanceof \ReflectionClass);
@@ -57,7 +57,6 @@ final class InjectionPoint implements InjectionPointInterface
      */
     public function getClass(): ReflectionClass
     {
-        $this->parameter = $this->getParameter();
         $class = $this->parameter->getDeclaringClass();
         assert($class instanceof \ReflectionClass);
 
@@ -90,10 +89,19 @@ final class InjectionPoint implements InjectionPointInterface
     }
 
     /**
+     * Rebuild the ReflectionParameter dropped by serialization.
+     *
+     * The enclosing container is serialized (e.g. by ModuleString and
+     * compiled-container caches), so a restored InjectionPoint must stay usable;
+     * the typed $parameter would otherwise be left uninitialized.
+     *
      * @param array<string> $array
      */
     public function __unserialize(array $array): void
     {
         [$this->pClass, $this->pFunction, $this->pName] = $array;
+        if ($this->pClass !== '') {
+            $this->parameter = new ReflectionParameter([$this->pClass, $this->pFunction], $this->pName);
+        }
     }
 }

--- a/src/di/MultiBinder.php
+++ b/src/di/MultiBinder.php
@@ -45,7 +45,7 @@ final class MultiBinder
 
     public function setBinding(?string $key = null): self
     {
-        $this->container->multiBindings->exchangeArray([]);
+        $this->multiBindings->offsetUnset($this->interface);
         $this->key = $key;
 
         return $this;

--- a/tests/di/AbstractModuleTest.php
+++ b/tests/di/AbstractModuleTest.php
@@ -61,6 +61,28 @@ class AbstractModuleTest extends TestCase
     }
 
     /**
+     * bindInterceptor() must register EVERY interceptor in the list, not just
+     * the first one. If the loop short-circuits (returns) after binding the
+     * first class interceptor, the second one is never registered and resolving
+     * it throws Unbound.
+     *
+     * @covers \Ray\Di\AbstractModule::bindInterceptor
+     */
+    public function testBindInterceptorRegistersAllInterceptors(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+        $module->bindInterceptor((new Matcher())->any(), (new Matcher())->any(), [FakeDoubleInterceptor::class, FakeAnnoInterceptor1::class]);
+
+        $container = $module->getContainer();
+        $this->assertInstanceOf(FakeDoubleInterceptor::class, $container->getInstance(FakeDoubleInterceptor::class, Name::ANY));
+        $this->assertInstanceOf(FakeAnnoInterceptor1::class, $container->getInstance(FakeAnnoInterceptor1::class, Name::ANY));
+    }
+
+    /**
      * bindPriorityInterceptor() likewise registers each interceptor as a
      * singleton in the container.
      *

--- a/tests/di/ContainerTest.php
+++ b/tests/di/ContainerTest.php
@@ -226,6 +226,21 @@ class ContainerTest extends TestCase
         (new Container())->getInstanceWithArgs(FakeEngineInterface::class, []);
     }
 
+    /**
+     * unbound() splits "{interface}-{name}" on the FIRST hyphen only. A bind
+     * name that itself contains a hyphen (e.g. "type-bool") must be preserved
+     * whole in the resulting Unbound message; splitting on every hyphen
+     * truncates the name to its first segment.
+     *
+     * @covers \Ray\Di\Container::unbound
+     */
+    public function testUnboundPreservesHyphenatedBindName(): void
+    {
+        $exception = (new Container())->unbound('Acme\Missing-type-bool');
+        $this->assertInstanceOf(Unbound::class, $exception);
+        $this->assertStringContainsString('type-bool', $exception->getMessage());
+    }
+
     public function testWeaveAspectsWithEmptyPointcuts(): void
     {
         $container = new Container();

--- a/tests/di/DependencyProviderTest.php
+++ b/tests/di/DependencyProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class DependencyProviderTest extends TestCase
+{
+    /**
+     * A singleton provider may legitimately return null. The instance must be
+     * cached on the FIRST call and never produced again, so the provider runs
+     * exactly once. Tracking instantiation through `$instance !== null` instead
+     * of an explicit flag re-runs the provider on every call when it returns
+     * null, breaking the singleton contract.
+     *
+     * @covers \Ray\Di\DependencyProvider::inject
+     */
+    public function testSingletonProviderReturningNullIsInstantiatedOnce(): void
+    {
+        FakeNullProvider::$count = 0;
+        /** @var ReflectionClass<object> $class */
+        $class = new ReflectionClass(FakeNullProvider::class);
+        $dependency = new Dependency(new NewInstance($class, new SetterMethods([])));
+        $dependencyProvider = new DependencyProvider($dependency, 'context');
+        $dependencyProvider->setScope(Scope::SINGLETON);
+        $container = new Container();
+
+        $first = $dependencyProvider->inject($container);
+        $second = $dependencyProvider->inject($container);
+
+        $this->assertNull($first);
+        $this->assertNull($second);
+        $this->assertSame(1, FakeNullProvider::$count);
+    }
+}

--- a/tests/di/Fake/FakeIncrementInterceptor.php
+++ b/tests/di/Fake/FakeIncrementInterceptor.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+class FakeIncrementInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        return $invocation->proceed() + 1;
+    }
+}

--- a/tests/di/Fake/FakeMultiInterceptorModule.php
+++ b/tests/di/Fake/FakeMultiInterceptorModule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeMultiInterceptorModule extends AbstractModule
+{
+    protected function configure()
+    {
+        // two interceptors bound in a SINGLE bindInterceptor() call
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->any(),
+            [FakeDoubleInterceptor::class, FakeIncrementInterceptor::class]
+        );
+    }
+}

--- a/tests/di/Fake/FakeNullProvider.php
+++ b/tests/di/Fake/FakeNullProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeNullProvider implements ProviderInterface
+{
+    /** @var int */
+    public static $count = 0;
+
+    /**
+     * Legitimately provides null (e.g. an optional dependency).
+     */
+    public function get()
+    {
+        self::$count++;
+
+        return null;
+    }
+}

--- a/tests/di/InjectionPointTest.php
+++ b/tests/di/InjectionPointTest.php
@@ -7,6 +7,9 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 use ReflectionParameter;
 
+use function serialize;
+use function unserialize;
+
 class InjectionPointTest extends TestCase
 {
     /** @var InjectionPointInterface */
@@ -44,6 +47,26 @@ class InjectionPointTest extends TestCase
         $annotations = $this->ip->getQualifiers();
         $this->assertCount(1, $annotations);
         $this->assertInstanceOf(FakeConstant::class, $annotations[0]);
+    }
+
+    /**
+     * An InjectionPoint is serialized into the compiled container. After
+     * unserialize() the ReflectionParameter must be reconstructed; otherwise
+     * the typed $parameter property stays uninitialized and getParameter()/
+     * getMethod()/getClass() raise an Error on first access.
+     *
+     * @covers \Ray\Di\InjectionPoint::__unserialize
+     * @covers \Ray\Di\InjectionPoint::__serialize
+     */
+    public function testSerializeRoundTripRestoresParameter(): void
+    {
+        /** @var InjectionPoint $restored */
+        $restored = unserialize(serialize($this->ip));
+
+        $this->assertInstanceOf(ReflectionParameter::class, $restored->getParameter());
+        $this->assertSame('rightLeg', $restored->getParameter()->name);
+        $this->assertSame((string) $this->parameter->getDeclaringFunction(), (string) $restored->getMethod());
+        $this->assertSame((string) $this->parameter->getDeclaringClass(), (string) $restored->getClass());
     }
 
     /**

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -312,6 +312,26 @@ class InjectorTest extends TestCase
         $this->assertSame(4, $result);
     }
 
+    /**
+     * Multiple interceptors bound in a SINGLE bindInterceptor() call must all be
+     * registered so the woven proxy can resolve every one. Before the fix the
+     * loop returned after the first class interceptor, leaving the rest unbound;
+     * building the proxy then threw an uncaught Untargeted during weaving. Here
+     * the woven instance must build AND both interceptors must run.
+     *
+     * @covers \Ray\Di\AbstractModule::bindInterceptor
+     */
+    public function testBindInterceptorWeavesAllInterceptors(): void
+    {
+        $injector = new Injector(new FakeMultiInterceptorModule());
+        $instance = $injector->getInstance(FakeAop::class);
+        // returnSame(2) wrapped by FakeDoubleInterceptor (*2) then
+        // FakeIncrementInterceptor (+1): (2 + 1) * 2 = 6. A result of 6 proves
+        // BOTH interceptors ran; 4 would mean only the first, 2 means neither.
+        $result = $instance->returnSame(2);
+        $this->assertSame(6, $result);
+    }
+
     public function testBindOrder(): void
     {
         $injector = new Injector(new FakeAnnoModule());

--- a/tests/di/MultiBinding/MultiBinderTest.php
+++ b/tests/di/MultiBinding/MultiBinderTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use Ray\Di\FakeEngine;
 use Ray\Di\FakeEngine2;
 use Ray\Di\FakeEngineInterface;
+use Ray\Di\FakeRobot;
+use Ray\Di\FakeRobotInterface;
 use Ray\Di\MultiBinder;
 use Ray\Di\NullModule;
 
@@ -39,5 +41,28 @@ class MultiBinderTest extends TestCase
         $multiBindings = $module->getContainer()->getInstance(MultiBindings::class);
         $this->assertArrayHasKey('one', (array) $multiBindings[FakeEngineInterface::class]);
         $this->assertArrayNotHasKey('two', (array) $multiBindings[FakeEngineInterface::class]);
+    }
+
+    /**
+     * setBinding() must clear only its OWN interface's bindings, not every
+     * interface registered in the shared MultiBindings. Binding interface A,
+     * then calling setBinding() on a different interface B, must leave A's
+     * bindings intact.
+     *
+     * @covers \Ray\Di\MultiBinder::setBinding
+     */
+    public function testSetBindingDoesNotClearOtherInterfaces(): void
+    {
+        $module = new NullModule();
+        MultiBinder::newInstance($module, FakeEngineInterface::class)->addBinding('one')->to(FakeEngine::class);
+        // a different interface replaces its own bindings via setBinding()
+        MultiBinder::newInstance($module, FakeRobotInterface::class)->setBinding('robot')->to(FakeRobot::class);
+
+        /** @var MultiBindings $multiBindings */
+        $multiBindings = $module->getContainer()->getInstance(MultiBindings::class);
+        // interface A's binding survived the unrelated setBinding() call
+        $this->assertArrayHasKey('one', (array) $multiBindings[FakeEngineInterface::class]);
+        // interface B's own binding is present
+        $this->assertArrayHasKey('robot', (array) $multiBindings[FakeRobotInterface::class]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes salvaged from #314 (closed as a stale grab-bag that now conflicts with `2.x`). Each change ships a regression test that **fails on current `2.x` and passes with the change**, verified by reverting just the `src` change with the test in place.

Honest scope after investigation: **3 reachable bug fixes + 3 cleanups.** The InjectionPoint change was originally filed as a bug but turned out to have no reachable crash (see below), so it is grouped under cleanups.

## Bug fixes (reachable)

1. **`AbstractModule::bindInterceptor()` registered only the first interceptor.** The loop `return`ed after the first class-string interceptor, so passing two or more interceptors to one call left the rest unbound. Building the woven proxy resolves interceptors via `AspectBind` → the raw `Container` (no untargeted fallback), so it threw an **uncaught `Untargeted` — a hard crash** — for the perfectly normal "multiple interceptors on one pointcut" pattern. → `continue`. Covered by a unit test *and* an end-to-end weaving test (`(2 + 1) * 2 = 6`). **Highest severity.**

2. **`MultiBinder::setBinding()` wiped every interface.** `exchangeArray([])` cleared the shared `MultiBindings` for *all* interfaces, not just this binder's. Binding one interface then calling `setBinding()` on another silently discarded the first. → unset only this binder's own interface. (Triggered when `setBinding()` is used across multiple interfaces.)

3. **A singleton provider returning `null` was never cached.** The fast-path tested `$instance !== null`, so a `null`-returning singleton provider re-ran `get()` on every `inject()` call (singleton-contract violation). → explicit `$isInstantiated` flag. (Niche: needs a deliberately `null`-returning singleton provider.)

## Cleanups / correctness (no reachable bug)

4. **`InjectionPoint` serialization round-trip restored.** Its `__serialize`/`__unserialize` are genuinely exercised in production (`ModuleString` does `unserialize(serialize($container))`; compiled-container caches serialize it too), but the `ReflectionParameter` rebuild had been dismantled by two unrelated changes: a 2023 import swap to `Ray\Aop\ReflectionClass` made the constructor's `instanceof` always false (so `$pClass` was always empty), and a 2025 Rector pass dropped `getParameter()`'s lazy-rebuild as "dead code" after typing the property non-null. **No reachable crash, though:** an `xtrace` confirms `ModuleString` round-trips an InjectionPoint but never calls `getParameter()/getMethod()/getClass()` on the restored instance, and live consumers (`MapProvider`, `ProviderSetProvider`) always get a freshly-constructed one. This restores round-trip correctness; the test pins the contract. Provenance is in the commit message.

5. **`Container::unbound()` error message preserved hyphenated bind names.** `explode('-', $index)` split a name like `type-bool` into the wrong segments, so the `Unbound` message showed `type`. Error-path text only — no behavioural impact. → `explode('-', $index, 2)`.

6. **Typo** `$reflectioClass` → `$reflectionClass` in `BindValidator` (local-variable rename).

## Dropped from #314

Cosmetic / competing / already-landed changes were intentionally left out: the `weaveAspects` reflection consolidation, the `SetterMethod` `is_callable`→`psalm-suppress` swap, `call_user_func_array`→spread, the `Injector::getInstance()` recursion tweak, the larger `MultiBindings` encapsulation refactor, and the PHP 8.4 static-analysis bump (already in `2.x`).

## Verification

- `composer test` — 201 tests / 301 assertions, green on PHP 8.4 **and** 8.5
- `composer cs` — clean
- Psalm + PHPStan — no errors (PHP 8.4)

Replaces #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interceptor registration so all interceptors in multi-interceptor setups are applied.
  * Corrected unbound error formatting to preserve hyphenated binding names.
  * Improved singleton-scoped dependency injection to cache and reuse nullable (`null`) results.
  * Enhanced injection point serialization so round-trips restore reflection details correctly.
  * Adjusted multi-binding updates to avoid clearing bindings for other interfaces.

* **Tests**
  * Added regression and round-trip coverage for multi-interceptor weaving, hyphenated unbound messages, `null` singletons, injection point serialization, and multi-binding isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->