### PR TITLE
Refactor module introspection: tree __toString(), toJson() export, structural target extraction

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,3 @@ jobs:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
       php_version: 8.4
-      has_crc_config: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,21 +10,4 @@ jobs:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
       php_version: 8.4
-
-  # Local ComposerRequireChecker that actually works
-  # The shared workflow's version crashes with exit code 255
-  composer-require-checker:
-    runs-on: ubuntu-latest
-    name: ComposerRequireChecker (local)
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress
-      - name: Install ComposerRequireChecker
-        run: composer global require maglnet/composer-require-checker
-      - name: Run ComposerRequireChecker
-        run: composer-require-checker check ./composer.json --config-file=./composer-require-checker.json
+      has_crc_config: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,8 @@ jobs:
     with:
       php_version: 8.4
 
+  # Local ComposerRequireChecker that actually works
+  # The shared workflow's version crashes with exit code 255
   composer-require-checker:
     runs-on: ubuntu-latest
     name: ComposerRequireChecker (local)
@@ -20,7 +22,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          tools: composer:v2
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
       - name: Install ComposerRequireChecker

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,3 +10,4 @@ jobs:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
       php_version: 8.4
+      has_crc_config: true

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,3 +10,23 @@ jobs:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
       php_version: 8.4
+
+  # Custom ComposerRequireChecker job that always uses config file
+  # This replaces the shared workflow's broken ComposerRequireChecker
+  composer-require-checker-local:
+    runs-on: ubuntu-latest
+    name: ComposerRequireChecker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Download ComposerRequireChecker
+        run: |
+          curl -sLO https://github.com/maglnet/ComposerRequireChecker/releases/latest/download/composer-require-checker.phar
+          chmod +x composer-require-checker.phar
+      - name: Run ComposerRequireChecker
+        run: php composer-require-checker.phar check ./composer.json --config-file=./composer-require-checker.json

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,22 +11,19 @@ jobs:
     with:
       php_version: 8.4
 
-  # Custom ComposerRequireChecker job that always uses config file
-  # This replaces the shared workflow's broken ComposerRequireChecker
-  composer-require-checker-local:
+  composer-require-checker:
     runs-on: ubuntu-latest
-    name: ComposerRequireChecker
+    name: ComposerRequireChecker (local)
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          tools: composer:v2
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
-      - name: Download ComposerRequireChecker
-        run: |
-          curl -sLO https://github.com/maglnet/ComposerRequireChecker/releases/latest/download/composer-require-checker.phar
-          chmod +x composer-require-checker.phar
+      - name: Install ComposerRequireChecker
+        run: composer global require maglnet/composer-require-checker
       - name: Run ComposerRequireChecker
-        run: php composer-require-checker.phar check ./composer.json --config-file=./composer-require-checker.json
+        run: composer-require-checker check ./composer.json --config-file=./composer-require-checker.json

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "ext-json": "*",
         "koriym/null-object": "^1.0",
         "ray/aop": "^2.19"
     },

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -64,6 +64,14 @@ abstract class AbstractModule implements Stringable
     }
 
     /**
+     * Return module bindings as JSON string
+     */
+    public function toJson(): string
+    {
+        return (new ModuleJson())($this->getContainer(), $this->getContainer()->getPointcuts());
+    }
+
+    /**
      * Install module
      */
     public function install(self $module): void

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -65,6 +65,10 @@ abstract class AbstractModule implements Stringable
 
     /**
      * Return module bindings as JSON string
+     *
+     * Introspection deep-copies the container via serialize()/unserialize()
+     * (as __toString() does), so modules holding unserializable instances —
+     * e.g. a closure bound with toInstance() — are not supported.
      */
     public function toJson(): string
     {

--- a/src/di/AopCollector.php
+++ b/src/di/AopCollector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use LogicException;
+use Ray\Aop\BindInterface;
+use Ray\Aop\CompilerInterface;
+
+use function method_exists;
+
+/**
+ * Collects AOP bindings for a dependency
+ *
+ * @psalm-import-type PointcutList from Types
+ * @psalm-type AopBindings = array<string, list<string>>
+ */
+final class AopCollector implements CompilerInterface
+{
+    /** @var AopBindings */
+    private array $bindings = [];
+
+    /**
+     * @param PointcutList $pointcuts
+     *
+     * @return AopBindings
+     */
+    public function collect(Dependency $dependency, array $pointcuts): array
+    {
+        $this->bindings = [];
+        $dependency->weaveAspects($this, $pointcuts);
+
+        return $this->bindings;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return never
+     */
+    public function newInstance(string $class, array $args, BindInterface $bind)
+    {
+        throw new LogicException('AopCollector::newInstance() should never be called');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function compile(string $class, BindInterface $bind): string
+    {
+        $bindings = $bind->getBindings();
+        if (! $bindings) {
+            return $class;
+        }
+
+        foreach ($bindings as $method => $interceptors) {
+            if (! method_exists($class, $method)) {
+                continue;
+            }
+
+            /** @var list<string> $interceptors */
+            $this->bindings[$method] = $interceptors;
+        }
+
+        return $class;
+    }
+}

--- a/src/di/AopCollector.php
+++ b/src/di/AopCollector.php
@@ -38,6 +38,8 @@ final class AopCollector implements CompilerInterface
      * {@inheritDoc}
      *
      * @return never
+     *
+     * @codeCoverageIgnore
      */
     public function newInstance(string $class, array $args, BindInterface $bind)
     {
@@ -51,12 +53,12 @@ final class AopCollector implements CompilerInterface
     {
         $bindings = $bind->getBindings();
         if (! $bindings) {
-            return $class;
+            return $class; // @codeCoverageIgnore
         }
 
         foreach ($bindings as $method => $interceptors) {
             if (! method_exists($class, $method)) {
-                continue;
+                continue; // @codeCoverageIgnore
             }
 
             /** @var list<string> $interceptors */

--- a/src/di/BindingIndex.php
+++ b/src/di/BindingIndex.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use function strrpos;
+use function substr;
+
+final class BindingIndex
+{
+    /**
+     * @return array{string, string}
+     */
+    public static function parse(string $index): array
+    {
+        $pos = strrpos($index, '-');
+        if ($pos === false) {
+            return [$index, Name::ANY];
+        }
+
+        return [substr($index, 0, $pos), substr($index, $pos + 1)];
+    }
+}

--- a/src/di/BindingIndex.php
+++ b/src/di/BindingIndex.php
@@ -16,7 +16,7 @@ final class BindingIndex
     {
         $pos = strrpos($index, '-');
         if ($pos === false) {
-            return [$index, Name::ANY];
+            return [$index, Name::ANY]; // @codeCoverageIgnore
         }
 
         return [substr($index, 0, $pos), substr($index, $pos + 1)];

--- a/src/di/BindingIndex.php
+++ b/src/di/BindingIndex.php
@@ -4,21 +4,29 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-use function strrpos;
-use function substr;
+use function explode;
 
+/**
+ * Single source of truth for the '{interface}-{name}' dependency index format
+ *
+ * Container keys are always built as interface . '-' . name.
+ */
 final class BindingIndex
 {
     /**
+     * Split a dependency index into [interface, bind name]
+     *
+     * Splits on the FIRST hyphen only: PHP class names cannot contain
+     * hyphens, but bind names can (e.g. 'type-bool'), so everything after
+     * the first hyphen belongs to the name.
+     *
      * @return array{string, string}
      */
     public static function parse(string $index): array
     {
-        $pos = strrpos($index, '-');
-        if ($pos === false) {
-            return [$index, Name::ANY]; // @codeCoverageIgnore
-        }
+        /** @psalm-suppress PossiblyUndefinedArrayOffset -- $index is always "{interface}-{name}" */
+        [$interface, $name] = explode('-', $index, 2);
 
-        return [substr($index, 0, $pos), substr($index, $pos + 1)];
+        return [$interface, $name];
     }
 }

--- a/src/di/BindingTargetVisitor.php
+++ b/src/di/BindingTargetVisitor.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\Bind as AopBind;
+use ReflectionParameter;
+
+/**
+ * Collects what a binding resolves to, as structured data
+ *
+ * Visiting yields the bound class for a Dependency, the provider class and
+ * its context for a DependencyProvider, and the raw value for an Instance,
+ * so that callers do not have to parse __toString() output.
+ */
+final class BindingTargetVisitor implements VisitorInterface
+{
+    /** Captured by visitNewInstance(): the class the visited binding instantiates */
+    private string $class = '';
+
+    /**
+     * Return the class a binding instantiates
+     *
+     * The bound class for a Dependency, the provider class for a
+     * DependencyProvider. Offered as a typed entry point because accept()
+     * returns mixed, which every caller would otherwise have to re-assert.
+     */
+    public function targetClass(Dependency|DependencyProvider $dependency): string
+    {
+        $dependency->accept($this);
+
+        return $this->class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return string The class the dependency instantiates
+     */
+    public function visitDependency(NewInstance $newInstance, ?string $postConstruct, bool $isSingleton): string
+    {
+        $newInstance->accept($this);
+
+        return $this->class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array{class: string, context: string} Provider class and binding context
+     */
+    public function visitProvider(Dependency $dependency, string $context, bool $isSingleton): array
+    {
+        $dependency->accept($this);
+
+        return ['class' => $this->class, 'context' => $context];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param mixed $value
+     *
+     * @return mixed The raw bound value
+     */
+    public function visitInstance($value)
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Aspect bindings carry no target information.
+     */
+    public function visitAspectBind(AopBind $aopBind)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * NewInstance::accept() discards the return value, so the class name is
+     * captured in a property for visitDependency()/visitProvider() to read.
+     */
+    public function visitNewInstance(
+        string $class,
+        SetterMethods $setterMethods,
+        ?Arguments $arguments,
+        ?AspectBind $bind
+    ): void {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Setter methods carry no target information.
+     */
+    public function visitSetterMethods(array $setterMethods)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Setter methods carry no target information.
+     */
+    public function visitSetterMethod(string $method, Arguments $arguments)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Arguments carry no target information.
+     */
+    public function visitArguments(array $arguments)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Arguments carry no target information.
+     *
+     * @param mixed $defaultValue
+     */
+    public function visitArgument(
+        string $index,
+        bool $isDefaultAvailable,
+        $defaultValue,
+        ReflectionParameter $parameter
+    ) {
+        return null;
+    }
+}

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -19,7 +19,6 @@ use ReflectionClass;
 use function array_keys;
 use function array_merge;
 use function class_exists;
-use function explode;
 use function implode;
 use function ksort;
 use function sprintf;
@@ -195,8 +194,7 @@ final class Container implements InjectorInterface
      */
     public function unbound(string $index): Untargeted|Unbound
     {
-        /** @psalm-suppress PossiblyUndefinedArrayOffset -- $index is always "{interface}-{name}" */
-        [$class, $name] = explode('-', $index, 2);
+        [$class, $name] = BindingIndex::parse($index);
         if (class_exists($class) && ! (new ReflectionClass($class))->isAbstract()) {
             return new Untargeted($class);
         }

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -110,7 +110,8 @@ final class ModuleJson
     {
         $dependencyString = (string) $dependency;
         // Extract class name from "(dependency) ClassName" or "(dependency) ClassName (aop) ..."
-        $className = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $dependencyString) ?? '';
+        /** @var string $className preg_replace won't return null with valid pattern */
+        $className = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $dependencyString);
 
         $entry = [
             'interface' => $interface,
@@ -133,7 +134,8 @@ final class ModuleJson
     {
         $providerString = (string) $dependency;
         // Extract provider class name from "(provider) (dependency) ProviderClassName"
-        $providerClass = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $providerString) ?? '';
+        /** @var string $providerClass preg_replace won't return null with valid pattern */
+        $providerClass = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $providerString);
 
         return [
             'interface' => $interface,

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -36,7 +36,7 @@ final class ModuleJson
 
         $json = json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         if ($json === false) {
-            return '{"bindings":[]}';
+            return '{"bindings":[]}'; // @codeCoverageIgnore
         }
 
         return $json;
@@ -100,7 +100,7 @@ final class ModuleJson
             ];
         }
 
-        return null;
+        return null; // @codeCoverageIgnore
     }
 
     /**

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use function gettype;
+use function is_object;
+use function is_scalar;
+use function json_encode;
+use function preg_replace;
+use function serialize;
+use function strrpos;
+use function substr;
+use function unserialize;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * @psalm-import-type PointcutList from Types
+ * @psalm-type BindingType = 'class'|'provider'|'instance'
+ * @psalm-type AopBindings = array<string, list<string>>
+ * @psalm-type BindingEntry = array{interface: string, name: string, type: BindingType, to: mixed, aop?: AopBindings}
+ * @psalm-type ModuleBindings = array{bindings: list<BindingEntry>}
+ */
+final class ModuleJson
+{
+    private const SCHEMA = 'https://ray-di.github.io/schemas/module.schema.json';
+
+    /**
+     * @param PointcutList $pointcuts
+     */
+    public function __invoke(Container $container, array $pointcuts): string
+    {
+        $bindings = $this->getBindings($container, $pointcuts);
+
+        return json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+    }
+
+    /**
+     * @param PointcutList $pointcuts
+     *
+     * @return ModuleBindings
+     */
+    public function getBindings(Container $container, array $pointcuts): array
+    {
+        /** @psalm-suppress MixedAssignment */
+        $container = unserialize(serialize($container), ['allowed_classes' => true]);
+        /** @var Container $container */
+        $collector = new AopCollector();
+        $entries = [];
+
+        foreach ($container->getContainer() as $dependencyIndex => $dependency) {
+            $aopBindings = [];
+            if ($dependency instanceof Dependency) {
+                $aopBindings = $collector->collect($dependency, $pointcuts);
+            }
+
+            $entry = $this->createEntry($dependencyIndex, $dependency, $aopBindings);
+            if ($entry !== null) {
+                $entries[] = $entry;
+            }
+        }
+
+        return ['bindings' => $entries];
+    }
+
+    /**
+     * @param AopBindings $aopBindings
+     *
+     * @return BindingEntry|null
+     */
+    private function createEntry(string $dependencyIndex, DependencyInterface $dependency, array $aopBindings): ?array
+    {
+        [$interface, $name] = $this->parseIndex($dependencyIndex);
+
+        if ($dependency instanceof Dependency) {
+            return $this->createDependencyEntry($interface, $name, $dependency, $aopBindings);
+        }
+
+        if ($dependency instanceof DependencyProvider) {
+            return $this->createProviderEntry($interface, $name, $dependency);
+        }
+
+        if ($dependency instanceof Instance) {
+            return $this->createInstanceEntry($interface, $name, $dependency);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function parseIndex(string $index): array
+    {
+        $pos = strrpos($index, '-');
+        if ($pos === false) {
+            return [$index, Name::ANY];
+        }
+
+        return [substr($index, 0, $pos), substr($index, $pos + 1)];
+    }
+
+    /**
+     * @param AopBindings $aopBindings
+     *
+     * @return BindingEntry
+     */
+    private function createDependencyEntry(string $interface, string $name, Dependency $dependency, array $aopBindings): array
+    {
+        $dependencyString = (string) $dependency;
+        // Extract class name from "(dependency) ClassName" or "(dependency) ClassName (aop) ..."
+        $className = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $dependencyString) ?? '';
+
+        $entry = [
+            'interface' => $interface,
+            'name' => $name,
+            'type' => 'class',
+            'to' => $className,
+        ];
+
+        if ($aopBindings !== []) {
+            $entry['aop'] = $aopBindings;
+        }
+
+        /** @var BindingEntry $entry */
+        return $entry;
+    }
+
+    /**
+     * @return BindingEntry
+     */
+    private function createProviderEntry(string $interface, string $name, DependencyProvider $dependency): array
+    {
+        $providerString = (string) $dependency;
+        // Extract provider class name from "(provider) (dependency) ProviderClassName"
+        $providerClass = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $providerString) ?? '';
+
+        return [
+            'interface' => $interface,
+            'name' => $name,
+            'type' => 'provider',
+            'to' => $providerClass,
+        ];
+    }
+
+    /**
+     * @return BindingEntry
+     */
+    private function createInstanceEntry(string $interface, string $name, Instance $dependency): array
+    {
+        $value = $dependency->value;
+
+        return [
+            'interface' => $interface,
+            'name' => $name,
+            'type' => 'instance',
+            'to' => $this->formatValue($value),
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function formatValue($value)
+    {
+        if (is_scalar($value) || $value === null) {
+            return $value;
+        }
+
+        if (is_object($value)) {
+            return ['__class' => $value::class];
+        }
+
+        return ['__type' => gettype($value)];
+    }
+}

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -20,7 +20,7 @@ use const JSON_UNESCAPED_UNICODE;
 
 /**
  * @psalm-import-type PointcutList from Types
- * @psalm-type BindingType = 'class'|'provider'|'instance'
+ * @psalm-type BindingType = 'class'|'provider'|'instance'|'null'
  * @psalm-type AopBindings = array<string, list<string>>
  * @psalm-type BindingEntry = array{interface: string, name: string, type: BindingType, to: mixed, aop?: AopBindings}
  * @psalm-type ModuleBindings = array{bindings: list<BindingEntry>}
@@ -35,8 +35,11 @@ final class ModuleJson
         $bindings = $this->getBindings($container, $pointcuts);
 
         $json = json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($json === false) {
+            return '{"bindings":[]}';
+        }
 
-        return $json === false ? '{}' : $json;
+        return $json;
     }
 
     /**
@@ -86,6 +89,15 @@ final class ModuleJson
 
         if ($dependency instanceof Instance) {
             return $this->createInstanceEntry($interface, $name, $dependency);
+        }
+
+        if ($dependency instanceof NullObjectDependency) {
+            return [
+                'interface' => $interface,
+                'name' => $name,
+                'type' => 'null',
+                'to' => null,
+            ];
         }
 
         return null;

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -11,6 +11,7 @@ use function json_encode;
 use function serialize;
 use function unserialize;
 
+use const JSON_INVALID_UTF8_SUBSTITUTE;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
@@ -36,7 +37,9 @@ final class ModuleJson
     {
         $bindings = $this->getBindings($container, $pointcuts);
 
-        $json = json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        // JSON_INVALID_UTF8_SUBSTITUTE: one binary toInstance() value must not
+        // erase the whole diagnostics report
+        $json = json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
         if ($json === false) {
             return '{"bindings":[]}'; // @codeCoverageIgnore
         }

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -8,7 +8,6 @@ use function gettype;
 use function is_object;
 use function is_scalar;
 use function json_encode;
-use function preg_replace;
 use function serialize;
 use function unserialize;
 
@@ -25,6 +24,11 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final class ModuleJson
 {
+    public function __construct(
+        private BindingTargetVisitor $targetVisitor = new BindingTargetVisitor()
+    ) {
+    }
+
     /**
      * @param PointcutList $pointcuts
      */
@@ -108,16 +112,11 @@ final class ModuleJson
      */
     private function createDependencyEntry(string $interface, string $name, Dependency $dependency, array $aopBindings): array
     {
-        $dependencyString = (string) $dependency;
-        // Extract class name from "(dependency) ClassName" or "(dependency) ClassName (aop) ..."
-        /** @var string $className preg_replace won't return null with valid pattern */
-        $className = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $dependencyString);
-
         $entry = [
             'interface' => $interface,
             'name' => $name,
             'type' => 'class',
-            'to' => $className,
+            'to' => $this->targetVisitor->targetClass($dependency),
         ];
 
         if ($aopBindings !== []) {
@@ -132,16 +131,11 @@ final class ModuleJson
      */
     private function createProviderEntry(string $interface, string $name, DependencyProvider $dependency): array
     {
-        $providerString = (string) $dependency;
-        // Extract provider class name from "(provider) (dependency) ProviderClassName"
-        /** @var string $providerClass preg_replace won't return null with valid pattern */
-        $providerClass = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $providerString);
-
         return [
             'interface' => $interface,
             'name' => $name,
             'type' => 'provider',
-            'to' => $providerClass,
+            'to' => $this->targetVisitor->targetClass($dependency),
         ];
     }
 
@@ -150,14 +144,11 @@ final class ModuleJson
      */
     private function createInstanceEntry(string $interface, string $name, Instance $dependency): array
     {
-        /** @psalm-suppress MixedAssignment */
-        $value = $dependency->value;
-
         return [
             'interface' => $interface,
             'name' => $name,
             'type' => 'instance',
-            'to' => $this->formatValue($value),
+            'to' => $this->formatValue($dependency->accept($this->targetVisitor)),
         ];
     }
 

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -34,7 +34,9 @@ final class ModuleJson
     {
         $bindings = $this->getBindings($container, $pointcuts);
 
-        return json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '{}';
+        $json = json_encode($bindings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $json === false ? '{}' : $json;
     }
 
     /**
@@ -149,6 +151,7 @@ final class ModuleJson
      */
     private function createInstanceEntry(string $interface, string $name, Instance $dependency): array
     {
+        /** @psalm-suppress MixedAssignment */
         $value = $dependency->value;
 
         return [

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -27,8 +27,6 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final class ModuleJson
 {
-    private const SCHEMA = 'https://ray-di.github.io/schemas/module.schema.json';
-
     /**
      * @param PointcutList $pointcuts
      */
@@ -126,7 +124,6 @@ final class ModuleJson
             $entry['aop'] = $aopBindings;
         }
 
-        /** @var BindingEntry $entry */
         return $entry;
     }
 

--- a/src/di/ModuleJson.php
+++ b/src/di/ModuleJson.php
@@ -10,8 +10,6 @@ use function is_scalar;
 use function json_encode;
 use function preg_replace;
 use function serialize;
-use function strrpos;
-use function substr;
 use function unserialize;
 
 use const JSON_PRETTY_PRINT;
@@ -77,7 +75,7 @@ final class ModuleJson
      */
     private function createEntry(string $dependencyIndex, DependencyInterface $dependency, array $aopBindings): ?array
     {
-        [$interface, $name] = $this->parseIndex($dependencyIndex);
+        [$interface, $name] = BindingIndex::parse($dependencyIndex);
 
         if ($dependency instanceof Dependency) {
             return $this->createDependencyEntry($interface, $name, $dependency, $aopBindings);
@@ -101,19 +99,6 @@ final class ModuleJson
         }
 
         return null; // @codeCoverageIgnore
-    }
-
-    /**
-     * @return array{string, string}
-     */
-    private function parseIndex(string $index): array
-    {
-        $pos = strrpos($index, '-');
-        if ($pos === false) {
-            return [$index, Name::ANY];
-        }
-
-        return [substr($index, 0, $pos), substr($index, $pos + 1)];
     }
 
     /**

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -14,7 +14,6 @@ use function is_scalar;
 use function ksort;
 use function preg_replace;
 use function serialize;
-use function sprintf;
 use function strrpos;
 use function substr;
 use function unserialize;
@@ -40,12 +39,23 @@ final class ModuleString
         $groups = $this->groupByInterface($container, $pointcuts);
         ksort($groups);
 
-        $output = [];
-        foreach ($groups as $interface => $bindings) {
-            $output[] = $this->renderGroup($interface, $bindings);
+        $lines = ['module'];
+        $interfaces = array_keys($groups);
+        $interfaceCount = count($interfaces);
+
+        foreach ($interfaces as $i => $interface) {
+            $isLast = $i === $interfaceCount - 1;
+            $branch = $isLast ? '└──' : '├──';
+            $continuation = $isLast ? '    ' : '│   ';
+
+            $groupLines = $this->renderGroup($interface, $groups[$interface]);
+            $lines[] = $branch . ' ' . $groupLines[0];
+            for ($j = 1, $n = count($groupLines); $j < $n; $j++) {
+                $lines[] = $continuation . $groupLines[$j];
+            }
         }
 
-        return implode(PHP_EOL . PHP_EOL, $output);
+        return implode(PHP_EOL, $lines);
     }
 
     /**
@@ -89,8 +99,10 @@ final class ModuleString
 
     /**
      * @param list<array{name: string, dependency: DependencyInterface, aop: array<string, list<string>>}> $bindings
+     *
+     * @return list<string>
      */
-    private function renderGroup(string $interface, array $bindings): string
+    private function renderGroup(string $interface, array $bindings): array
     {
         $header = $interface === '' ? "''" : $interface;
         $lines = [$header];
@@ -111,7 +123,7 @@ final class ModuleString
             }
         }
 
-        return implode(PHP_EOL, $lines);
+        return $lines;
     }
 
     private function renderBinding(string $name, DependencyInterface $dependency): string

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -11,6 +11,7 @@ use function gettype;
 use function implode;
 use function is_object;
 use function is_scalar;
+use function is_string;
 use function ksort;
 use function preg_replace;
 use function serialize;
@@ -175,11 +176,7 @@ final class ModuleString
         }
 
         if (is_scalar($value)) {
-            if (gettype($value) === 'string') {
-                return var_export($value, true);
-            }
-
-            return (string) $value;
+            return is_string($value) ? var_export($value, true) : (string) $value;
         }
 
         if (is_object($value)) {

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -15,8 +15,6 @@ use function ksort;
 use function preg_replace;
 use function serialize;
 use function sort;
-use function strrpos;
-use function substr;
 use function unserialize;
 use function usort;
 use function var_export;
@@ -70,7 +68,7 @@ final class ModuleString
         $groups = [];
 
         foreach ($container->getContainer() as $dependencyIndex => $dependency) {
-            [$interface, $name] = $this->parseIndex($dependencyIndex);
+            [$interface, $name] = BindingIndex::parse($dependencyIndex);
             $aop = $dependency instanceof Dependency
                 ? $collector->collect($dependency, $pointcuts)
                 : [];
@@ -83,19 +81,6 @@ final class ModuleString
         }
 
         return $groups;
-    }
-
-    /**
-     * @return array{string, string}
-     */
-    private function parseIndex(string $index): array
-    {
-        $pos = strrpos($index, '-');
-        if ($pos === false) {
-            return [$index, Name::ANY];
-        }
-
-        return [substr($index, 0, $pos), substr($index, $pos + 1)];
     }
 
     /**

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -14,6 +14,7 @@ use function is_scalar;
 use function ksort;
 use function preg_replace;
 use function serialize;
+use function sort;
 use function strrpos;
 use function substr;
 use function unserialize;
@@ -224,6 +225,7 @@ final class ModuleString
     private function renderAop(array $aop): array
     {
         $methods = array_keys($aop);
+        sort($methods);
         $lines = [];
         $count = count($methods);
 

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -105,7 +105,9 @@ final class ModuleString
 
             if ($binding['aop'] !== []) {
                 $aopPrefix = $isLast ? '    ' : '│   ';
-                $lines[] = $aopPrefix . $this->renderAop($binding['aop']);
+                foreach ($this->renderAop($binding['aop']) as $aopLine) {
+                    $lines[] = $aopPrefix . $aopLine;
+                }
             }
         }
 
@@ -200,8 +202,10 @@ final class ModuleString
 
     /**
      * @param array<string, list<string>> $aop
+     *
+     * @return list<string>
      */
-    private function renderAop(array $aop): string
+    private function renderAop(array $aop): array
     {
         $methods = array_keys($aop);
         $lines = [];
@@ -213,6 +217,6 @@ final class ModuleString
             $lines[] = $branch . ' ' . $method . ': ' . implode(', ', $aop[$method]);
         }
 
-        return implode(PHP_EOL, $lines);
+        return $lines;
     }
 }

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use function array_keys;
 use function assert;
+use function count;
+use function gettype;
 use function implode;
+use function is_object;
+use function is_scalar;
+use function ksort;
+use function preg_replace;
 use function serialize;
-use function sort;
 use function sprintf;
+use function strrpos;
+use function substr;
 use function unserialize;
+use function usort;
+use function var_export;
 
 use const PHP_EOL;
 
@@ -23,25 +33,186 @@ final class ModuleString
      */
     public function __invoke(Container $container, array $pointcuts): string
     {
-        $log = [];
         /** @psalm-suppress MixedAssignment */
         $container = unserialize(serialize($container), ['allowed_classes' => true]);
         assert($container instanceof Container);
-        $spy = new SpyCompiler();
-        foreach ($container->getContainer() as $dependencyIndex => $dependency) {
-            if ($dependency instanceof Dependency) {
-                $dependency->weaveAspects($spy, $pointcuts);
-            }
 
-            $log[] = sprintf(
-                '%s => %s',
-                $dependencyIndex,
-                (string) $dependency
-            );
+        $groups = $this->groupByInterface($container, $pointcuts);
+        ksort($groups);
+
+        $output = [];
+        foreach ($groups as $interface => $bindings) {
+            $output[] = $this->renderGroup($interface, $bindings);
         }
 
-        sort($log);
+        return implode(PHP_EOL . PHP_EOL, $output);
+    }
 
-        return implode(PHP_EOL, $log);
+    /**
+     * @param PointcutList $pointcuts
+     *
+     * @return array<string, list<array{name: string, dependency: DependencyInterface, aop: array<string, list<string>>}>>
+     */
+    private function groupByInterface(Container $container, array $pointcuts): array
+    {
+        $collector = new AopCollector();
+        $groups = [];
+
+        foreach ($container->getContainer() as $dependencyIndex => $dependency) {
+            [$interface, $name] = $this->parseIndex($dependencyIndex);
+            $aop = $dependency instanceof Dependency
+                ? $collector->collect($dependency, $pointcuts)
+                : [];
+
+            $groups[$interface][] = [
+                'name' => $name,
+                'dependency' => $dependency,
+                'aop' => $aop,
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function parseIndex(string $index): array
+    {
+        $pos = strrpos($index, '-');
+        if ($pos === false) {
+            return [$index, Name::ANY];
+        }
+
+        return [substr($index, 0, $pos), substr($index, $pos + 1)];
+    }
+
+    /**
+     * @param list<array{name: string, dependency: DependencyInterface, aop: array<string, list<string>>}> $bindings
+     */
+    private function renderGroup(string $interface, array $bindings): string
+    {
+        $header = $interface === '' ? "''" : $interface;
+        $lines = [$header];
+
+        usort($bindings, static fn (array $a, array $b): int => $a['name'] <=> $b['name']);
+
+        $count = count($bindings);
+        foreach ($bindings as $i => $binding) {
+            $isLast = $i === $count - 1;
+            $branch = $isLast ? '└──' : '├──';
+            $lines[] = $branch . ' ' . $this->renderBinding($binding['name'], $binding['dependency']);
+
+            if ($binding['aop'] !== []) {
+                $aopPrefix = $isLast ? '    ' : '│   ';
+                $lines[] = $aopPrefix . $this->renderAop($binding['aop']);
+            }
+        }
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function renderBinding(string $name, DependencyInterface $dependency): string
+    {
+        $parts = [];
+
+        if ($name !== Name::ANY) {
+            $parts[] = 'named:' . $name;
+        }
+
+        $parts[] = $this->renderTarget($dependency);
+
+        $scope = $this->getScope($dependency);
+        if ($scope === Scope::SINGLETON) {
+            $parts[] = 'in:Singleton';
+        }
+
+        return implode(' ─ ', $parts);
+    }
+
+    private function renderTarget(DependencyInterface $dependency): string
+    {
+        if ($dependency instanceof Dependency) {
+            $str = (string) $dependency;
+            $class = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $str) ?? '';
+
+            return 'to:' . $class;
+        }
+
+        if ($dependency instanceof DependencyProvider) {
+            $str = (string) $dependency;
+            $class = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $str) ?? '';
+
+            return 'toProvider:' . $class;
+        }
+
+        if ($dependency instanceof Instance) {
+            return 'toInstance:' . $this->renderValue($dependency->value);
+        }
+
+        return (string) $dependency;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function renderValue($value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if ($value === true) {
+            return 'true';
+        }
+
+        if ($value === false) {
+            return 'false';
+        }
+
+        if (is_scalar($value)) {
+            if (gettype($value) === 'string') {
+                return var_export($value, true);
+            }
+
+            return (string) $value;
+        }
+
+        if (is_object($value)) {
+            return '(' . $value::class . ')';
+        }
+
+        return '(' . gettype($value) . ')';
+    }
+
+    private function getScope(DependencyInterface $dependency): string
+    {
+        if ($dependency instanceof Dependency && $dependency->isSingleton()) {
+            return Scope::SINGLETON;
+        }
+
+        if ($dependency instanceof DependencyProvider && $dependency->isSingleton()) {
+            return Scope::SINGLETON;
+        }
+
+        return Scope::PROTOTYPE;
+    }
+
+    /**
+     * @param array<string, list<string>> $aop
+     */
+    private function renderAop(array $aop): string
+    {
+        $methods = array_keys($aop);
+        $lines = [];
+        $count = count($methods);
+
+        foreach ($methods as $i => $method) {
+            $isLast = $i === $count - 1;
+            $branch = $isLast ? '└─' : '├─';
+            $lines[] = $branch . ' ' . $method . ': ' . implode(', ', $aop[$method]);
+        }
+
+        return implode(PHP_EOL, $lines);
     }
 }

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -217,7 +217,7 @@ final class ModuleString
 
         foreach ($methods as $i => $method) {
             $isLast = $i === $count - 1;
-            $branch = $isLast ? '└─' : '├─';
+            $branch = $isLast ? '└─intercept─' : '├─intercept─';
             $lines[] = $branch . ' ' . $method . ': ' . implode(', ', $aop[$method]);
         }
 

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -13,7 +13,6 @@ use function is_object;
 use function is_scalar;
 use function is_string;
 use function ksort;
-use function preg_replace;
 use function serialize;
 use function sort;
 use function unserialize;
@@ -27,6 +26,11 @@ use const PHP_EOL;
  */
 final class ModuleString
 {
+    public function __construct(
+        private BindingTargetVisitor $targetVisitor = new BindingTargetVisitor()
+    ) {
+    }
+
     /**
      * @param PointcutList $pointcuts
      */
@@ -134,23 +138,15 @@ final class ModuleString
     private function renderTarget(DependencyInterface $dependency): string
     {
         if ($dependency instanceof Dependency) {
-            $str = (string) $dependency;
-            /** @var string $class preg_replace won't return null with valid pattern */
-            $class = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $str);
-
-            return 'to:' . $class;
+            return 'to:' . $this->targetVisitor->targetClass($dependency);
         }
 
         if ($dependency instanceof DependencyProvider) {
-            $str = (string) $dependency;
-            /** @var string $class preg_replace won't return null with valid pattern */
-            $class = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $str);
-
-            return 'toProvider:' . $class;
+            return 'toProvider:' . $this->targetVisitor->targetClass($dependency);
         }
 
         if ($dependency instanceof Instance) {
-            return 'toInstance:' . $this->renderValue($dependency->value);
+            return 'toInstance:' . $this->renderValue($dependency->accept($this->targetVisitor));
         }
 
         if ($dependency instanceof NullObjectDependency) {

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -168,7 +168,7 @@ final class ModuleString
             return 'toNull';
         }
 
-        return (string) $dependency;
+        return (string) $dependency; // @codeCoverageIgnore
     }
 
     /**

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -135,14 +135,16 @@ final class ModuleString
     {
         if ($dependency instanceof Dependency) {
             $str = (string) $dependency;
-            $class = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $str) ?? '';
+            /** @var string $class preg_replace won't return null with valid pattern */
+            $class = preg_replace('/^\(dependency\) ([^\s]+).*$/', '$1', $str);
 
             return 'to:' . $class;
         }
 
         if ($dependency instanceof DependencyProvider) {
             $str = (string) $dependency;
-            $class = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $str) ?? '';
+            /** @var string $class preg_replace won't return null with valid pattern */
+            $class = preg_replace('/^\(provider\) \(dependency\) ([^\s]+).*$/', '$1', $str);
 
             return 'toProvider:' . $class;
         }

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -152,6 +152,10 @@ final class ModuleString
             return 'toInstance:' . $this->renderValue($dependency->value);
         }
 
+        if ($dependency instanceof NullObjectDependency) {
+            return 'toNull';
+        }
+
         return (string) $dependency;
     }
 

--- a/tests/di/DependencyProviderTest.php
+++ b/tests/di/DependencyProviderTest.php
@@ -35,4 +35,19 @@ class DependencyProviderTest extends TestCase
         $this->assertNull($second);
         $this->assertSame(1, FakeNullProvider::$count);
     }
+
+    /**
+     * __toString() is the human-readable diagnostic form of a binding.
+     * ModuleString/ModuleJson extract targets structurally via
+     * BindingTargetVisitor, so this contract is pinned here directly.
+     */
+    public function testToStringShowsProviderClass(): void
+    {
+        /** @var ReflectionClass<object> $class */
+        $class = new ReflectionClass(FakeNullProvider::class);
+        $dependency = new Dependency(new NewInstance($class, new SetterMethods([])));
+        $dependencyProvider = new DependencyProvider($dependency, 'context');
+
+        $this->assertSame('(provider) (dependency) ' . FakeNullProvider::class, (string) $dependencyProvider);
+    }
 }

--- a/tests/di/DependencyTest.php
+++ b/tests/di/DependencyTest.php
@@ -52,6 +52,16 @@ class DependencyTest extends TestCase
     }
 
     /**
+     * __toString() is the human-readable diagnostic form of a binding.
+     * ModuleString/ModuleJson extract targets structurally via
+     * BindingTargetVisitor, so this contract is pinned here directly.
+     */
+    public function testToStringShowsDependencyClass(): void
+    {
+        $this->assertSame('(dependency) ' . FakeCar::class, (string) $this->dependency);
+    }
+
+    /**
      * @dataProvider containerProvider
      */
     public function testInject(Container $container): void

--- a/tests/di/Fake/FakeLogStringModule.php
+++ b/tests/di/Fake/FakeLogStringModule.php
@@ -12,7 +12,9 @@ class FakeLogStringModule extends AbstractModule
     {
         $this->bind()->annotatedWith('null')->toInstance(null);
         $this->bind()->annotatedWith('bool')->toInstance(true);
+        $this->bind()->annotatedWith('false')->toInstance(false);
         $this->bind()->annotatedWith('int')->toInstance(1);
+        $this->bind()->annotatedWith('float')->toInstance(1.5);
         $this->bind()->annotatedWith('string')->toInstance('1');
         $this->bind()->annotatedWith('array')->toInstance([1]);
         $this->bind()->annotatedWith('object')->toInstance(new stdClass());

--- a/tests/di/Fake/FakeMultiAop.php
+++ b/tests/di/Fake/FakeMultiAop.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeMultiAop implements FakeMultiAopInterface
+{
+    public function methodA()
+    {
+        return 'a';
+    }
+
+    public function methodB()
+    {
+        return 'b';
+    }
+}

--- a/tests/di/Fake/FakeMultiAopInterface.php
+++ b/tests/di/Fake/FakeMultiAopInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+interface FakeMultiAopInterface
+{
+    public function methodA();
+
+    public function methodB();
+}

--- a/tests/di/Fake/FakeMultiAopModule.php
+++ b/tests/di/Fake/FakeMultiAopModule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeMultiAopModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind(FakeMultiAopInterface::class)->to(FakeMultiAop::class);
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->startsWith('method'),
+            [FakeDoubleInterceptor::class]
+        );
+    }
+}

--- a/tests/di/Fake/FakeMultiBindingAopModule.php
+++ b/tests/di/Fake/FakeMultiBindingAopModule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Module with multiple bindings for same interface, where non-last has AOP.
+ */
+class FakeMultiBindingAopModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        // Two named bindings for same interface - 'first' (alphabetically before 'second')
+        $this->bind(FakeAopInterface::class)->annotatedWith('first')->to(FakeAop::class);
+        $this->bind(FakeAopInterface::class)->annotatedWith('second')->to(FakeAop::class);
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->startsWith('returnSame'),
+            [FakeDoubleInterceptor::class]
+        );
+    }
+}

--- a/tests/di/Fake/FakeSingletonClassModule.php
+++ b/tests/di/Fake/FakeSingletonClassModule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Module with explicit class binding to Singleton scope (not via interceptor).
+ */
+class FakeSingletonClassModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind(FakeRobotInterface::class)->to(FakeRobot::class)->in(Scope::SINGLETON);
+    }
+}

--- a/tests/di/Fake/FakeToNullModule.php
+++ b/tests/di/Fake/FakeToNullModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeToNullModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind(FakeRobotInterface::class)->toNull();
+    }
+}

--- a/tests/di/InstanceTest.php
+++ b/tests/di/InstanceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class InstanceTest extends TestCase
+{
+    public function testToStringScalarString(): void
+    {
+        $instance = new Instance('hello');
+        $this->assertSame('(string) hello', (string) $instance);
+    }
+
+    public function testToStringScalarInt(): void
+    {
+        $instance = new Instance(42);
+        $this->assertSame('(integer) 42', (string) $instance);
+    }
+
+    public function testToStringObject(): void
+    {
+        $instance = new Instance(new stdClass());
+        $this->assertSame('(object) stdClass', (string) $instance);
+    }
+
+    public function testToStringArray(): void
+    {
+        $instance = new Instance([1, 2, 3]);
+        $this->assertSame('(array)', (string) $instance);
+    }
+
+    public function testToStringNull(): void
+    {
+        $instance = new Instance(null);
+        $this->assertSame('(NULL)', (string) $instance);
+    }
+}

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -194,6 +194,29 @@ class ModuleJsonTest extends TestCase
     }
 
     /**
+     * A binding whose instance value is not valid UTF-8 must not erase the
+     * whole report: json_encode() substitutes the bad byte (U+FFFD) instead
+     * of failing, and every binding stays listed.
+     */
+    public function testInvalidUtf8InstanceValueDoesNotEraseReport(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind('')->annotatedWith('bin')->toInstance("\xB1\x31");
+                $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+            }
+        };
+        /** @var array{bindings: list<array{interface: string, name: string, type: string, to: mixed}>} $decoded */
+        $decoded = json_decode($module->toJson(), true);
+
+        $this->assertCount(2, $decoded['bindings']);
+        $binding = $this->findBindingByName($decoded['bindings'], 'bin');
+        $this->assertNotNull($binding);
+        $this->assertSame("\u{FFFD}1", $binding['to']);
+    }
+
+    /**
      * @return list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}>
      */
     private function decodeBindings(): array

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -71,12 +71,7 @@ class ModuleJsonTest extends TestCase
 
     public function testToNullBinding(): void
     {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->bind(FakeRobotInterface::class)->toNull();
-            }
-        };
+        $module = new FakeToNullModule();
         $json = $module->toJson();
         /** @var array{bindings: list<array{interface: string, name: string, type: string, to: mixed}>} $decoded */
         $decoded = json_decode($json, true);

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+
+use function array_column;
+use function json_decode;
+
+class ModuleJsonTest extends TestCase
+{
+    public function testToJson(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('bindings', $decoded);
+        $this->assertIsArray($decoded['bindings']);
+    }
+
+    public function testBindingsContainInterface(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $bindings = $decoded['bindings'];
+        $interfaces = array_column($bindings, 'interface');
+
+        $this->assertContains(FakeAopInterface::class, $interfaces);
+        $this->assertContains(FakeRobotInterface::class, $interfaces);
+    }
+
+    public function testDependencyBinding(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $binding = $this->findBinding($decoded['bindings'], FakeAopInterface::class);
+
+        $this->assertNotNull($binding);
+        $this->assertSame('class', $binding['type']);
+        $this->assertSame(FakeAop::class, $binding['to']);
+    }
+
+    public function testProviderBinding(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $binding = $this->findBinding($decoded['bindings'], FakeRobotInterface::class);
+
+        $this->assertNotNull($binding);
+        $this->assertSame('provider', $binding['type']);
+        $this->assertSame(FakeRobotProvider::class, $binding['to']);
+    }
+
+    public function testInstanceBinding(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $binding = $this->findBindingByName($decoded['bindings'], 'string');
+
+        $this->assertNotNull($binding);
+        $this->assertSame('instance', $binding['type']);
+        $this->assertSame('1', $binding['to']);
+    }
+
+    public function testAopBinding(): void
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        $decoded = json_decode($json, true);
+
+        $binding = $this->findBinding($decoded['bindings'], FakeAopInterface::class);
+
+        $this->assertNotNull($binding);
+        $this->assertArrayHasKey('aop', $binding);
+        $this->assertArrayHasKey('returnSame', $binding['aop']);
+        $this->assertContains(FakeDoubleInterceptor::class, $binding['aop']['returnSame']);
+    }
+
+    /**
+     * @param array<array{interface: string, name: string, type: string, to: mixed}> $bindings
+     *
+     * @return array{interface: string, name: string, type: string, to: mixed}|null
+     */
+    private function findBinding(array $bindings, string $interface): ?array
+    {
+        foreach ($bindings as $binding) {
+            if ($binding['interface'] === $interface) {
+                return $binding;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<array{interface: string, name: string, type: string, to: mixed}> $bindings
+     *
+     * @return array{interface: string, name: string, type: string, to: mixed}|null
+     */
+    private function findBindingByName(array $bindings, string $name): ?array
+    {
+        foreach ($bindings as $binding) {
+            if ($binding['name'] === $name) {
+                return $binding;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\Bind as AopBind;
+use ReflectionMethod;
+use ReflectionParameter;
 
 use function array_column;
+use function assert;
 use function json_decode;
 
 class ModuleJsonTest extends TestCase
@@ -122,6 +126,50 @@ class ModuleJsonTest extends TestCase
         $this->assertNotNull($binding);
         $this->assertSame('null', $binding['type']);
         $this->assertNull($binding['to']);
+    }
+
+    public function testVisitDependencyReturnsBoundClass(): void
+    {
+        $container = (new FakeLogStringModule())->getContainer()->getContainer();
+        $dependency = $container[FakeAopInterface::class . '-' . Name::ANY];
+        assert($dependency instanceof Dependency);
+
+        $this->assertSame(FakeAop::class, $dependency->accept(new BindingTargetVisitor()));
+    }
+
+    public function testVisitProviderReturnsProviderClassAndContext(): void
+    {
+        $container = (new FakeLogStringModule())->getContainer()->getContainer();
+        $provider = $container[FakeRobotInterface::class . '-' . Name::ANY];
+        assert($provider instanceof DependencyProvider);
+
+        $this->assertSame(
+            ['class' => FakeRobotProvider::class, 'context' => ''],
+            $provider->accept(new BindingTargetVisitor())
+        );
+    }
+
+    /**
+     * Nodes below the binding target (aspects, setters, arguments) carry no
+     * target information; the visitor must answer null for all of them.
+     */
+    public function testVisitorReturnsNullForNonTargetNodes(): void
+    {
+        $visitor = new BindingTargetVisitor();
+        $arguments = new Arguments(new ReflectionMethod(self::class, 'setUp'), new Name(Name::ANY));
+
+        $this->assertNull($visitor->visitAspectBind(new AopBind()));
+        $this->assertNull($visitor->visitSetterMethods([]));
+        $this->assertNull($visitor->visitSetterMethod('setUp', $arguments));
+        $this->assertNull($visitor->visitArguments([]));
+        $this->assertNull($visitor->visitArgument(
+            '0',
+            false,
+            null,
+            new ReflectionParameter(static function (int $arg): int {
+                return $arg;
+            }, 0)
+        ));
     }
 
     /**

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -76,6 +76,15 @@ class ModuleJsonTest extends TestCase
         $this->assertSame(['__class' => 'stdClass'], $binding['to']);
     }
 
+    public function testInstanceBindingNull(): void
+    {
+        $binding = $this->findBindingByName($this->decodeBindings(), 'null');
+
+        $this->assertNotNull($binding);
+        $this->assertSame('instance', $binding['type']);
+        $this->assertNull($binding['to']);
+    }
+
     public function testAopBinding(): void
     {
         $binding = $this->findBinding($this->decodeBindings(), FakeAopInterface::class);

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -87,6 +87,15 @@ class ModuleJsonTest extends TestCase
         $this->assertContains(FakeDoubleInterceptor::class, $aop['returnSame']);
     }
 
+    public function testDependencyWithoutAop(): void
+    {
+        $binding = $this->findBinding($this->decodeBindings(), FakeDoubleInterceptor::class);
+
+        $this->assertNotNull($binding);
+        $this->assertSame('class', $binding['type']);
+        $this->assertArrayNotHasKey('aop', $binding);
+    }
+
     public function testToNullBinding(): void
     {
         $module = new FakeToNullModule();

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -24,11 +24,7 @@ class ModuleJsonTest extends TestCase
 
     public function testBindingsContainInterface(): void
     {
-        $module = new FakeLogStringModule();
-        $json = $module->toJson();
-        $decoded = json_decode($json, true);
-
-        $bindings = $decoded['bindings'];
+        $bindings = $this->decodeBindings();
         $interfaces = array_column($bindings, 'interface');
 
         $this->assertContains(FakeAopInterface::class, $interfaces);
@@ -37,11 +33,7 @@ class ModuleJsonTest extends TestCase
 
     public function testDependencyBinding(): void
     {
-        $module = new FakeLogStringModule();
-        $json = $module->toJson();
-        $decoded = json_decode($json, true);
-
-        $binding = $this->findBinding($decoded['bindings'], FakeAopInterface::class);
+        $binding = $this->findBinding($this->decodeBindings(), FakeAopInterface::class);
 
         $this->assertNotNull($binding);
         $this->assertSame('class', $binding['type']);
@@ -50,11 +42,7 @@ class ModuleJsonTest extends TestCase
 
     public function testProviderBinding(): void
     {
-        $module = new FakeLogStringModule();
-        $json = $module->toJson();
-        $decoded = json_decode($json, true);
-
-        $binding = $this->findBinding($decoded['bindings'], FakeRobotInterface::class);
+        $binding = $this->findBinding($this->decodeBindings(), FakeRobotInterface::class);
 
         $this->assertNotNull($binding);
         $this->assertSame('provider', $binding['type']);
@@ -63,11 +51,7 @@ class ModuleJsonTest extends TestCase
 
     public function testInstanceBinding(): void
     {
-        $module = new FakeLogStringModule();
-        $json = $module->toJson();
-        $decoded = json_decode($json, true);
-
-        $binding = $this->findBindingByName($decoded['bindings'], 'string');
+        $binding = $this->findBindingByName($this->decodeBindings(), 'string');
 
         $this->assertNotNull($binding);
         $this->assertSame('instance', $binding['type']);
@@ -76,22 +60,32 @@ class ModuleJsonTest extends TestCase
 
     public function testAopBinding(): void
     {
-        $module = new FakeLogStringModule();
-        $json = $module->toJson();
-        $decoded = json_decode($json, true);
-
-        $binding = $this->findBinding($decoded['bindings'], FakeAopInterface::class);
+        $binding = $this->findBinding($this->decodeBindings(), FakeAopInterface::class);
 
         $this->assertNotNull($binding);
         $this->assertArrayHasKey('aop', $binding);
-        $this->assertArrayHasKey('returnSame', $binding['aop']);
-        $this->assertContains(FakeDoubleInterceptor::class, $binding['aop']['returnSame']);
+        $aop = $binding['aop'] ?? [];
+        $this->assertArrayHasKey('returnSame', $aop);
+        $this->assertContains(FakeDoubleInterceptor::class, $aop['returnSame']);
     }
 
     /**
-     * @param array<array{interface: string, name: string, type: string, to: mixed}> $bindings
+     * @return list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}>
+     */
+    private function decodeBindings(): array
+    {
+        $module = new FakeLogStringModule();
+        $json = $module->toJson();
+        /** @var array{bindings: list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}>} $decoded */
+        $decoded = json_decode($json, true);
+
+        return $decoded['bindings'];
+    }
+
+    /**
+     * @param list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}> $bindings
      *
-     * @return array{interface: string, name: string, type: string, to: mixed}|null
+     * @return array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}|null
      */
     private function findBinding(array $bindings, string $interface): ?array
     {
@@ -105,9 +99,9 @@ class ModuleJsonTest extends TestCase
     }
 
     /**
-     * @param array<array{interface: string, name: string, type: string, to: mixed}> $bindings
+     * @param list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}> $bindings
      *
-     * @return array{interface: string, name: string, type: string, to: mixed}|null
+     * @return array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}|null
      */
     private function findBindingByName(array $bindings, string $name): ?array
     {

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -69,6 +69,30 @@ class ModuleJsonTest extends TestCase
         $this->assertContains(FakeDoubleInterceptor::class, $aop['returnSame']);
     }
 
+    public function testToNullBinding(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeRobotInterface::class)->toNull();
+            }
+        };
+        $json = $module->toJson();
+        /** @var array{bindings: list<array{interface: string, name: string, type: string, to: mixed}>} $decoded */
+        $decoded = json_decode($json, true);
+        $binding = null;
+        foreach ($decoded['bindings'] as $b) {
+            if ($b['interface'] === FakeRobotInterface::class) {
+                $binding = $b;
+                break;
+            }
+        }
+
+        $this->assertNotNull($binding);
+        $this->assertSame('null', $binding['type']);
+        $this->assertNull($binding['to']);
+    }
+
     /**
      * @return list<array{interface: string, name: string, type: string, to: mixed, aop?: array<string, list<string>>}>
      */

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -128,6 +128,27 @@ class ModuleJsonTest extends TestCase
         $this->assertNull($binding['to']);
     }
 
+    /**
+     * BindingIndex::parse() is shared with Container::unbound(): both split
+     * '{interface}-{name}' on the FIRST hyphen, because class names cannot
+     * contain hyphens but bind names can. Splitting on the last hyphen would
+     * report interface '-type' / name 'bool' here.
+     */
+    public function testHyphenatedBindNameKeptWholeInIndex(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind()->annotatedWith('type-bool')->toInstance(true);
+            }
+        };
+        /** @var array{bindings: list<array{interface: string, name: string, type: string, to: mixed}>} $decoded */
+        $decoded = json_decode($module->toJson(), true);
+
+        $this->assertSame('', $decoded['bindings'][0]['interface']);
+        $this->assertSame('type-bool', $decoded['bindings'][0]['name']);
+    }
+
     public function testVisitDependencyReturnsBoundClass(): void
     {
         $container = (new FakeLogStringModule())->getContainer()->getContainer();

--- a/tests/di/ModuleJsonTest.php
+++ b/tests/di/ModuleJsonTest.php
@@ -58,6 +58,24 @@ class ModuleJsonTest extends TestCase
         $this->assertSame('1', $binding['to']);
     }
 
+    public function testInstanceBindingArray(): void
+    {
+        $binding = $this->findBindingByName($this->decodeBindings(), 'array');
+
+        $this->assertNotNull($binding);
+        $this->assertSame('instance', $binding['type']);
+        $this->assertSame(['__type' => 'array'], $binding['to']);
+    }
+
+    public function testInstanceBindingObject(): void
+    {
+        $binding = $this->findBindingByName($this->decodeBindings(), 'object');
+
+        $this->assertNotNull($binding);
+        $this->assertSame('instance', $binding['type']);
+        $this->assertSame(['__class' => 'stdClass'], $binding['to']);
+    }
+
     public function testAopBinding(): void
     {
         $binding = $this->findBinding($this->decodeBindings(), FakeAopInterface::class);

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -83,4 +83,12 @@ EOT;
         $string = (string) $module;
         $this->assertStringContainsString('└── toNull', $string);
     }
+
+    public function testtoStringWithMultipleAopMethods(): void
+    {
+        $module = new FakeMultiAopModule();
+        $string = (string) $module;
+        $this->assertStringContainsString('├─intercept─ methodA', $string);
+        $this->assertStringContainsString('└─intercept─ methodB', $string);
+    }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -101,4 +101,12 @@ EOT;
         $this->assertStringContainsString('│   └─intercept─', $string);
         $this->assertStringContainsString('└── named:second', $string);
     }
+
+    public function testtoStringWithExplicitSingletonClass(): void
+    {
+        $module = new FakeSingletonClassModule();
+        $string = (string) $module;
+        // Explicit class binding with Singleton scope (not via interceptor)
+        $this->assertStringContainsString('to:Ray\Di\FakeRobot ─ in:Singleton', $string);
+    }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -56,23 +56,21 @@ class ModuleTest extends TestCase
             return str_replace(["\r\n", "\r"], "\n", $str);
         };
         $expected = <<<'EOT'
-''
-├── named:array ─ toInstance:(array)
-├── named:bool ─ toInstance:true
-├── named:int ─ toInstance:1
-├── named:null ─ toInstance:null
-├── named:object ─ toInstance:(stdClass)
-└── named:string ─ toInstance:'1'
-
-Ray\Di\FakeAopInterface
-└── to:Ray\Di\FakeAop
-    └─intercept─ returnSame: Ray\Di\FakeDoubleInterceptor
-
-Ray\Di\FakeDoubleInterceptor
-└── to:Ray\Di\FakeDoubleInterceptor ─ in:Singleton
-
-Ray\Di\FakeRobotInterface
-└── toProvider:Ray\Di\FakeRobotProvider ─ in:Singleton
+module
+├── ''
+│   ├── named:array ─ toInstance:(array)
+│   ├── named:bool ─ toInstance:true
+│   ├── named:int ─ toInstance:1
+│   ├── named:null ─ toInstance:null
+│   ├── named:object ─ toInstance:(stdClass)
+│   └── named:string ─ toInstance:'1'
+├── Ray\Di\FakeAopInterface
+│   └── to:Ray\Di\FakeAop
+│       └─intercept─ returnSame: Ray\Di\FakeDoubleInterceptor
+├── Ray\Di\FakeDoubleInterceptor
+│   └── to:Ray\Di\FakeDoubleInterceptor ─ in:Singleton
+└── Ray\Di\FakeRobotInterface
+    └── toProvider:Ray\Di\FakeRobotProvider ─ in:Singleton
 EOT;
         $this->assertSame($normalize($expected), $normalize($string));
     }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\NotFound;
 
 use function str_replace;
+use function strpos;
 
 class ModuleTest extends TestCase
 {
@@ -108,5 +109,17 @@ EOT;
         $string = (string) $module;
         // Explicit class binding with Singleton scope (not via interceptor)
         $this->assertStringContainsString('to:Ray\Di\FakeRobot ─ in:Singleton', $string);
+    }
+
+    public function testtoStringBindingsSortedByName(): void
+    {
+        $module = new FakeLogStringModule();
+        $string = (string) $module;
+        // Verify bindings are sorted: array < bool < false < float < int < null < object < string
+        $arrayPos = strpos($string, 'named:array');
+        $stringPos = strpos($string, 'named:string');
+        $this->assertNotFalse($arrayPos);
+        $this->assertNotFalse($stringPos);
+        $this->assertLessThan($stringPos, $arrayPos);
     }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -91,4 +91,14 @@ EOT;
         $this->assertStringContainsString('├─intercept─ methodA', $string);
         $this->assertStringContainsString('└─intercept─ methodB', $string);
     }
+
+    public function testtoStringWithAopOnNonLastBinding(): void
+    {
+        $module = new FakeMultiBindingAopModule();
+        $string = (string) $module;
+        // When AOP binding is not last in group, continuation line uses '│   ' prefix
+        $this->assertStringContainsString('├── named:first', $string);
+        $this->assertStringContainsString('│   └─intercept─', $string);
+        $this->assertStringContainsString('└── named:second', $string);
+    }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -74,4 +74,16 @@ module
 EOT;
         $this->assertSame($normalize($expected), $normalize($string));
     }
+
+    public function testtoStringWithToNull(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeRobotInterface::class)->toNull();
+            }
+        };
+        $string = (string) $module;
+        $this->assertStringContainsString('toNull', $string);
+    }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -60,6 +60,8 @@ module
 ├── ''
 │   ├── named:array ─ toInstance:(array)
 │   ├── named:bool ─ toInstance:true
+│   ├── named:false ─ toInstance:false
+│   ├── named:float ─ toInstance:1.5
 │   ├── named:int ─ toInstance:1
 │   ├── named:null ─ toInstance:null
 │   ├── named:object ─ toInstance:(stdClass)

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -79,13 +79,8 @@ EOT;
 
     public function testtoStringWithToNull(): void
     {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->bind(FakeRobotInterface::class)->toNull();
-            }
-        };
+        $module = new FakeToNullModule();
         $string = (string) $module;
-        $this->assertStringContainsString('toNull', $string);
+        $this->assertStringContainsString('└── toNull', $string);
     }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -66,7 +66,7 @@ class ModuleTest extends TestCase
 
 Ray\Di\FakeAopInterface
 └── to:Ray\Di\FakeAop
-    └─ returnSame: Ray\Di\FakeDoubleInterceptor
+    └─intercept─ returnSame: Ray\Di\FakeDoubleInterceptor
 
 Ray\Di\FakeDoubleInterceptor
 └── to:Ray\Di\FakeDoubleInterceptor ─ in:Singleton

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -55,14 +55,25 @@ class ModuleTest extends TestCase
         $normalize = static function (string $str): string {
             return str_replace(["\r\n", "\r"], "\n", $str);
         };
-        $this->assertSame($normalize('-array => (array)
--bool => (boolean) 1
--int => (integer) 1
--null => (NULL)
--object => (object) stdClass
--string => (string) 1
-Ray\Di\FakeAopInterface- => (dependency) Ray\Di\FakeAop (aop) +returnSame(Ray\Di\FakeDoubleInterceptor)
-Ray\Di\FakeDoubleInterceptor- => (dependency) Ray\Di\FakeDoubleInterceptor
-Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider'), $normalize($string));
+        $expected = <<<'EOT'
+''
+├── named:array ─ toInstance:(array)
+├── named:bool ─ toInstance:true
+├── named:int ─ toInstance:1
+├── named:null ─ toInstance:null
+├── named:object ─ toInstance:(stdClass)
+└── named:string ─ toInstance:'1'
+
+Ray\Di\FakeAopInterface
+└── to:Ray\Di\FakeAop
+    └─ returnSame: Ray\Di\FakeDoubleInterceptor
+
+Ray\Di\FakeDoubleInterceptor
+└── to:Ray\Di\FakeDoubleInterceptor ─ in:Singleton
+
+Ray\Di\FakeRobotInterface
+└── toProvider:Ray\Di\FakeRobotProvider ─ in:Singleton
+EOT;
+        $this->assertSame($normalize($expected), $normalize($string));
     }
 }


### PR DESCRIPTION
## Summary

Supersedes #313 — the same feature, rebased onto the merged #319 with review fixes applied on top. #313's branch predates #319 and cannot be fast-forwarded, so this fresh PR keeps the history clean; #313 can be closed in its favor.

Refactors the module introspection system: a readable tree-based string representation and a JSON export for tooling.

### Key changes (carried over from #313, 32 commits, messages preserved)

- **ModuleString**: hierarchical tree output grouped by interface (`├──`/`└──`), showing binding name, target type (class/provider/instance/null), and scope; AOP interceptors as sub-items; deterministic ordering
- **ModuleJson / `AbstractModule::toJson()`**: JSON export of all bindings (`interface`, `name`, `type`, `to`, `aop`) for programmatic access
- **AopCollector**: gathers interceptor information through the existing weaving mechanism without generating code

### New in this PR (review fixes on top)

- **Structural target extraction** — `ModuleJson`/`ModuleString` no longer recover class names by regex over `(string) $dependency`; a `BindingTargetVisitor` built on the existing `VisitorInterface` double dispatch extracts targets structurally. The `Dependency`/`DependencyProvider` `__toString()` diagnostic formats are now pinned by their own tests.
- **Single source of truth for the binding index** — #313's `BindingIndex::parse()` split on the *last* hyphen (`strrpos`) while `Container::unbound()` splits on the *first* (`explode('-', $index, 2)`), so hyphenated bind names were mis-parsed in the JSON/tree output. `parse()` is rewritten to the container's semantics and `Container::unbound()` now uses it, pinned by `testHyphenatedBindNameKeptWholeInIndex`.
- **UTF-8 hardening** — a single binary `toInstance()` value made `json_encode()` fail and silently emptied the whole report; `JSON_INVALID_UTF8_SUBSTITUTE` keeps every binding listed (bad bytes become U+FFFD). The serialize-based deep-copy limitation (e.g. closures bound via `toInstance()`) is documented on `toJson()`.

## Testing

- 259 tests, 100% line coverage (pcov); cs + Psalm + PHPStan clean
- Establishes the `BindingEntry` JSON schema that the BindingLog provenance feature (next PR in this stack) extends with a `source` field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON export for dependency-injection module bindings, including classes, providers, instances, null bindings, scopes, and AOP metadata.
  * Added a clearer tree-style text view of module bindings, including named bindings and interceptors.
  * Added support for preserving binding names containing hyphens.
* **Bug Fixes**
  * Improved handling of invalid UTF-8 values during JSON export.
  * Added the required JSON PHP extension declaration.
* **Tests**
  * Expanded coverage for serialization, binding types, AOP details, sorting, scopes, and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->