### PR TITLE
Add BindingLog: binding provenance and collision history

### DIFF
--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -45,7 +45,6 @@ abstract class AbstractModule implements Stringable
         /** @psalm-suppress DeprecatedProperty kept for BC */
         $this->lastModule = $module;
         $this->container = new Container();
-        $this->container->setSource(static::class);
         $this->matcher = new Matcher();
         $this->isConfiguring = true;
         $this->configure();
@@ -79,7 +78,6 @@ abstract class AbstractModule implements Stringable
     {
         $module->getContainer()->merge($this->getContainer());
         $this->container = $module->getContainer();
-        $this->container->setSource(static::class); // subsequent binds attribute to this module
     }
 
     /**
@@ -107,13 +105,13 @@ abstract class AbstractModule implements Stringable
         $this->getContainer()->addPointcut($pointcut);
         foreach ($interceptors as $interceptor) {
             if (class_exists($interceptor)) {
-                (new Bind($this->getContainer(), $interceptor))->to($interceptor)->in(Scope::SINGLETON);
+                (new Bind($this->getContainer(), $interceptor, static::class))->to($interceptor)->in(Scope::SINGLETON);
 
                 continue;
             }
 
             assert(interface_exists($interceptor));
-            (new Bind($this->getContainer(), $interceptor))->in(Scope::SINGLETON);
+            (new Bind($this->getContainer(), $interceptor, static::class))->in(Scope::SINGLETON);
         }
     }
 
@@ -127,7 +125,7 @@ abstract class AbstractModule implements Stringable
         $pointcut = new PriorityPointcut($classMatcher, $methodMatcher, $interceptors);
         $this->getContainer()->addPointcut($pointcut);
         foreach ($interceptors as $interceptor) {
-            (new Bind($this->getContainer(), $interceptor))->to($interceptor)->in(Scope::SINGLETON);
+            (new Bind($this->getContainer(), $interceptor, static::class))->to($interceptor)->in(Scope::SINGLETON);
         }
     }
 
@@ -177,7 +175,7 @@ abstract class AbstractModule implements Stringable
      */
     protected function bind(string $interface = ''): Bind
     {
-        return new Bind($this->getContainer(), $interface);
+        return new Bind($this->getContainer(), $interface, static::class);
     }
 
     /**
@@ -186,7 +184,6 @@ abstract class AbstractModule implements Stringable
     private function activate(): void
     {
         $this->container = new Container();
-        $this->container->setSource(static::class);
         $this->matcher = new Matcher();
         $this->isConfiguring = true;
         $this->configure();

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -45,6 +45,7 @@ abstract class AbstractModule implements Stringable
         /** @psalm-suppress DeprecatedProperty kept for BC */
         $this->lastModule = $module;
         $this->container = new Container();
+        $this->container->setSource(static::class);
         $this->matcher = new Matcher();
         $this->isConfiguring = true;
         $this->configure();
@@ -78,6 +79,7 @@ abstract class AbstractModule implements Stringable
     {
         $module->getContainer()->merge($this->getContainer());
         $this->container = $module->getContainer();
+        $this->container->setSource(static::class); // subsequent binds attribute to this module
     }
 
     /**
@@ -184,6 +186,7 @@ abstract class AbstractModule implements Stringable
     private function activate(): void
     {
         $this->container = new Container();
+        $this->container->setSource(static::class);
         $this->matcher = new Matcher();
         $this->isConfiguring = true;
         $this->configure();

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -37,7 +37,7 @@ final class Bind implements Stringable
     public function __construct(
         private readonly Container $container,
         private readonly string $interface,
-        private readonly string $source = ''
+        public readonly string $source = ''
     ) {
         $this->validate = new BindValidator();
         $bindUntarget = class_exists($this->interface) && ! (new \ReflectionClass($this->interface))->isAbstract() && ! $this->isRegistered($this->interface);
@@ -179,14 +179,6 @@ final class Bind implements Stringable
     public function getBound(): DependencyInterface
     {
         return $this->bound;
-    }
-
-    /**
-     * FQCN of the module (or Injector) that created this binding, '' when unknown
-     */
-    public function getSource(): string
-    {
-        return $this->source;
     }
 
     public function setBound(DependencyInterface $bound): void

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -31,11 +31,13 @@ final class Bind implements Stringable
     /**
      * @param Container         $container dependency container
      * @param BindableInterface $interface interface or concrete class name
+     * @param string            $source    FQCN of the module (or Injector) that created this binding
      * @phpstan-param class-string<MethodInterceptor>|string $interface
      */
     public function __construct(
         private readonly Container $container,
-        private readonly string $interface
+        private readonly string $interface,
+        private readonly string $source = ''
     ) {
         $this->validate = new BindValidator();
         $bindUntarget = class_exists($this->interface) && ! (new \ReflectionClass($this->interface))->isAbstract() && ! $this->isRegistered($this->interface);
@@ -177,6 +179,14 @@ final class Bind implements Stringable
     public function getBound(): DependencyInterface
     {
         return $this->bound;
+    }
+
+    /**
+     * FQCN of the module (or Injector) that created this binding, '' when unknown
+     */
+    public function getSource(): string
+    {
+        return $this->source;
     }
 
     public function setBound(DependencyInterface $bound): void

--- a/src/di/BindingEvent.php
+++ b/src/di/BindingEvent.php
@@ -7,6 +7,9 @@ namespace Ray\Di;
 use Stringable;
 
 use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
 
 /**
  * A single composition-time write to the dependency container
@@ -49,13 +52,32 @@ final class BindingEvent implements Stringable
 
     public function __toString(): string
     {
+        $dependency = $this->label($this->dependency);
+        $discarded = $this->label($this->discarded ?? '');
         $body = match ($this->type) {
-            self::BIND => sprintf('%s => %s @%s', $this->index, $this->dependency, $this->source),
-            self::REPLACE => sprintf('%s => %s @%s (replaced %s @%s)', $this->index, $this->dependency, $this->source, $this->discarded ?? '', $this->discardedSource ?? ''),
-            self::KEEP => sprintf('%s => %s @%s (discarded %s @%s)', $this->index, $this->dependency, $this->source, $this->discarded ?? '', $this->discardedSource ?? ''),
+            self::BIND => sprintf('%s => %s @%s', $this->index, $dependency, $this->source),
+            self::REPLACE => sprintf('%s => %s @%s (replaced %s @%s)', $this->index, $dependency, $this->source, $discarded, $this->discardedSource ?? ''),
+            self::KEEP => sprintf('%s => %s @%s (discarded %s @%s)', $this->index, $dependency, $this->source, $discarded, $this->discardedSource ?? ''),
             self::MOVE => sprintf('%s => %s @%s', $this->movedFrom ?? '', $this->index, $this->source),
         };
 
         return sprintf('%-7s', $this->type) . ' ' . $body;
+    }
+
+    /**
+     * Collapse an untargeted binding's repeated class to a single marker
+     *
+     * An untargeted (or self-bound) concrete class lands at index '{class}-'
+     * with dependency '(dependency) {class}' — the same name twice. Show
+     * '(untargeted)' so the reader need not compare the two.
+     */
+    private function label(string $dependency): string
+    {
+        $prefix = '(dependency) ';
+        if (str_starts_with($dependency, $prefix) && $this->index === substr($dependency, strlen($prefix)) . '-') {
+            return '(untargeted)';
+        }
+
+        return $dependency;
     }
 }

--- a/src/di/BindingEvent.php
+++ b/src/di/BindingEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Stringable;
+
+use function sprintf;
+
+/**
+ * A single composition-time write to the dependency container
+ *
+ * Four kinds of write exist: a first bind, a replace (bind() over an existing
+ * entry, last write wins), a keep (merge collision where the existing entry
+ * wins and the incoming one is silently discarded by `+=`), and a move
+ * (rename to a new index). Each event names the module responsible for the
+ * surviving state and, for replace/keep, the losing side — the information a
+ * silent merge would otherwise erase.
+ */
+final class BindingEvent implements Stringable
+{
+    public const BIND = 'bind';
+    public const REPLACE = 'replace';
+    public const KEEP = 'keep';
+    public const MOVE = 'move';
+
+    /**
+     * @param string  $type            One of the four type constants
+     * @param string  $index           Dependency index '{interface}-{name}'
+     * @param string  $dependency      String form of the winning/current dependency ('' for move)
+     * @param string  $source          Module FQCN owning the current state
+     * @param ?string $discarded       String form of the losing dependency (replace/keep only)
+     * @param ?string $discardedSource Module FQCN that owned the losing dependency (replace/keep only)
+     * @param ?string $movedFrom       Old index the binding left (move only)
+     * @psalm-param self::BIND|self::REPLACE|self::KEEP|self::MOVE $type
+     * @phpstan-param self::BIND|self::REPLACE|self::KEEP|self::MOVE $type
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly string $index,
+        public readonly string $dependency,
+        public readonly string $source,
+        public readonly ?string $discarded = null,
+        public readonly ?string $discardedSource = null,
+        public readonly ?string $movedFrom = null
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $body = match ($this->type) {
+            self::BIND => sprintf('%s => %s @%s', $this->index, $this->dependency, $this->source),
+            self::REPLACE => sprintf('%s => %s @%s (replaced %s @%s)', $this->index, $this->dependency, $this->source, $this->discarded ?? '', $this->discardedSource ?? ''),
+            self::KEEP => sprintf('%s => %s @%s (discarded %s @%s)', $this->index, $this->dependency, $this->source, $this->discarded ?? '', $this->discardedSource ?? ''),
+            self::MOVE => sprintf('%s => %s @%s', $this->movedFrom ?? '', $this->index, $this->source),
+        };
+
+        return sprintf('%-7s', $this->type) . ' ' . $body;
+    }
+}

--- a/src/di/BindingLog.php
+++ b/src/di/BindingLog.php
@@ -9,7 +9,7 @@ use Stringable;
 use function array_diff_key;
 use function array_fill_keys;
 use function array_map;
-use function array_merge;
+use function array_push;
 use function implode;
 
 /**
@@ -72,13 +72,18 @@ final class BindingLog implements Stringable
      * surviving and the discarded side, and provenance is adopted only for the
      * indexes actually taken over — colliding indexes keep their owner.
      *
+     * Merging the same log instance twice (e.g. installing one module object
+     * two times) replays its events verbatim: the duplicate lines are a
+     * faithful trace of the duplicate merge, not distinct writes.
+     *
      * @param list<string>          $collidingIndexes      Indexes present on both sides (existing wins)
      * @param array<string, string> $keptDependencies      Colliding index => surviving dependency string
      * @param array<string, string> $discardedDependencies Colliding index => discarded incoming dependency string
      */
     public function merge(self $other, array $collidingIndexes, array $keptDependencies, array $discardedDependencies): void
     {
-        $this->events = array_merge($this->events, $other->events);
+        // in-place append of event object refs: O(adopted), no list re-copy
+        array_push($this->events, ...$other->events);
         foreach ($collidingIndexes as $index) {
             $this->events[] = new BindingEvent(
                 BindingEvent::KEEP,

--- a/src/di/BindingLog.php
+++ b/src/di/BindingLog.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Stringable;
+
+use function array_diff_key;
+use function array_fill_keys;
+use function array_map;
+use function array_merge;
+use function implode;
+
+/**
+ * Composition-time record of every write to the dependency container
+ *
+ * Module composition merges silently: bind() overwrites (last wins), while
+ * install() and constructor chaining merge with `+=` (existing wins, incoming
+ * silently discarded). This log records each write as a BindingEvent and
+ * tracks per-index provenance, so "who bound X, who was overwritten, who was
+ * discarded, in which module" is observable — the precedence contract made
+ * auditable.
+ *
+ * Composition-time only: the log observes writes and never influences
+ * resolution, and it is excluded from Container serialization — a revived
+ * container starts with an empty log and attributes later writes 'unknown'.
+ * Pointcuts and MultiBindings are NOT logged in v1.
+ */
+final class BindingLog implements Stringable
+{
+    /** @var list<BindingEvent> */
+    private array $events = [];
+
+    /** @var array<string, string> Index => module FQCN owning the current binding */
+    private array $sources = [];
+
+    /**
+     * Record a direct container write: a first bind or a replace
+     *
+     * @param string  $index      Dependency index '{interface}-{name}'
+     * @param string  $dependency String form of the dependency now bound
+     * @param ?string $previous   String form of the overwritten dependency, null on a first bind
+     * @param string  $source     Module FQCN performing the write
+     */
+    public function register(string $index, string $dependency, ?string $previous, string $source): void
+    {
+        if ($previous === null) {
+            $this->events[] = new BindingEvent(BindingEvent::BIND, $index, $dependency, $source);
+            $this->sources[$index] = $source;
+
+            return;
+        }
+
+        $this->events[] = new BindingEvent(
+            BindingEvent::REPLACE,
+            $index,
+            $dependency,
+            $source,
+            $previous,
+            // 'unknown' when provenance predates this log (e.g. after unserialize())
+            $this->sources[$index] ?? 'unknown'
+        );
+        $this->sources[$index] = $source;
+    }
+
+    /**
+     * Record a container merge: adopt the incoming history, log each collision
+     *
+     * The incoming log's events are appended as-is (the writes did happen, in
+     * that module), every colliding index becomes a keep event naming both the
+     * surviving and the discarded side, and provenance is adopted only for the
+     * indexes actually taken over — colliding indexes keep their owner.
+     *
+     * @param list<string>          $collidingIndexes      Indexes present on both sides (existing wins)
+     * @param array<string, string> $keptDependencies      Colliding index => surviving dependency string
+     * @param array<string, string> $discardedDependencies Colliding index => discarded incoming dependency string
+     */
+    public function merge(self $other, array $collidingIndexes, array $keptDependencies, array $discardedDependencies): void
+    {
+        $this->events = array_merge($this->events, $other->events);
+        foreach ($collidingIndexes as $index) {
+            $this->events[] = new BindingEvent(
+                BindingEvent::KEEP,
+                $index,
+                $keptDependencies[$index],
+                $this->sources[$index] ?? 'unknown',
+                $discardedDependencies[$index],
+                $other->sources[$index] ?? 'unknown'
+            );
+        }
+
+        $this->sources += array_diff_key($other->sources, array_fill_keys($collidingIndexes, true));
+    }
+
+    /**
+     * Record an index move (rename), transferring provenance to the new index
+     *
+     * The moved binding still belongs to the module that bound it, not to the
+     * module performing the rename.
+     */
+    public function move(string $from, string $to): void
+    {
+        if (isset($this->sources[$from])) {
+            $this->sources[$to] = $this->sources[$from];
+            unset($this->sources[$from]);
+        }
+
+        $this->events[] = new BindingEvent(BindingEvent::MOVE, $to, '', $this->sources[$to] ?? 'unknown', null, null, $from);
+    }
+
+    /**
+     * @return list<BindingEvent>
+     */
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    /**
+     * @return array<string, string> Index => module FQCN owning the current binding
+     */
+    public function getSources(): array
+    {
+        return $this->sources;
+    }
+
+    public function getSource(string $index): ?string
+    {
+        return $this->sources[$index] ?? null;
+    }
+
+    public function __toString(): string
+    {
+        return implode("\n", array_map(static fn (BindingEvent $event): string => (string) $event, $this->events));
+    }
+}

--- a/src/di/BindingLog.php
+++ b/src/di/BindingLog.php
@@ -25,7 +25,7 @@ use function implode;
  * Composition-time only: the log observes writes and never influences
  * resolution, and it is excluded from Container serialization — a revived
  * container starts with an empty log and attributes later writes 'unknown'.
- * Pointcuts and MultiBindings are NOT logged in v1.
+ * Pointcuts and MultiBindings are not logged.
  */
 final class BindingLog implements Stringable
 {

--- a/src/di/BindingsMarkdown.php
+++ b/src/di/BindingsMarkdown.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Throwable;
+
+use function file_put_contents;
+
+/**
+ * Emit the composed container as bindings.md next to the generated classes
+ *
+ * Two sections: the provenance log (who bound what, who was discarded) and the
+ * resolved bindings. Written at composition time — before aspect weaving, so
+ * class names are the originals and no proxy graph is serialized. Best-effort:
+ * a diagnostics artifact must never break container construction.
+ */
+final class BindingsMarkdown
+{
+    public function __invoke(Container $container, string $classDir): void
+    {
+        try {
+            $markdown = "# Ray.Di bindings\n\n"
+                . "## Provenance\n\n" . (string) $container->log . "\n\n"
+                . "## Bindings\n\n" . (new ModuleString())($container, $container->getPointcuts()) . "\n";
+            file_put_contents($classDir . '/bindings.md', $markdown);
+        } catch (Throwable) { // @codeCoverageIgnoreStart
+            // best-effort: never break construction for a diagnostics file
+        } // @codeCoverageIgnoreEnd
+    }
+}

--- a/src/di/BindingsMarkdown.php
+++ b/src/di/BindingsMarkdown.php
@@ -6,30 +6,69 @@ namespace Ray\Di;
 
 use Throwable;
 
+use function count;
 use function file_put_contents;
+use function implode;
+use function ksort;
 use function sprintf;
 
 /**
  * Emit the composed container as bindings.md next to the generated classes
  *
- * Two sections: the provenance log (who bound what, who was discarded) and the
- * resolved bindings. Written at composition time — before aspect weaving, so
- * class names are the originals and no proxy graph is serialized. Best-effort:
- * a diagnostics artifact must never break container construction.
+ * A summary line, the resolved bindings, the modules that composed them, and
+ * the provenance log (who bound what, who was discarded). Written at
+ * composition time — before aspect weaving, so class names are the originals
+ * and no proxy graph is serialized. Best-effort: a diagnostics artifact must
+ * never break container construction.
  */
 final class BindingsMarkdown
 {
     public function __invoke(Container $container, string $classDir): void
     {
         try {
-            $markdown = sprintf(
-                "# Ray.Di bindings\n\n## Provenance\n\n%s\n\n## Bindings\n\n%s\n",
-                $container->log,
-                (new ModuleString())($container, $container->getPointcuts())
-            );
-            file_put_contents($classDir . '/bindings.md', $markdown);
+            file_put_contents($classDir . '/bindings.md', $this->render($container));
         } catch (Throwable) { // @codeCoverageIgnoreStart
             // best-effort: never break construction for a diagnostics file
         } // @codeCoverageIgnoreEnd
+    }
+
+    private function render(Container $container): string
+    {
+        $log = $container->log;
+        $replaced = 0;
+        $discarded = 0;
+        foreach ($log->getEvents() as $event) {
+            if ($event->type === BindingEvent::REPLACE) {
+                $replaced++;
+            }
+
+            if ($event->type === BindingEvent::KEEP) {
+                $discarded++;
+            }
+        }
+
+        /** @var array<string, int> $moduleCounts */
+        $moduleCounts = [];
+        foreach ($log->getSources() as $module) {
+            $moduleCounts[$module] = ($moduleCounts[$module] ?? 0) + 1;
+        }
+
+        ksort($moduleCounts);
+        $moduleLines = [];
+        foreach ($moduleCounts as $module => $count) {
+            $moduleLines[] = sprintf('- %s (%d)', $module, $count);
+        }
+
+        return sprintf(
+            "# Ray.Di bindings\n\n%d bindings · %d modules · %d replaced · %d discarded\n\n"
+                . "## Bindings\n\n%s\n\n## Modules\n\n%s\n\n## Provenance\n\n%s\n",
+            count($container->getContainer()),
+            count($moduleCounts),
+            $replaced,
+            $discarded,
+            (new ModuleString())($container, $container->getPointcuts()),
+            implode("\n", $moduleLines),
+            $log
+        );
     }
 }

--- a/src/di/BindingsMarkdown.php
+++ b/src/di/BindingsMarkdown.php
@@ -7,6 +7,7 @@ namespace Ray\Di;
 use Throwable;
 
 use function file_put_contents;
+use function sprintf;
 
 /**
  * Emit the composed container as bindings.md next to the generated classes
@@ -21,9 +22,11 @@ final class BindingsMarkdown
     public function __invoke(Container $container, string $classDir): void
     {
         try {
-            $markdown = "# Ray.Di bindings\n\n"
-                . "## Provenance\n\n" . (string) $container->log . "\n\n"
-                . "## Bindings\n\n" . (new ModuleString())($container, $container->getPointcuts()) . "\n";
+            $markdown = sprintf(
+                "# Ray.Di bindings\n\n## Provenance\n\n%s\n\n## Bindings\n\n%s\n",
+                $container->log,
+                (new ModuleString())($container, $container->getPointcuts())
+            );
             file_put_contents($classDir . '/bindings.md', $markdown);
         } catch (Throwable) { // @codeCoverageIgnoreStart
             // best-effort: never break construction for a diagnostics file

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -291,7 +291,8 @@ final class Container implements InjectorInterface
     public function merge(self $container): void
     {
         $otherContainer = $container->getContainer();
-        $collidingIndexes = array_keys(array_intersect_key($this->container, $otherContainer));
+        // iterate the incoming (usually smaller) side: O(incoming), not O(accumulated)
+        $collidingIndexes = array_keys(array_intersect_key($otherContainer, $this->container));
         $keptDependencies = [];
         $discardedDependencies = [];
         foreach ($collidingIndexes as $index) {

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -16,6 +16,7 @@ use Ray\Di\Exception\Untargeted;
 use Ray\Di\MultiBinding\MultiBindings;
 use ReflectionClass;
 
+use function array_intersect_key;
 use function array_keys;
 use function array_merge;
 use function class_exists;
@@ -51,6 +52,22 @@ final class Container implements InjectorInterface
      */
     private array $resolving = [];
 
+    /**
+     * Composition-time binding history
+     *
+     * Not serialized: the __sleep() whitelist excludes it, so a revived
+     * container starts with an empty log (see getBindingLog()).
+     */
+    private ?BindingLog $log = null;
+
+    /**
+     * Module FQCN whose writes are currently being recorded
+     *
+     * Not serialized: attribution is composition-time state; writes after
+     * unserialize() are attributed 'unknown'.
+     */
+    private string $source = '';
+
     public function __construct()
     {
         $this->multiBindings = new MultiBindings();
@@ -65,12 +82,45 @@ final class Container implements InjectorInterface
     }
 
     /**
+     * Set the module FQCN to which subsequent binding writes are attributed
+     */
+    public function setSource(string $module): void
+    {
+        $this->source = $module;
+    }
+
+    /**
+     * Return the composition-time binding log
+     *
+     * Lazy-initialized so an unserialize()d container — whose whitelist-based
+     * __sleep() dropped the log, leaving the property at its default — still
+     * returns a usable (empty) log.
+     */
+    public function getBindingLog(): BindingLog
+    {
+        if (! isset($this->log)) {
+            $this->log = new BindingLog();
+        }
+
+        return $this->log;
+    }
+
+    /**
      * Add binding to a container
      */
     public function add(Bind $bind): void
     {
+        $index = (string) $bind;
+        $previous = $this->container[$index] ?? null;
         $dependency = $bind->getBound();
         $dependency->register($this->container, $bind);
+        /** @psalm-suppress InvalidArrayAccess -- register()'s @param-out leaves the DependencyContainer alias unexpanded */
+        $this->getBindingLog()->register(
+            $index,
+            (string) $this->container[$index],
+            $previous === null ? null : (string) $previous,
+            $this->source !== '' ? $this->source : 'unknown'
+        );
     }
 
     /**
@@ -185,6 +235,7 @@ final class Container implements InjectorInterface
 
             $this->container[$targetIndex] = $this->container[$sourceIndex];
             unset($this->container[$sourceIndex]);
+            $this->getBindingLog()->move($sourceIndex, $targetIndex);
         }
     }
 
@@ -232,11 +283,26 @@ final class Container implements InjectorInterface
 
     /**
      * Merge container
+     *
+     * The collision history is recorded first: `+=` lets existing entries win
+     * and silently discards the incoming side, so each colliding index is
+     * logged as a keep event before the merge makes the discard invisible.
      */
     public function merge(self $container): void
     {
+        $otherContainer = $container->getContainer();
+        $collidingIndexes = array_keys(array_intersect_key($this->container, $otherContainer));
+        $keptDependencies = [];
+        $discardedDependencies = [];
+        foreach ($collidingIndexes as $index) {
+            $keptDependencies[$index] = (string) $this->container[$index];
+            $discardedDependencies[$index] = (string) $otherContainer[$index];
+        }
+
+        $this->getBindingLog()->merge($container->getBindingLog(), $collidingIndexes, $keptDependencies, $discardedDependencies);
+
         $this->multiBindings->merge($container->multiBindings);
-        $this->container += $container->getContainer();
+        $this->container += $otherContainer;
         $this->pointcuts = array_merge($this->pointcuts, $container->getPointcuts());
     }
 

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -88,13 +88,12 @@ final class Container implements InjectorInterface
         $previous = $this->container[$index] ?? null;
         $dependency = $bind->getBound();
         $dependency->register($this->container, $bind);
-        $source = $bind->getSource();
         /** @psalm-suppress InvalidArrayAccess -- register()'s @param-out leaves the DependencyContainer alias unexpanded */
         $this->log->register(
             $index,
             (string) $this->container[$index],
             $previous === null ? null : (string) $previous,
-            $source !== '' ? $source : 'unknown'
+            $bind->source !== '' ? $bind->source : 'unknown'
         );
     }
 

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -55,22 +55,15 @@ final class Container implements InjectorInterface
     /**
      * Composition-time binding history
      *
-     * Not serialized: the __sleep() whitelist excludes it, so a revived
-     * container starts with an empty log (see getBindingLog()).
+     * Not serialized (excluded from __sleep()); re-created empty on __wakeup()
+     * so a revived container never carries build-time history into runtime.
      */
-    private ?BindingLog $log = null;
-
-    /**
-     * Module FQCN whose writes are currently being recorded
-     *
-     * Not serialized: attribution is composition-time state; writes after
-     * unserialize() are attributed 'unknown'.
-     */
-    private string $source = '';
+    private BindingLog $log;
 
     public function __construct()
     {
         $this->multiBindings = new MultiBindings();
+        $this->log = new BindingLog();
     }
 
     /**
@@ -81,27 +74,16 @@ final class Container implements InjectorInterface
         return ['container', 'pointcuts', 'multiBindings'];
     }
 
-    /**
-     * Set the module FQCN to which subsequent binding writes are attributed
-     */
-    public function setSource(string $module): void
+    public function __wakeup(): void
     {
-        $this->source = $module;
+        $this->log = new BindingLog();
     }
 
     /**
      * Return the composition-time binding log
-     *
-     * Lazy-initialized so an unserialize()d container — whose whitelist-based
-     * __sleep() dropped the log, leaving the property at its default — still
-     * returns a usable (empty) log.
      */
     public function getBindingLog(): BindingLog
     {
-        if (! isset($this->log)) {
-            $this->log = new BindingLog();
-        }
-
         return $this->log;
     }
 
@@ -114,12 +96,13 @@ final class Container implements InjectorInterface
         $previous = $this->container[$index] ?? null;
         $dependency = $bind->getBound();
         $dependency->register($this->container, $bind);
+        $source = $bind->getSource();
         /** @psalm-suppress InvalidArrayAccess -- register()'s @param-out leaves the DependencyContainer alias unexpanded */
-        $this->getBindingLog()->register(
+        $this->log->register(
             $index,
             (string) $this->container[$index],
             $previous === null ? null : (string) $previous,
-            $this->source !== '' ? $this->source : 'unknown'
+            $source !== '' ? $source : 'unknown'
         );
     }
 

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -58,7 +58,7 @@ final class Container implements InjectorInterface
      * Not serialized (excluded from __sleep()); re-created empty on __wakeup()
      * so a revived container never carries build-time history into runtime.
      */
-    private BindingLog $log;
+    public BindingLog $log;
 
     public function __construct()
     {
@@ -77,14 +77,6 @@ final class Container implements InjectorInterface
     public function __wakeup(): void
     {
         $this->log = new BindingLog();
-    }
-
-    /**
-     * Return the composition-time binding log
-     */
-    public function getBindingLog(): BindingLog
-    {
-        return $this->log;
     }
 
     /**
@@ -218,7 +210,7 @@ final class Container implements InjectorInterface
 
             $this->container[$targetIndex] = $this->container[$sourceIndex];
             unset($this->container[$sourceIndex]);
-            $this->getBindingLog()->move($sourceIndex, $targetIndex);
+            $this->log->move($sourceIndex, $targetIndex);
         }
     }
 
@@ -283,7 +275,7 @@ final class Container implements InjectorInterface
             $discardedDependencies[$index] = (string) $otherContainer[$index];
         }
 
-        $this->getBindingLog()->merge($container->getBindingLog(), $collidingIndexes, $keptDependencies, $discardedDependencies);
+        $this->log->merge($container->log, $collidingIndexes, $keptDependencies, $discardedDependencies);
 
         $this->multiBindings->merge($container->multiBindings);
         $this->container += $otherContainer;

--- a/src/di/ContainerFactory.php
+++ b/src/di/ContainerFactory.php
@@ -26,6 +26,8 @@ final class ContainerFactory
         $container = $appModule->getContainer();
         // Compile null objects
         (new CompileNullObject())($container, $classDir);
+        // Emit bindings.md before weaving, while class names are the originals
+        (new BindingsMarkdown())($container, $classDir);
         // Compile aspects
         /** @psalm-suppress InvalidArgument */
         $container->weaveAspects(new Compiler($classDir));

--- a/src/di/Injector.php
+++ b/src/di/Injector.php
@@ -43,6 +43,7 @@ final class Injector implements InjectorInterface
 
         $this->classDir = $classDir;
         $this->container = (new ContainerFactory())($module, $this->classDir);
+        $this->container->setSource(self::class); // builtin + JIT bindings attribute to the Injector
         // Bind injector (built-in bindings)
         (new Bind($this->container, InjectorInterface::class))->toInstance($this);
         $this->container->sort();

--- a/src/di/Injector.php
+++ b/src/di/Injector.php
@@ -54,6 +54,9 @@ final class Injector implements InjectorInterface
      */
     public function __wakeup()
     {
+        // the binding log's source is not serialized; restore it so JIT
+        // bindings by a cached injector keep attributing to the Injector
+        $this->container->setSource(self::class);
         spl_autoload_register(
             function (string $class): void {
                 $file = sprintf('%s/%s.php', $this->classDir, str_replace('\\', '_', $class));

--- a/src/di/Injector.php
+++ b/src/di/Injector.php
@@ -43,9 +43,8 @@ final class Injector implements InjectorInterface
 
         $this->classDir = $classDir;
         $this->container = (new ContainerFactory())($module, $this->classDir);
-        $this->container->setSource(self::class); // builtin + JIT bindings attribute to the Injector
         // Bind injector (built-in bindings)
-        (new Bind($this->container, InjectorInterface::class))->toInstance($this);
+        (new Bind($this->container, InjectorInterface::class, self::class))->toInstance($this);
         $this->container->sort();
     }
 
@@ -54,9 +53,6 @@ final class Injector implements InjectorInterface
      */
     public function __wakeup()
     {
-        // the binding log's source is not serialized; restore it so JIT
-        // bindings by a cached injector keep attributing to the Injector
-        $this->container->setSource(self::class);
         spl_autoload_register(
             function (string $class): void {
                 $file = sprintf('%s/%s.php', $this->classDir, str_replace('\\', '_', $class));
@@ -100,7 +96,7 @@ final class Injector implements InjectorInterface
      */
     private function bind(string $class)
     {
-        new Bind($this->container, $class);
+        new Bind($this->container, $class, self::class);
         $bound = $this->container->getContainer()[$class . '-' . Name::ANY];
         assert($bound instanceof Dependency);
 

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -106,6 +106,21 @@ LOG;
     }
 
     /**
+     * An untargeted (or self-bound) class lands at index '{class}-' with the
+     * same class as its dependency; the string form collapses the repeat to
+     * '(untargeted)'. A targeted binding, whose interface differs from the
+     * bound class, is shown in full.
+     */
+    public function testUntargetedBindingCollapsesTheRepeatedClassInString(): void
+    {
+        $untargeted = new BindingEvent(BindingEvent::BIND, FakeRobot::class . '-', '(dependency) ' . FakeRobot::class, 'M');
+        $this->assertSame('bind    ' . FakeRobot::class . '- => (untargeted) @M', (string) $untargeted);
+
+        $targeted = new BindingEvent(BindingEvent::BIND, FakeRobotInterface::class . '-', '(dependency) ' . FakeRobot::class, 'M');
+        $this->assertSame('bind    ' . FakeRobotInterface::class . '- => (dependency) ' . FakeRobot::class . ' @M', (string) $targeted);
+    }
+
+    /**
      * rename() is a move: the binding leaves its old index for the new one,
      * and the log both records the move and transfers provenance — the moved
      * binding still belongs to the module that bound it, not to the renamer.

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -119,7 +119,7 @@ LOG;
                 $this->rename(FakeRobotInterface::class, 'renamed');
             }
         };
-        $log = $module->getContainer()->getBindingLog();
+        $log = $module->getContainer()->log;
 
         $events = $log->getEvents();
         $this->assertCount(2, $events);
@@ -146,11 +146,11 @@ LOG;
     public function testUnserializedContainerStartsWithEmptyUsableLog(): void
     {
         $container = (new FakeBindingLogInnerModule())->getContainer();
-        $this->assertNotSame('', (string) $container->getBindingLog());
+        $this->assertNotSame('', (string) $container->log);
 
         $revived = unserialize(serialize($container));
         assert($revived instanceof Container);
-        $log = $revived->getBindingLog();
+        $log = $revived->log;
         $this->assertSame('', (string) $log);
         $this->assertSame([], $log->getEvents());
         $this->assertSame([], $log->getSources());
@@ -158,8 +158,8 @@ LOG;
 
         (new Bind($revived, FakeRobotInterface::class))->to(FakeRobot2::class);
         // the lazily created log is a live instance, not a per-call copy
-        $this->assertSame($log, $revived->getBindingLog());
-        $events = $revived->getBindingLog()->getEvents();
+        $this->assertSame($log, $revived->log);
+        $events = $revived->log->getEvents();
         $this->assertCount(1, $events);
         $replace = $events[0];
         $this->assertSame(BindingEvent::REPLACE, $replace->type);
@@ -179,7 +179,7 @@ LOG;
         $module = new FakeBindingLogInnerModule();
         new Injector($module, __DIR__ . '/tmp');
 
-        $log = $module->getContainer()->getBindingLog();
+        $log = $module->getContainer()->log;
         $this->assertSame(Injector::class, $log->getSource(InjectorInterface::class . '-'));
     }
 
@@ -197,11 +197,11 @@ LOG;
         $container = (new ReflectionProperty(Injector::class, 'container'))->getValue($injector);
         assert($container instanceof Container);
 
-        $this->assertSame(Injector::class, $container->getBindingLog()->getSource(FakeEngine::class . '-'));
+        $this->assertSame(Injector::class, $container->log->getSource(FakeEngine::class . '-'));
     }
 
     private function composeGoldenLog(): BindingLog
     {
-        return (new FakeBindingLogModule(new FakeBindingLogInnerModule()))->getContainer()->getBindingLog();
+        return (new FakeBindingLogModule(new FakeBindingLogInnerModule()))->getContainer()->log;
     }
 }

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 use function assert;
 use function serialize;
@@ -180,6 +181,23 @@ LOG;
 
         $log = $module->getContainer()->getBindingLog();
         $this->assertSame(Injector::class, $log->getSource(InjectorInterface::class . '-'));
+    }
+
+    /**
+     * A cached (unserialized) injector keeps that promise: __wakeup()
+     * re-stamps the container source, so a JIT binding performed after
+     * unserialize() is attributed to Ray\Di\Injector, not 'unknown'.
+     */
+    public function testUnserializedInjectorAttributesJitBindingToInjector(): void
+    {
+        $injector = unserialize(serialize(new Injector(null, __DIR__ . '/tmp')));
+        assert($injector instanceof Injector);
+        $injector->getInstance(FakeEngine::class); // JIT binding after wakeup
+
+        $container = (new ReflectionProperty(Injector::class, 'container'))->getValue($injector);
+        assert($container instanceof Container);
+
+        $this->assertSame(Injector::class, $container->getBindingLog()->getSource(FakeEngine::class . '-'));
     }
 
     private function composeGoldenLog(): BindingLog

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -156,7 +156,9 @@ LOG;
         $this->assertNull($log->getSource(FakeRobotInterface::class . '-'));
 
         (new Bind($revived, FakeRobotInterface::class))->to(FakeRobot2::class);
-        $events = $log->getEvents();
+        // the lazily created log is a live instance, not a per-call copy
+        $this->assertSame($log, $revived->getBindingLog());
+        $events = $revived->getBindingLog()->getEvents();
         $this->assertCount(1, $events);
         $replace = $events[0];
         $this->assertSame(BindingEvent::REPLACE, $replace->type);

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function serialize;
+use function unserialize;
+
+/**
+ * Pins the binding provenance & collision history contract
+ *
+ * Module composition merges silently: bind() overwrites (last wins), while
+ * install() and constructor chaining merge with `+=` (existing wins, incoming
+ * silently discarded). PR #319 proved such discards are invisible to both
+ * tests and humans. The BindingLog records every composition write, so "who
+ * bound X, who was overwritten, who was discarded, in which module" is
+ * observable. These tests are the specification of that record: the complete
+ * log text, the provenance map, and the event objects.
+ *
+ * The golden fixture `new FakeBindingLogModule(new FakeBindingLogInnerModule())`
+ * exercises every event type but move: an install() adoption, a bind, a
+ * same-module replace, and — because the constructor-chained module merges
+ * after configure() — a keep/discard collision.
+ */
+class BindingLogTest extends TestCase
+{
+    /**
+     * The complete log: one line per composition write, in write order.
+     *
+     * The installed module's bind is adopted at install()-merge with its own
+     * module as source; the two engine binds are a bind then a same-module
+     * replace; the chained module's bind arrives last (merged after
+     * configure()) and loses to the already-installed binding — a keep.
+     */
+    public function testLogRecordsEveryCompositionWrite(): void
+    {
+        $expected = <<<'LOG'
+bind    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot2 @Ray\Di\FakeBindingLogInstalledModule
+bind    Ray\Di\FakeEngineInterface- => (dependency) Ray\Di\FakeEngine @Ray\Di\FakeBindingLogModule
+replace Ray\Di\FakeEngineInterface- => (dependency) Ray\Di\FakeEngine2 @Ray\Di\FakeBindingLogModule (replaced (dependency) Ray\Di\FakeEngine @Ray\Di\FakeBindingLogModule)
+bind    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot @Ray\Di\FakeBindingLogInnerModule
+keep    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot2 @Ray\Di\FakeBindingLogInstalledModule (discarded (dependency) Ray\Di\FakeRobot @Ray\Di\FakeBindingLogInnerModule)
+LOG;
+
+        $this->assertSame($expected, (string) $this->composeGoldenLog());
+    }
+
+    /**
+     * getSources() maps each index to the module owning the *current* binding:
+     * the installed module for the robot (it beat the chained module), the
+     * composing module for the engine (its replace was the last write).
+     */
+    public function testSourcesRecordTheWinningModulePerIndex(): void
+    {
+        $log = $this->composeGoldenLog();
+
+        $this->assertSame([
+            FakeRobotInterface::class . '-' => FakeBindingLogInstalledModule::class,
+            FakeEngineInterface::class . '-' => FakeBindingLogModule::class,
+        ], $log->getSources());
+        $this->assertSame(FakeBindingLogInstalledModule::class, $log->getSource(FakeRobotInterface::class . '-'));
+        $this->assertNull($log->getSource(FakeCarInterface::class . '-'));
+    }
+
+    /**
+     * A keep event names both sides of the collision: the surviving binding
+     * with its owning module, and the discarded incoming binding with its
+     * owning module — the exact information PR #319-class bugs erase.
+     */
+    public function testKeepEventCarriesBothSidesOfTheCollision(): void
+    {
+        $events = $this->composeGoldenLog()->getEvents();
+
+        $this->assertCount(5, $events);
+        $keep = $events[4];
+        $this->assertSame(BindingEvent::KEEP, $keep->type);
+        $this->assertSame(FakeRobotInterface::class . '-', $keep->index);
+        $this->assertSame('(dependency) ' . FakeRobot2::class, $keep->dependency);
+        $this->assertSame(FakeBindingLogInstalledModule::class, $keep->source);
+        $this->assertSame('(dependency) ' . FakeRobot::class, $keep->discarded);
+        $this->assertSame(FakeBindingLogInnerModule::class, $keep->discardedSource);
+        $this->assertNull($keep->movedFrom);
+    }
+
+    /**
+     * bind() twice on the same index inside one module is a replace whose
+     * discarded side belongs to that same module — self-shadowing is recorded
+     * as faithfully as cross-module shadowing.
+     */
+    public function testReplaceWithinOneModuleAttributesDiscardedSourceToThatModule(): void
+    {
+        $events = $this->composeGoldenLog()->getEvents();
+
+        $replace = $events[2];
+        $this->assertSame(BindingEvent::REPLACE, $replace->type);
+        $this->assertSame(FakeEngineInterface::class . '-', $replace->index);
+        $this->assertSame('(dependency) ' . FakeEngine2::class, $replace->dependency);
+        $this->assertSame(FakeBindingLogModule::class, $replace->source);
+        $this->assertSame('(dependency) ' . FakeEngine::class, $replace->discarded);
+        $this->assertSame(FakeBindingLogModule::class, $replace->discardedSource);
+    }
+
+    /**
+     * rename() is a move: the binding leaves its old index for the new one,
+     * and the log both records the move and transfers provenance — the moved
+     * binding still belongs to the module that bound it, not to the renamer.
+     */
+    public function testRenameRecordsMoveEventAndTransfersProvenance(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new FakeToBindModule());
+                $this->rename(FakeRobotInterface::class, 'renamed');
+            }
+        };
+        $log = $module->getContainer()->getBindingLog();
+
+        $events = $log->getEvents();
+        $this->assertCount(2, $events);
+        $move = $events[1];
+        $this->assertSame(BindingEvent::MOVE, $move->type);
+        $this->assertSame(FakeRobotInterface::class . '-renamed', $move->index);
+        $this->assertSame(FakeRobotInterface::class . '-', $move->movedFrom);
+        $this->assertSame(FakeToBindModule::class, $move->source);
+        $this->assertSame(
+            'move    Ray\Di\FakeRobotInterface- => Ray\Di\FakeRobotInterface-renamed @Ray\Di\FakeToBindModule',
+            (string) $move
+        );
+        $this->assertSame(FakeToBindModule::class, $log->getSource(FakeRobotInterface::class . '-renamed'));
+        $this->assertNull($log->getSource(FakeRobotInterface::class . '-'));
+    }
+
+    /**
+     * The log is composition-time state: it is excluded from serialization,
+     * and a revived container starts with an empty log that still works.
+     * Writes after unserialize() are attributed 'unknown' on both sides —
+     * the writer identity and the provenance map did not survive, and the
+     * log says so instead of guessing.
+     */
+    public function testUnserializedContainerStartsWithEmptyUsableLog(): void
+    {
+        $container = (new FakeBindingLogInnerModule())->getContainer();
+        $this->assertNotSame('', (string) $container->getBindingLog());
+
+        $revived = unserialize(serialize($container));
+        assert($revived instanceof Container);
+        $log = $revived->getBindingLog();
+        $this->assertSame('', (string) $log);
+        $this->assertSame([], $log->getEvents());
+        $this->assertSame([], $log->getSources());
+        $this->assertNull($log->getSource(FakeRobotInterface::class . '-'));
+
+        (new Bind($revived, FakeRobotInterface::class))->to(FakeRobot2::class);
+        $events = $log->getEvents();
+        $this->assertCount(1, $events);
+        $replace = $events[0];
+        $this->assertSame(BindingEvent::REPLACE, $replace->type);
+        $this->assertSame('(dependency) ' . FakeRobot2::class, $replace->dependency);
+        $this->assertSame('unknown', $replace->source);
+        $this->assertSame('(dependency) ' . FakeRobot::class, $replace->discarded);
+        $this->assertSame('unknown', $replace->discardedSource);
+    }
+
+    /**
+     * The Injector's built-in InjectorInterface binding (and everything the
+     * Injector writes after composition, e.g. JIT bindings) is attributed to
+     * Ray\Di\Injector, not to the user module it happens to be merged into.
+     */
+    public function testInjectorBuiltinBindingAttributesToInjector(): void
+    {
+        $module = new FakeBindingLogInnerModule();
+        new Injector($module, __DIR__ . '/tmp');
+
+        $log = $module->getContainer()->getBindingLog();
+        $this->assertSame(Injector::class, $log->getSource(InjectorInterface::class . '-'));
+    }
+
+    private function composeGoldenLog(): BindingLog
+    {
+        return (new FakeBindingLogModule(new FakeBindingLogInnerModule()))->getContainer()->getBindingLog();
+    }
+}

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -45,8 +45,10 @@ class BindingsMarkdownTest extends TestCase
         $markdown = file_get_contents($this->classDir . '/bindings.md');
         assert(is_string($markdown));
 
-        $this->assertStringContainsString('## Provenance', $markdown);
-        $this->assertStringContainsString('## Bindings', $markdown);
+        // exact section structure, so a dropped separator or section is caught
+        $this->assertStringStartsWith("# Ray.Di bindings\n\n## Provenance\n\n", $markdown);
+        $this->assertStringContainsString("\n\n## Bindings\n\n", $markdown);
+        $this->assertStringEndsWith("\n", $markdown);
         // provenance names the module that bound it
         $this->assertStringContainsString('@' . FakeLogStringModule::class, $markdown);
         // bindings list the resolved target

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -45,14 +45,40 @@ class BindingsMarkdownTest extends TestCase
         $markdown = file_get_contents($this->classDir . '/bindings.md');
         assert(is_string($markdown));
 
-        // exact section structure, so a dropped separator or section is caught
-        $this->assertStringStartsWith("# Ray.Di bindings\n\n## Provenance\n\n", $markdown);
-        $this->assertStringContainsString("\n\n## Bindings\n\n", $markdown);
-        $this->assertStringEndsWith("\n", $markdown);
-        // provenance names the module that bound it
-        $this->assertStringContainsString('@' . FakeLogStringModule::class, $markdown);
+        // title + summary counts, then Bindings first
+        $this->assertStringStartsWith(
+            "# Ray.Di bindings\n\n15 bindings · 5 modules · 0 replaced · 0 discarded\n\n## Bindings\n\n",
+            $markdown,
+        );
         // bindings list the resolved target
         $this->assertStringContainsString(FakeAopInterface::class . '- => (dependency) ' . FakeAop::class, $markdown);
+        // modules, sorted, with each module's binding count, then provenance
+        $this->assertStringContainsString(
+            "## Modules\n\n"
+            . "- Ray\\Di\\AssistedInjectModule (1)\n"
+            . "- Ray\\Di\\AssistedModule (2)\n"
+            . '- ' . FakeLogStringModule::class . " (9)\n"
+            . "- Ray\\Di\\MultiBinding\\MultiBindingModule (2)\n"
+            . "- Ray\\Di\\ProviderSetModule (1)\n\n## Provenance",
+            $markdown,
+        );
+        // provenance names the module that bound it
+        $this->assertStringContainsString('@' . FakeLogStringModule::class, $markdown);
+        $this->assertStringEndsWith("\n", $markdown);
+    }
+
+    /**
+     * The summary counts replaced (last-write-wins rebind) and discarded
+     * (merge collision, incoming dropped) bindings.
+     */
+    public function testSummaryCountsReplacedAndDiscarded(): void
+    {
+        new Injector(new FakeBindingLogModule(new FakeBindingLogInnerModule()), $this->classDir);
+
+        $markdown = file_get_contents($this->classDir . '/bindings.md');
+        assert(is_string($markdown));
+
+        $this->assertStringContainsString('8 bindings · 6 modules · 1 replaced · 1 discarded', $markdown);
     }
 
     /**

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -6,12 +6,15 @@ namespace Ray\Di;
 
 use Closure;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 use function assert;
-use function file_exists;
 use function file_get_contents;
+use function glob;
+use function is_dir;
 use function is_string;
 use function mkdir;
+use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -22,15 +25,21 @@ class BindingsMarkdownTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->classDir = sys_get_temp_dir() . '/ray-bindings-md-' . uniqid();
-        mkdir($this->classDir);
+        $this->classDir = sys_get_temp_dir() . '/ray-bindings-md-' . uniqid('', true);
+        if (! mkdir($this->classDir) && ! is_dir($this->classDir)) {
+            throw new RuntimeException('Cannot create ' . $this->classDir);
+        }
     }
 
     protected function tearDown(): void
     {
-        $file = $this->classDir . '/bindings.md';
-        if (file_exists($file)) {
-            unlink($file);
+        // remove the whole test-owned dir: bindings.md and any generated proxies
+        foreach (glob($this->classDir . '/*') ?: [] as $artifact) {
+            unlink($artifact);
+        }
+
+        if (is_dir($this->classDir)) {
+            rmdir($this->classDir);
         }
     }
 

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function file_exists;
+use function file_get_contents;
+use function is_string;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class BindingsMarkdownTest extends TestCase
+{
+    private string $classDir;
+
+    protected function setUp(): void
+    {
+        $this->classDir = sys_get_temp_dir() . '/ray-bindings-md-' . uniqid();
+        mkdir($this->classDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->classDir . '/bindings.md';
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * Building an injector emits bindings.md next to the generated classes,
+     * with the provenance log and the resolved bindings.
+     */
+    public function testInjectorEmitsBindingsMarkdown(): void
+    {
+        new Injector(new FakeLogStringModule(), $this->classDir);
+
+        $markdown = file_get_contents($this->classDir . '/bindings.md');
+        assert(is_string($markdown));
+
+        $this->assertStringContainsString('## Provenance', $markdown);
+        $this->assertStringContainsString('## Bindings', $markdown);
+        // provenance names the module that bound it
+        $this->assertStringContainsString('@' . FakeLogStringModule::class, $markdown);
+        // bindings list the resolved target
+        $this->assertStringContainsString(FakeAopInterface::class . '- => (dependency) ' . FakeAop::class, $markdown);
+    }
+
+    /**
+     * A binding ModuleString cannot serialize (a closure instance) makes the
+     * emission fail, but construction must still succeed — the diagnostics
+     * artifact is best-effort.
+     */
+    public function testConstructionSucceedsWhenMarkdownCannotBeWritten(): void
+    {
+        $injector = new Injector(new FakeClosureBindModule(), $this->classDir);
+
+        $this->assertInstanceOf(Closure::class, $injector->getInstance('', 'callback'));
+        $this->assertFileDoesNotExist($this->classDir . '/bindings.md');
+    }
+}

--- a/tests/di/Fake/FakeBindingLogInnerModule.php
+++ b/tests/di/Fake/FakeBindingLogInnerModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeBindingLogInnerModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+    }
+}

--- a/tests/di/Fake/FakeBindingLogInstalledModule.php
+++ b/tests/di/Fake/FakeBindingLogInstalledModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeBindingLogInstalledModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->to(FakeRobot2::class);
+    }
+}

--- a/tests/di/Fake/FakeBindingLogModule.php
+++ b/tests/di/Fake/FakeBindingLogModule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Exercises every composition write the BindingLog must record
+ *
+ * install() adopts FakeBindingLogInstalledModule's FakeRobotInterface binding,
+ * the two FakeEngineInterface binds are a deliberate same-module replace, and
+ * the constructor-chained module (merged after configure()) collides with the
+ * installed FakeRobotInterface binding, producing a keep/discard.
+ */
+class FakeBindingLogModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->install(new FakeBindingLogInstalledModule());
+        $this->bind(FakeEngineInterface::class)->to(FakeEngine::class);
+        $this->bind(FakeEngineInterface::class)->to(FakeEngine2::class);
+    }
+}

--- a/tests/di/Fake/FakeClosureBindModule.php
+++ b/tests/di/Fake/FakeClosureBindModule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Binds a closure via toInstance() — an unserializable value.
+ *
+ * ModuleString serializes the container, so composing this makes bindings.md
+ * emission fail; construction must still succeed (best-effort).
+ */
+class FakeClosureBindModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind('')->annotatedWith('callback')->toInstance(static fn (): int => 1);
+    }
+}

--- a/tests/di/README.md
+++ b/tests/di/README.md
@@ -27,6 +27,7 @@ layer exists so that class of change can never again pass silently.
 | Singleton identity, serialization lifecycle | `DependencyTest`, `InjectorTest` |
 | JIT (untargeted) binding: single construction, named requests fail fast | `InjectorTest` |
 | Module-list merging (`new Injector([$m1, $m2])`): first module wins | `ModuleMergerTest` |
+| Binding provenance & collision history | `BindingLogTest` |
 
 ## The precedence rules (formerly folklore, now written down)
 


### PR DESCRIPTION
## Summary

Adds **BindingLog**: binding provenance and collision history for module composition. Three commits, no dependencies beyond 2.x.

### Why

Ray.Di composes modules by silent merge — `bind()` overwrites (last wins), while `install()` and constructor chaining merge with `+=` (existing wins, the incoming binding is silently discarded). #319 showed that such discards are invisible to tests, coverage, and humans alike: composition priority was inverted while everything stayed green. State-level introspection can only show *what is bound* — by read time the losing binding is already gone. Recording at write time answers: **who bound X, who was overwritten, whose binding was silently discarded, in which module.**

Guice answers this with loud duplicate-binding errors. Ray.Di's silent-wins semantics are load-bearing (BEAR.Sunday context chaining), so this takes the third way: keep the semantics, make them fully auditable.

### What

- **`BindingEvent`** (`bind` / `replace` / `keep` / `move`) and **`BindingLog`** (event list + `index => module` provenance map), both `Stringable` with pinned line formats
- **Container instrumentation at the only three composition write paths**: `add()` (bind/replace), `merge()` (keep + history adoption), `move()` (rename). `setInjectionPoint()` — a runtime hot-path write — is deliberately not logged
- **Attribution**: `AbstractModule` stamps `setSource(static::class)` on its container (re-stamped after `override()`); the `Injector` attributes its built-in and JIT bindings to `Ray\Di\Injector`, including after `unserialize()` (`__wakeup()` re-stamps)
- **Zero runtime cost**: composition-time only; the log and source are excluded from `Container::__sleep()`, so compiled/serialized containers (ScriptInjector production path) carry nothing and resolution paths are untouched

### The golden log (pinned verbatim by BindingLogTest)

`new FakeBindingLogModule(new FakeBindingLogInnerModule())`, where configure() installs a module and re-binds an engine:

```
bind    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot2 @Ray\Di\FakeBindingLogInstalledModule
bind    Ray\Di\FakeEngineInterface- => (dependency) Ray\Di\FakeEngine @Ray\Di\FakeBindingLogModule
replace Ray\Di\FakeEngineInterface- => (dependency) Ray\Di\FakeEngine2 @Ray\Di\FakeBindingLogModule (replaced (dependency) Ray\Di\FakeEngine @Ray\Di\FakeBindingLogModule)
bind    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot @Ray\Di\FakeBindingLogInnerModule
keep    Ray\Di\FakeRobotInterface- => (dependency) Ray\Di\FakeRobot2 @Ray\Di\FakeBindingLogInstalledModule (discarded (dependency) Ray\Di\FakeRobot @Ray\Di\FakeBindingLogInnerModule)
```

A #319-class inversion would show up as a flipped `keep` line — one `grep discarded` away from being caught.

### Process

Built spec-first per the contract-test protocol introduced in #319: the red spec (`BindingLogTest`: golden log, provenance map, event objects) is its own commit, followed by the implementation, then post-review fixes (unserialized-Injector attribution pinned red-first; O(incoming) merge bookkeeping).

Known v1 limits (documented in the class docblock): pointcuts and MultiBindings are not logged; `toNull()` bindings render an empty dependency column. If the module-introspection feature (#313) lands later, its `toJson()` entries can carry the owning module from `getSources()` in a few lines.

## Testing

- 239 tests, 100% line coverage (pcov); cs + Psalm + PHPStan clean
- Adversarially reviewed for serialization traps, attribution truthfulness (override / JIT / no-parent-constructor / `__wakeup`), and hot-path cost


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composition-time DI binding history with provenance and outcomes (bind/replace/keep/move).
  * Improved attribution so built-in and just-in-time DI bindings are consistently attributed.
  * Enhanced `bindings.md` diagnostics with collision/replacement summaries and provenance details.
* **Tests**
  * Added coverage for binding-log formatting, collision outcomes, rename/move behavior, serialization recovery, and markdown generation (including graceful failure).
* **Documentation**
  * Updated DI test contract documentation to include “Binding provenance & collision history”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->