### PR TITLE
Make ModuleString read the container in place instead of serialize-cloning it

### DIFF
--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -142,12 +142,10 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * Read-only counterpart of weaveAspects() for introspection
+     * Render this dependency as '(dependency) ClassName (aop) +method(...)'
      *
-     * Returns the same '(dependency) ClassName (aop) +method(...)' string that
-     * stringifying a spy-woven dependency produces, but WITHOUT mutating $this
-     * — so callers (ModuleString) no longer need to deep-copy the container to
-     * protect it from the spy weave.
+     * Resolves the AOP annotation read-only; the introspection counterpart of
+     * weaveAspects(), which mutates the instance for real injection.
      *
      * @param PointcutList $pointcuts
      */

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -131,12 +131,12 @@ final class Dependency implements DependencyInterface, AcceptInterface
      */
     public function weaveAspects(CompilerInterface $compiler, array $pointcuts): void
     {
-        $bind = $this->aopBind($pointcuts);
+        $className = (string) $this->newInstance;
+        $bind = $this->aopBind($className, $pointcuts);
         if (! $bind instanceof AopBind) {
             return;
         }
 
-        $className = (string) $this->newInstance;
         $class = $compiler->compile($className, $bind);
         $this->newInstance->weaveAspects($class, $bind);
     }
@@ -154,7 +154,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
     public function describe(array $pointcuts): string
     {
         $className = (string) $this->newInstance;
-        $bind = $this->aopBind($pointcuts);
+        $bind = $this->aopBind($className, $pointcuts);
         if ($bind instanceof AopBind) {
             $className = (new SpyCompiler())->compile($className, $bind);
         }
@@ -163,15 +163,15 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * Match pointcuts against this dependency's class, read-only
+     * Match pointcuts against the given class, read-only
      *
+     * @param class-string $className
      * @param PointcutList $pointcuts
      *
      * @return ?AopBind the matched bindings, or null when nothing is intercepted
      */
-    private function aopBind(array $pointcuts): ?AopBind
+    private function aopBind(string $className, array $pointcuts): ?AopBind
     {
-        $className = (string) $this->newInstance;
         $reflection = new ReflectionClass($className);
         if ($reflection->isFinal()) {
             return null;

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -131,27 +131,60 @@ final class Dependency implements DependencyInterface, AcceptInterface
      */
     public function weaveAspects(CompilerInterface $compiler, array $pointcuts): void
     {
-        $class = (string) $this->newInstance;
-        $reflection = new ReflectionClass($class);
-        if ($reflection->isFinal()) {
+        $bind = $this->aopBind($pointcuts);
+        if (! $bind instanceof AopBind) {
             return;
         }
 
-        $isInterceptor = $reflection->implementsInterface(MethodInterceptor::class);
-        $isWeaved = $reflection->implementsInterface(WeavedInterface::class);
-        if ($isInterceptor || $isWeaved) {
-            return;
+        $className = (string) $this->newInstance;
+        $class = $compiler->compile($className, $bind);
+        $this->newInstance->weaveAspects($class, $bind);
+    }
+
+    /**
+     * Read-only counterpart of weaveAspects() for introspection
+     *
+     * Returns the same '(dependency) ClassName (aop) +method(...)' string that
+     * stringifying a spy-woven dependency produces, but WITHOUT mutating $this
+     * — so callers (ModuleString) no longer need to deep-copy the container to
+     * protect it from the spy weave.
+     *
+     * @param PointcutList $pointcuts
+     */
+    public function describe(array $pointcuts): string
+    {
+        $className = (string) $this->newInstance;
+        $bind = $this->aopBind($pointcuts);
+        if ($bind instanceof AopBind) {
+            $className = (new SpyCompiler())->compile($className, $bind);
+        }
+
+        return sprintf('(dependency) %s', $className);
+    }
+
+    /**
+     * Match pointcuts against this dependency's class, read-only
+     *
+     * @param PointcutList $pointcuts
+     *
+     * @return ?AopBind the matched bindings, or null when nothing is intercepted
+     */
+    private function aopBind(array $pointcuts): ?AopBind
+    {
+        $className = (string) $this->newInstance;
+        $reflection = new ReflectionClass($className);
+        if ($reflection->isFinal()) {
+            return null;
+        }
+
+        if ($reflection->implementsInterface(MethodInterceptor::class) || $reflection->implementsInterface(WeavedInterface::class)) {
+            return null;
         }
 
         $bind = new AopBind();
-        $className = (string) $this->newInstance;
         $bind->bind($className, $pointcuts);
-        if (! $bind->getBindings()) {
-            return;
-        }
 
-        $class = $compiler->compile($className, $bind);
-        $this->newInstance->weaveAspects($class, $bind);
+        return $bind->getBindings() ? $bind : null;
     }
 
     /** @inheritDoc */

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -22,10 +22,6 @@ final class ModuleString
     {
         $log = [];
         foreach ($container->getContainer() as $dependencyIndex => $dependency) {
-            // Dependency::describe() computes the AOP annotation read-only, so —
-            // unlike the former spy weave — the container is neither mutated nor
-            // serialize()-deep-copied to protect it (which also threw on
-            // unserializable instances such as closures bound via toInstance()).
             $log[] = sprintf(
                 '%s => %s',
                 $dependencyIndex,

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-use function assert;
 use function implode;
-use function serialize;
 use function sort;
 use function sprintf;
-use function unserialize;
 
 use const PHP_EOL;
 
@@ -24,19 +21,15 @@ final class ModuleString
     public function __invoke(Container $container, array $pointcuts): string
     {
         $log = [];
-        /** @psalm-suppress MixedAssignment */
-        $container = unserialize(serialize($container), ['allowed_classes' => true]);
-        assert($container instanceof Container);
-        $spy = new SpyCompiler();
         foreach ($container->getContainer() as $dependencyIndex => $dependency) {
-            if ($dependency instanceof Dependency) {
-                $dependency->weaveAspects($spy, $pointcuts);
-            }
-
+            // Dependency::describe() computes the AOP annotation read-only, so —
+            // unlike the former spy weave — the container is neither mutated nor
+            // serialize()-deep-copied to protect it (which also threw on
+            // unserializable instances such as closures bound via toInstance()).
             $log[] = sprintf(
                 '%s => %s',
                 $dependencyIndex,
-                (string) $dependency
+                $dependency instanceof Dependency ? $dependency->describe($pointcuts) : (string) $dependency
             );
         }
 

--- a/tests/di/Fake/FakeClosureBindModule.php
+++ b/tests/di/Fake/FakeClosureBindModule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Binds a closure via toInstance() — an unserializable value.
+ *
+ * Used to prove ModuleString renders such a binding instead of throwing, the
+ * way the former serialize()-based deep copy did.
+ */
+class FakeClosureBindModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $this->bind('')->annotatedWith('callback')->toInstance(static fn (): int => 1);
+    }
+}

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -65,4 +65,24 @@ Ray\Di\FakeAopInterface- => (dependency) Ray\Di\FakeAop (aop) +returnSame(Ray\Di
 Ray\Di\FakeDoubleInterceptor- => (dependency) Ray\Di\FakeDoubleInterceptor
 Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider'), $normalize($string));
     }
+
+    /**
+     * A closure bound via toInstance() must not break introspection. The old
+     * ModuleString deep-copied the whole container with serialize(), which
+     * threw "Serialization of 'Closure' is not allowed"; describe() reads the
+     * container in place, so an unserializable instance renders as an object.
+     *
+     * @covers \Ray\Di\ModuleString::__invoke
+     */
+    public function testToStringWithClosureInstanceDoesNotThrow(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind('')->annotatedWith('callback')->toInstance(static fn (): int => 1);
+            }
+        };
+
+        $this->assertStringContainsString('-callback => (object) Closure', (string) $module);
+    }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -76,12 +76,7 @@ Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider')
      */
     public function testToStringWithClosureInstanceDoesNotThrow(): void
     {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->bind('')->annotatedWith('callback')->toInstance(static fn (): int => 1);
-            }
-        };
+        $module = new FakeClosureBindModule();
 
         $this->assertStringContainsString('-callback => (object) Closure', (string) $module);
     }


### PR DESCRIPTION
## Summary

`ModuleString` deep-copied the **entire container** via `unserialize(serialize($container))` on every `(string) $module`, purely to protect the real container from the destructive spy-weave it then ran to collect AOP annotations. That deep copy had two real costs:

- It threw `Serialization of 'Closure' is not allowed` for any closure / PDO / resource bound via `toInstance()`. Best-effort callers then silently lost the whole binding listing.
- On a real-weaved container it exhausted memory outright (OOM), not just ran slowly.

The AOP annotation was already available **read-only**: Ray.Aop's `Bind::bind()` matches methods against pointcuts without mutation, and `SpyCompiler::compile()` formats the `(aop) +method(...)` string as a pure function. The `serialize()` clone only existed because the collection was routed through the *mutating* `Dependency::weaveAspects()`.

## Change

- `Dependency::describe(array $pointcuts): string` — a non-mutating counterpart of `weaveAspects()` that returns the same `(dependency) ClassName (aop) +method(...)` string, without touching `$this`.
- `ModuleString::__invoke()` calls `describe()` directly: no clone, no mutation, no `serialize()`.
- `weaveAspects()` (the real-injection path) and `describe()` share the guard + pointcut-match via a private `aopBind()`; injection behaves identically.

Output is **byte-identical**, pinned by the unchanged `ModuleTest::testToString` golden string.

## Measured (235-entry BeMart module, xdebug/xprofile + wall-clock)

| Path | Before (serialize) | After (describe) |
| --- | --- | --- |
| fresh module `(string) $module` | 2.64 ms / 206 MB | **1.99 ms / 194 MB** |
| real-weaved container | **OOM (>128 MB)** | no serialize, renders in place |
| output (BeMart) | `649a36682df3` | `649a36682df3` (identical) |

The remaining ~2 ms is the pointcut matching itself, run once per `(string) $module`. The headline win is memory and robustness: a real-weaved container's whole-graph `serialize()` exceeded 128 MB and crashed; the in-place read no longer serializes, and a closure bound via `toInstance()` no longer breaks the listing.

## Testing

- 233 tests, 100% line coverage (pcov); cs + Psalm + PHPStan clean
- `ModuleTest::testToString` (golden string) unchanged → output byte-identical
- `testToStringWithClosureInstanceDoesNotThrow`, red-first: threw at `ModuleString.php:28` on the serialize version, green now

Independent of the DI resolution path — this only changes how bindings are rendered for `__toString()`.
