### PR TITLE
Fix InjectionPoint corrupted by a provider's own constructor dependencies

### DIFF
--- a/src/di/Arguments.php
+++ b/src/di/Arguments.php
@@ -57,7 +57,10 @@ final class Arguments implements AcceptInterface
      */
     private function getParameter(Container $container, Argument $argument)
     {
-        $this->bindInjectionPoint($container, $argument);
+        $isInjectionPointItself = (string) $argument === InjectionPointInterface::class . '-' . Name::ANY;
+        $previousInjectionPoint = $isInjectionPointItself
+            ? null
+            : $container->setInjectionPoint(new InjectionPoint($argument->get()));
         try {
             return $container->getDependency((string) $argument);
         } catch (Unbound $unbound) {
@@ -70,17 +73,11 @@ final class Arguments implements AcceptInterface
             }
 
             throw new Unbound($argument->getMeta(), 0, $unbound);
+        } finally {
+            if (! $isInjectionPointItself) {
+                $container->restoreInjectionPoint($previousInjectionPoint);
+            }
         }
-    }
-
-    private function bindInjectionPoint(Container $container, Argument $argument): void
-    {
-        $isSelf = (string) $argument === InjectionPointInterface::class . '-' . Name::ANY;
-        if ($isSelf) {
-            return;
-        }
-
-        $container->setInjectionPoint(new InjectionPoint($argument->get()));
     }
 
     private function getNoHintMsg(Argument $argument): string

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -61,11 +61,37 @@ final class Container implements InjectorInterface
     }
 
     /**
+     * Set the current injection point, returning the previous one so it can be restored
+     *
      * @internal
      */
-    public function setInjectionPoint(InjectionPointInterface $ip): void
+    public function setInjectionPoint(InjectionPointInterface $ip): ?InjectionPointInterface
     {
-        $this->container[InjectionPointInterface::class . '-' . Name::ANY] = new Instance($ip);
+        $key = InjectionPointInterface::class . '-' . Name::ANY;
+        $existing = $this->container[$key] ?? null;
+        $previous = $existing instanceof Instance && $existing->value instanceof InjectionPointInterface
+            ? $existing->value
+            : null;
+        $this->container[$key] = new Instance($ip);
+
+        return $previous;
+    }
+
+    /**
+     * Restore a previously saved injection point
+     *
+     * @internal
+     */
+    public function restoreInjectionPoint(?InjectionPointInterface $ip): void
+    {
+        $key = InjectionPointInterface::class . '-' . Name::ANY;
+        if ($ip === null) {
+            unset($this->container[$key]);
+
+            return;
+        }
+
+        $this->container[$key] = new Instance($ip);
     }
 
     /**

--- a/tests/di/Fake/FakeWalkRobotLegProviderWithOtherDep.php
+++ b/tests/di/Fake/FakeWalkRobotLegProviderWithOtherDep.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use InvalidArgumentException;
+
+class FakeWalkRobotLegProviderWithOtherDep implements ProviderInterface
+{
+    /** @var InjectionPointInterface */
+    private $ip;
+
+    public function __construct(FakeRobotInterface $robot, InjectionPointInterface $ip)
+    {
+        $this->ip = $ip;
+    }
+
+    public function get()
+    {
+        $varName = $this->ip->getParameter()->getName();
+        if ($varName === 'leftLeg') {
+            return new FakeLeftLeg();
+        }
+
+        if ($varName === 'rightLeg') {
+            return new FakeRightLeg();
+        }
+
+        throw new InvalidArgumentException('Unexpected var name for LegInterface: ' . $varName);
+    }
+}

--- a/tests/di/Fake/FakeWalkRobotOtherDepModule.php
+++ b/tests/di/Fake/FakeWalkRobotOtherDepModule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeWalkRobotOtherDepModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+        $this->bind(FakeLegInterface::class)->toProvider(FakeWalkRobotLegProviderWithOtherDep::class);
+    }
+}

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -355,6 +355,19 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeRightLeg::class, $robot->rightLeg);
     }
 
+    /**
+     * When a provider's constructor requests another dependency before
+     * InjectionPointInterface, resolving that other dependency overwrites
+     * the container's current injection point before the provider reads it.
+     */
+    public function testContextualDependencyInjectionWithOtherProviderDependency(): void
+    {
+        $injector = new Injector(new FakeWalkRobotOtherDepModule());
+        $robot = $injector->getInstance(FakeWalkRobot::class);
+        $this->assertInstanceOf(FakeLeftLeg::class, $robot->leftLeg);
+        $this->assertInstanceOf(FakeRightLeg::class, $robot->rightLeg);
+    }
+
     public function testNewAbstract(): void
     {
         $this->expectException(Unbound::class);


### PR DESCRIPTION
## Summary
- `InjectionPointInterface` injected into a `toProvider()` class could report the wrong injection target when the provider's own constructor had another dependency declared before it
- `Container` kept the "current injection point" in a single mutable slot with no way to restore the previous value, so resolving the provider's own dependency clobbered it before the provider read it
- Added a red test that reproduces the corruption, then fixed `Container`/`Arguments` to save and restore the injection point around each argument's resolution

## Root cause
`Arguments::getParameter()` sets the container's "current injection point" right before resolving each constructor argument, then never restores it. For a normal provider whose constructor only takes `InjectionPointInterface`, this happens to work because nothing else runs in between. But if the provider's constructor requests another dependency first, e.g.:

```php
final class LoggerProvider implements ProviderInterface
{
    public function __construct(
        private SomeOtherDependency $other,
        private InjectionPointInterface $ip,
    ) {
    }
}
```

resolving `$other` overwrites the slot with `LoggerProvider`'s own constructor parameter info before `$ip` is read, so `getClass()`/`getMethod()`/`getParameter()` return details about the provider itself instead of the class that actually depends on `LoggerInterface`.

## Fix
- `Container::setInjectionPoint()` now returns the previous value instead of `void`
- Added `Container::restoreInjectionPoint()` to put it back
- `Arguments::getParameter()` wraps dependency resolution in `try/finally` and restores the previous injection point once the current argument is resolved, so a provider's own dependency resolution no longer leaks into sibling arguments

## Verification
- Added `FakeWalkRobotLegProviderWithOtherDep` / `FakeWalkRobotOtherDepModule` and `InjectorTest::testContextualDependencyInjectionWithOtherProviderDependency`, which fails on `2.x` (`InvalidArgumentException: Unexpected var name for LegInterface: robot`) and passes with this fix
- `composer test` — 202 tests / 303 assertions, green (PHP 8.3)
- Psalm + PHPStan — no errors on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contextual dependency injection when providers have additional dependencies.
  * Preserved and restored injection-point context during dependency resolution, preventing context leakage between resolutions.

* **Tests**
  * Added coverage for providers that resolve other dependencies before reading the injection point.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->