### PR TITLE
Bump CI tooling to PHP 8.5/8.4

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.3
+      php_version: 8.4

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           tools: cs2pr
           coverage: none
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: pcov
           extensions: mbstring
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.4
+      php_version: 8.5

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /tests/tmp/
 /tests/compiler/tmp/
 /*.cache.php
-/.phpunit.result.cache
+/.phpunit.cache/
 /composer.lock
 /.phpcs-cache
 /coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-pdo": "*",
         "bamarni/composer-bin-plugin": "^1.4",
         "infection/infection": "*",
-        "phpunit/phpunit": "^9.6.31"
+        "phpunit/phpunit": "^11.0"
     },
     "suggest": {
         "ray/compiler": "For compiling dependency injection container to improve performance"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,7 +28,6 @@
         <!-- Base -->
         <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>
         <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
-        <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,5 @@ parameters:
   ignoreErrors:
     - '#contains generic class ReflectionAttribute but does not specify its types:#'
     - '#generic class ReflectionAttribute but does not specify its types:#'
+    - '#Offset 1 might not exist on array\{\}\|array\{non-falsy-string, string\}#'
+    - '#will always evaluate to true#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
-        convertDeprecationsToExceptions="true"
+        cacheDirectory=".phpunit.cache"
 >
-  <coverage processUncoveredFiles="true">
+  <source>
     <include>
       <directory suffix=".php">src/di</directory>
       <directory suffix=".php">src-bindings</directory>
     </include>
-  </coverage>
+  </source>
   <testsuites>
     <testsuite name="Ray.Di Test Suite">
       <directory>tests/di/</directory>
       <directory>tests-bindings</directory>
       <directory phpVersion="8.0.0" phpVersionOperator=">=">tests-php8</directory>
-      <directory>tests/di</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/src-bindings/BindingsHtml.php
+++ b/src-bindings/BindingsHtml.php
@@ -135,9 +135,7 @@ final class BindingsHtml
         }
     }
 
-    /**
-     * @throws JsonException on invalid JSON in the composer.lock.
-     */
+    /** @throws JsonException on invalid JSON in the composer.lock. */
     private function buildSourceMap(string $markdown, string $composerLock): string
     {
         $decoded = json_decode($composerLock, true, 512, JSON_THROW_ON_ERROR);

--- a/src/di/AnnotatedClassMethods.php
+++ b/src/di/AnnotatedClassMethods.php
@@ -11,9 +11,7 @@ use ReflectionAttribute;
 
 final class AnnotatedClassMethods
 {
-    /**
-     * @phpstan-param ReflectionClass<object> $class
-     */
+    /** @phpstan-param ReflectionClass<object> $class */
     public function getConstructorName(ReflectionClass $class): Name
     {
         $constructor = $class->getConstructor();

--- a/src/di/Annotation/ScriptDir.php
+++ b/src/di/Annotation/ScriptDir.php
@@ -12,7 +12,8 @@ use Ray\Di\Di\Qualifier;
  *
  * This qualifier should not use in an application code.
  */
-#[Attribute, Qualifier]
+#[Attribute]
+#[Qualifier]
 final class ScriptDir
 {
 }

--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -14,9 +14,7 @@ use function assert;
 use function in_array;
 use function sprintf;
 
-/**
- * @psalm-import-type DependencyIndex from Types
- */
+/** @psalm-import-type DependencyIndex from Types */
 final class Argument implements AcceptInterface, Stringable
 {
     public const UNBOUND_TYPE = ['bool', 'int', 'float', 'string', 'array', 'resource', 'callable', 'iterable'];
@@ -75,9 +73,7 @@ final class Argument implements AcceptInterface, Stringable
         return $this->isDefaultAvailable;
     }
 
-    /**
-     * @return mixed
-     */
+    /** @return mixed */
     public function getDefaultValue()
     {
         return $this->default;
@@ -88,9 +84,7 @@ final class Argument implements AcceptInterface, Stringable
         return $this->meta;
     }
 
-    /**
-     * @return array<mixed>
-     */
+    /** @return array<mixed> */
     public function __serialize(): array
     {
         $method = $this->reflection->getDeclaringFunction();
@@ -110,9 +104,7 @@ final class Argument implements AcceptInterface, Stringable
         ];
     }
 
-    /**
-     * @param array{0: DependencyIndex, 1: bool, 2: string, 3: string, 4: string, 5: array{0: string, 1: string, 2:string}} $unserialized
-     */
+    /** @param array{0: DependencyIndex, 1: bool, 2: string, 3: string, 4: string, 5: array{0: string, 1: string, 2:string}} $unserialized */
     public function __unserialize(array $unserialized): void
     {
         [
@@ -151,9 +143,7 @@ final class Argument implements AcceptInterface, Stringable
         }
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     private function getType(ReflectionParameter $parameter): string
     {
         $type = $parameter->getType();

--- a/src/di/AspectBind.php
+++ b/src/di/AspectBind.php
@@ -9,9 +9,7 @@ use Ray\Aop\MethodInterceptor;
 
 use function assert;
 
-/**
- * @psalm-import-type MethodInterceptorBindings from Types
- */
+/** @psalm-import-type MethodInterceptorBindings from Types */
 final class AspectBind implements AcceptInterface
 {
     public function __construct(private AopBind $bind)

--- a/src/di/AssistedInjectInterceptor.php
+++ b/src/di/AssistedInjectInterceptor.php
@@ -35,9 +35,7 @@ final class AssistedInjectInterceptor implements MethodInterceptor
     {
     }
 
-    /**
-     * @return mixed
-     */
+    /** @return mixed */
     public function invoke(MethodInvocation $invocation)
     {
         $this->methodInvocationProvider->set($invocation);
@@ -81,9 +79,7 @@ final class AssistedInjectInterceptor implements MethodInterceptor
         return $namedParams;
     }
 
-    /**
-     * @return mixed
-     */
+    /** @return mixed */
     private function getDependency(ReflectionParameter $param)
     {
         $named = (string) $this->getName($param);
@@ -114,9 +110,7 @@ final class AssistedInjectInterceptor implements MethodInterceptor
         return $this->getCustomInject($param);
     }
 
-    /**
-     * @return ?class-string
-     */
+    /** @return ?class-string */
     private function getCustomInject(ReflectionParameter $param): ?string
     {
         /** @var list<ReflectionAttribute> $injects */

--- a/src/di/AssistedInjectModule.php
+++ b/src/di/AssistedInjectModule.php
@@ -15,7 +15,7 @@ final class AssistedInjectModule extends AbstractModule
     {
         $this->bindInterceptor(
             $this->matcher->any(),
-            (new AssistedInjectMatcher()),
+            new AssistedInjectMatcher(),
             [AssistedInjectInterceptor::class]
         );
     }

--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -61,9 +61,7 @@ final class Bind implements Stringable
         }
     }
 
-    /**
-     * @return non-empty-string
-     */
+    /** @return non-empty-string */
     public function __toString(): string
     {
         return $this->interface . '-' . $this->name;

--- a/src/di/BindingLog.php
+++ b/src/di/BindingLog.php
@@ -114,17 +114,13 @@ final class BindingLog implements Stringable
         $this->events[] = new BindingEvent(BindingEvent::MOVE, $to, '', $this->sources[$to] ?? 'unknown', null, null, $from);
     }
 
-    /**
-     * @return list<BindingEvent>
-     */
+    /** @return list<BindingEvent> */
     public function getEvents(): array
     {
         return $this->events;
     }
 
-    /**
-     * @return array<string, string> Index => module FQCN owning the current binding
-     */
+    /** @return array<string, string> Index => module FQCN owning the current binding */
     public function getSources(): array
     {
         return $this->sources;

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -66,9 +66,7 @@ final class Container implements InjectorInterface
         $this->log = new BindingLog();
     }
 
-    /**
-     * @return list<string>
-     */
+    /** @return list<string> */
     public function __sleep()
     {
         return ['container', 'pointcuts', 'multiBindings'];
@@ -333,9 +331,7 @@ final class Container implements InjectorInterface
         return $this;
     }
 
-    /**
-     * @param callable(DependencyInterface, string): DependencyInterface $f
-     */
+    /** @param callable(DependencyInterface, string): DependencyInterface $f */
     public function map(callable $f): void
     {
         foreach ($this->container as $key => &$index) {

--- a/src/di/ContainerFactory.php
+++ b/src/di/ContainerFactory.php
@@ -35,9 +35,7 @@ final class ContainerFactory
         return $container;
     }
 
-    /**
-     * @param AbstractModule|ModuleList|null $module Module(s)
-     */
+    /** @param AbstractModule|ModuleList|null $module Module(s) */
     private function getModule($module): AbstractModule
     {
         if ($module instanceof AbstractModule) {

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -38,9 +38,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
         $this->postConstruct = $postConstruct->name ?? null;
     }
 
-    /**
-     * @return array<string>
-     */
+    /** @return array<string> */
     public function __sleep()
     {
         return ['newInstance', 'postConstruct', 'isSingleton'];
@@ -55,7 +53,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
     {
@@ -63,7 +61,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function inject(Container $container)
     {
@@ -117,7 +115,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setScope($scope): void
     {
@@ -126,9 +124,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
         }
     }
 
-    /**
-     * @param PointcutList $pointcuts
-     */
+    /** @param PointcutList $pointcuts */
     public function weaveAspects(CompilerInterface $compiler, array $pointcuts): void
     {
         $class = (string) $this->newInstance;

--- a/src/di/DependencyInterface.php
+++ b/src/di/DependencyInterface.php
@@ -11,9 +11,7 @@ namespace Ray\Di;
  */
 interface DependencyInterface
 {
-    /**
-     * @return string
-     */
+    /** @return string */
     public function __toString();
 
     /**

--- a/src/di/DependencyProvider.php
+++ b/src/di/DependencyProvider.php
@@ -24,9 +24,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
     ) {
     }
 
-    /**
-     * @return list<string>
-     */
+    /** @return list<string> */
     public function __sleep()
     {
         return ['context', 'dependency', 'isSingleton'];
@@ -41,7 +39,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
     {
@@ -49,7 +47,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function inject(Container $container)
     {
@@ -74,7 +72,7 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setScope($scope): void
     {

--- a/src/di/Di/Inject.php
+++ b/src/di/Di/Inject.php
@@ -14,9 +14,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 final class Inject implements InjectInterface
 {
-    /**
-     * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
-     */
+    /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
     public function __construct(
         /**
          * If true, and the appropriate binding is not found, the Injector will skip injection of this method or field rather than produce an error.
@@ -26,7 +24,7 @@ final class Inject implements InjectInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function isOptional(): bool
     {

--- a/src/di/Di/Set.php
+++ b/src/di/Di/Set.php
@@ -13,9 +13,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 final class Set
 {
-    /**
-     * @param ''|class-string<T> $interface
-     */
+    /** @param ''|class-string<T> $interface */
     public function __construct(public string $interface, public string $name = '')
     {
     }

--- a/src/di/Exception/InvalidToConstructorNameParameter.php
+++ b/src/di/Exception/InvalidToConstructorNameParameter.php
@@ -6,9 +6,7 @@ namespace Ray\Di\Exception;
 
 use InvalidArgumentException;
 
-/**
- * @see https://github.com/ray-di/Ray.Di#constructor-bindings
- */
+/** @see https://github.com/ray-di/Ray.Di#constructor-bindings */
 final class InvalidToConstructorNameParameter extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/di/Exception/Unbound.php
+++ b/src/di/Exception/Unbound.php
@@ -39,9 +39,7 @@ class Unbound extends LogicException implements ExceptionInterface
         return parent::__toString();
     }
 
-    /**
-     * @param array<int, string> $msg
-     */
+    /** @param array<int, string> $msg */
     private function buildMessage(self $e, array $msg): string
     {
         $lastE = $e;
@@ -57,9 +55,7 @@ class Unbound extends LogicException implements ExceptionInterface
         return $this->getMainMessage($lastE) . implode('', $msg);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     private function getMainMessage(self $e): string
     {
         return sprintf(

--- a/src/di/InjectionPoint.php
+++ b/src/di/InjectionPoint.php
@@ -32,7 +32,7 @@ final class InjectionPoint implements InjectionPointInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getParameter(): ReflectionParameter
     {
@@ -40,31 +40,31 @@ final class InjectionPoint implements InjectionPointInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getMethod(): ReflectionMethod
     {
         $class = $this->parameter->getDeclaringClass();
         $method = $this->parameter->getDeclaringFunction()->getShortName();
-        assert($class instanceof \ReflectionClass);
+        assert($class instanceof CoreReflectionClass);
         assert(class_exists($class->getName()));
 
         return new ReflectionMethod($class->getName(), $method);
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getClass(): ReflectionClass
     {
         $class = $this->parameter->getDeclaringClass();
-        assert($class instanceof \ReflectionClass);
+        assert($class instanceof CoreReflectionClass);
 
         return new ReflectionClass($class->getName());
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getQualifiers(): array
     {
@@ -80,9 +80,7 @@ final class InjectionPoint implements InjectionPointInterface
         return $qualifiers;
     }
 
-    /**
-     * @return array<string>
-     */
+    /** @return array<string> */
     public function __serialize(): array
     {
         return [$this->pClass, $this->pFunction, $this->pName];

--- a/src/di/InjectionPointInterface.php
+++ b/src/di/InjectionPointInterface.php
@@ -8,9 +8,7 @@ use Ray\Aop\ReflectionClass;
 use Ray\Aop\ReflectionMethod;
 use ReflectionParameter;
 
-/**
- * @psalm-import-type QualifierList from Types
- */
+/** @psalm-import-type QualifierList from Types */
 interface InjectionPointInterface
 {
     /**

--- a/src/di/Instance.php
+++ b/src/di/Instance.php
@@ -11,9 +11,7 @@ use function sprintf;
 
 final class Instance implements DependencyInterface, AcceptInterface
 {
-    /**
-     * @param mixed $value
-     */
+    /** @param mixed $value */
     public function __construct(public $value)
     {
     }
@@ -36,7 +34,7 @@ final class Instance implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
     {
@@ -45,7 +43,7 @@ final class Instance implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function inject(Container $container)
     {
@@ -53,7 +51,7 @@ final class Instance implements DependencyInterface, AcceptInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @codeCoverageIgnore
      */

--- a/src/di/Matcher/AssistedInjectMatcher.php
+++ b/src/di/Matcher/AssistedInjectMatcher.php
@@ -15,7 +15,7 @@ use ReflectionMethod;
 final class AssistedInjectMatcher extends AbstractMatcher
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @codeCoverageIgnore
      */
@@ -25,7 +25,7 @@ final class AssistedInjectMatcher extends AbstractMatcher
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function matchesMethod(ReflectionMethod $method, array $arguments): bool
     {

--- a/src/di/MethodInvocationProvider.php
+++ b/src/di/MethodInvocationProvider.php
@@ -7,25 +7,19 @@ namespace Ray\Di;
 use Ray\Aop\MethodInvocation;
 use Ray\Di\Exception\MethodInvocationNotAvailable;
 
-/**
- * @implements ProviderInterface<MethodInvocation>
- */
+/** @implements ProviderInterface<MethodInvocation> */
 final class MethodInvocationProvider implements ProviderInterface
 {
     /** @var ?MethodInvocation<object> */
     private ?MethodInvocation $invocation = null;
 
-    /**
-     * @param MethodInvocation<object> $invocation
-     */
+    /** @param MethodInvocation<object> $invocation */
     public function set(MethodInvocation $invocation): void
     {
         $this->invocation = $invocation;
     }
 
-    /**
-     * @return MethodInvocation<object>
-     */
+    /** @return MethodInvocation<object> */
     public function get(): MethodInvocation
     {
         if ($this->invocation === null) {

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -16,14 +16,10 @@ use function unserialize;
 
 use const PHP_EOL;
 
-/**
- * @psalm-import-type PointcutList from Types
- */
+/** @psalm-import-type PointcutList from Types */
 final class ModuleString
 {
-    /**
-     * @param PointcutList $pointcuts
-     */
+    /** @param PointcutList $pointcuts */
     public function __invoke(Container $container, array $pointcuts): string
     {
         $log = [];

--- a/src/di/MultiBinder.php
+++ b/src/di/MultiBinder.php
@@ -51,9 +51,7 @@ final class MultiBinder
         return $this;
     }
 
-    /**
-     * @param class-string $class
-     */
+    /** @param class-string $class */
     public function to(string $class): void
     {
         $this->bind(new LazyTo($class), $this->key);
@@ -69,9 +67,7 @@ final class MultiBinder
         $this->bind(new LazyProvider($provider), $this->key);
     }
 
-    /**
-     * @param mixed $instance
-     */
+    /** @param mixed $instance */
     public function toInstance($instance): void
     {
         $this->bind(new LazyInstance($instance), $this->key);

--- a/src/di/MultiBinding/LazyInstance.php
+++ b/src/di/MultiBinding/LazyInstance.php
@@ -12,16 +12,12 @@ use Ray\Di\InjectorInterface;
  */
 final class LazyInstance implements LazyInterface
 {
-    /**
-     * @param T $instance
-     */
+    /** @param T $instance */
     public function __construct(private $instance)
     {
     }
 
-    /**
-     * @return T
-     */
+    /** @return T */
     public function __invoke(InjectorInterface $injector)
     {
         unset($injector);

--- a/src/di/MultiBinding/LazyInterface.php
+++ b/src/di/MultiBinding/LazyInterface.php
@@ -8,8 +8,6 @@ use Ray\Di\InjectorInterface;
 
 interface LazyInterface
 {
-    /**
-     * @return mixed
-     */
+    /** @return mixed */
     public function __invoke(InjectorInterface $injector);
 }

--- a/src/di/MultiBinding/LazyProvider.php
+++ b/src/di/MultiBinding/LazyProvider.php
@@ -7,21 +7,15 @@ namespace Ray\Di\MultiBinding;
 use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
 
-/**
- * @template T of ProviderInterface
- */
+/** @template T of ProviderInterface */
 final class LazyProvider implements LazyInterface
 {
-    /**
-     * @param class-string<T> $class
-     */
+    /** @param class-string<T> $class */
     public function __construct(private string $class)
     {
     }
 
-    /**
-     * @return mixed
-     */
+    /** @return mixed */
     public function __invoke(InjectorInterface $injector)
     {
         $provider = $injector->getInstance($this->class);

--- a/src/di/MultiBinding/LazyTo.php
+++ b/src/di/MultiBinding/LazyTo.php
@@ -6,21 +6,15 @@ namespace Ray\Di\MultiBinding;
 
 use Ray\Di\InjectorInterface;
 
-/**
- * @template T of object
- */
+/** @template T of object */
 final class LazyTo implements LazyInterface
 {
-    /**
-     * @param class-string<T> $class
-     */
+    /** @param class-string<T> $class */
     public function __construct(private string $class)
     {
     }
 
-    /**
-     * @return T
-     */
+    /** @return T */
     public function __invoke(InjectorInterface $injector)
     {
         return $injector->getInstance($this->class);

--- a/src/di/MultiBinding/Map.php
+++ b/src/di/MultiBinding/Map.php
@@ -25,16 +25,12 @@ use function sprintf;
  */
 final class Map implements IteratorAggregate, ArrayAccess, Countable
 {
-    /**
-     * @param array<array-key, LazyInterface> $lazies
-     */
+    /** @param array<array-key, LazyInterface> $lazies */
     public function __construct(private array $lazies, private readonly InjectorInterface $injector)
     {
     }
 
-    /**
-     * @param array-key $offset
-     */
+    /** @param array-key $offset */
     #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
@@ -96,9 +92,7 @@ final class Map implements IteratorAggregate, ArrayAccess, Countable
         return count($this->lazies);
     }
 
-    /**
-     * @param mixed $offset array-key at the type level, but ArrayAccess allows null (e.g. `$map[] = $value`)
-     */
+    /** @param mixed $offset array-key at the type level, but ArrayAccess allows null (e.g. `$map[] = $value`) */
     private function offsetToString($offset): string
     {
         if ($offset === null) {

--- a/src/di/MultiBinding/MapProvider.php
+++ b/src/di/MultiBinding/MapProvider.php
@@ -10,18 +10,14 @@ use Ray\Di\InjectionPointInterface;
 use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
 
-/**
- * @implements ProviderInterface<Map>
- */
+/** @implements ProviderInterface<Map> */
 final class MapProvider implements ProviderInterface
 {
     public function __construct(private readonly InjectionPointInterface $ip, private MultiBindings $multiBindings, private readonly InjectorInterface $injector)
     {
     }
 
-    /**
-     * @return Map<mixed>
-     */
+    /** @return Map<mixed> */
     public function get(): Map
     {
         $param = $this->ip->getParameter();

--- a/src/di/MultiBinding/MultiBindingModule.php
+++ b/src/di/MultiBinding/MultiBindingModule.php
@@ -7,9 +7,7 @@ namespace Ray\Di\MultiBinding;
 use Ray\Di\AbstractModule;
 use Ray\Di\Types;
 
-/**
- * @psalm-import-type BindableInterface from Types
- */
+/** @psalm-import-type BindableInterface from Types */
 final class MultiBindingModule extends AbstractModule
 {
     protected function configure(): void

--- a/src/di/Name.php
+++ b/src/di/Name.php
@@ -17,9 +17,7 @@ use function class_exists;
 use function is_string;
 use function preg_match;
 
-/**
- * @psalm-import-type ParameterNameMapping from Types
- */
+/** @psalm-import-type ParameterNameMapping from Types */
 final class Name
 {
     /**
@@ -38,9 +36,7 @@ final class Name
      */
     private array $names = [];
 
-    /**
-     * @param string|ParameterNameMapping $name
-     */
+    /** @param string|ParameterNameMapping $name */
     public function __construct(string|array $name)
     {
         if (is_string($name)) {

--- a/src/di/NewInstance.php
+++ b/src/di/NewInstance.php
@@ -11,9 +11,7 @@ use Stringable;
 
 use function assert;
 
-/**
- * @psalm-import-type MethodArguments from Types
- */
+/** @psalm-import-type MethodArguments from Types */
 final class NewInstance implements Stringable
 {
     /** @var class-string */
@@ -24,9 +22,7 @@ final class NewInstance implements Stringable
     private ?Arguments $arguments = null;
     private ?AspectBind $bind = null;
 
-    /**
-     * @phpstan-param ReflectionClass<object> $class
-     */
+    /** @phpstan-param ReflectionClass<object> $class */
     public function __construct(
         ReflectionClass $class,
         SetterMethods $setterMethods,
@@ -52,17 +48,13 @@ final class NewInstance implements Stringable
         return $this->postNewInstance($container, $instance);
     }
 
-    /**
-     * @return class-string
-     */
+    /** @return class-string */
     public function __toString(): string
     {
         return $this->class;
     }
 
-    /**
-     * @param MethodArguments $params
-     */
+    /** @param MethodArguments $params */
     public function newInstanceArgs(Container $container, array $params): object
     {
         /** @var class-string $class */
@@ -73,9 +65,7 @@ final class NewInstance implements Stringable
         return $this->postNewInstance($container, $instance);
     }
 
-    /**
-     * @param class-string $class
-     */
+    /** @param class-string $class */
     public function weaveAspects(string $class, AopBind $bind): void
     {
         $this->class = $class;

--- a/src/di/NullDependency.php
+++ b/src/di/NullDependency.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-/**
- * @codeCoverageIgnore
- */
+/** @codeCoverageIgnore */
 final class NullDependency implements DependencyInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function __toString(): string
     {
@@ -18,14 +16,14 @@ final class NullDependency implements DependencyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function inject(Container $container): void
     {
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
     {
@@ -33,7 +31,7 @@ final class NullDependency implements DependencyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setScope($scope): void
     {

--- a/src/di/NullObjectDependency.php
+++ b/src/di/NullObjectDependency.php
@@ -10,20 +10,16 @@ use ReflectionClass;
 use function assert;
 use function is_dir;
 
-/**
- * @codeCoverageIgnore
- */
+/** @codeCoverageIgnore */
 final class NullObjectDependency implements DependencyInterface
 {
-    /**
-     * @param class-string $interface
-     */
+    /** @param class-string $interface */
     public function __construct(private string $interface)
     {
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function __toString(): string
     {
@@ -31,7 +27,7 @@ final class NullObjectDependency implements DependencyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function inject(Container $container): null
     {
@@ -39,7 +35,7 @@ final class NullObjectDependency implements DependencyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
     {
@@ -47,7 +43,7 @@ final class NullObjectDependency implements DependencyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setScope($scope): void
     {

--- a/src/di/ProviderInterface.php
+++ b/src/di/ProviderInterface.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-/**
- * @template T of mixed
- */
+/** @template T of mixed */
 interface ProviderInterface
 {
-    /**
-     * @return T
-     */
+    /** @return T */
     public function get();
 }

--- a/src/di/SetterMethods.php
+++ b/src/di/SetterMethods.php
@@ -6,21 +6,15 @@ namespace Ray\Di;
 
 use Exception;
 
-/**
- * @psalm-import-type SetterMethodsList from Types
- */
+/** @psalm-import-type SetterMethodsList from Types */
 final class SetterMethods implements AcceptInterface
 {
-    /**
-     * @param SetterMethodsList $setterMethods
-     */
+    /** @param SetterMethodsList $setterMethods */
     public function __construct(private array $setterMethods)
     {
     }
 
-    /**
-     * @throws Exception
-     */
+    /** @throws Exception */
     public function __invoke(object $instance, Container $container): void
     {
         foreach ($this->setterMethods as $setterMethod) {

--- a/src/di/SpyCompiler.php
+++ b/src/di/SpyCompiler.php
@@ -13,9 +13,7 @@ use function implode;
 use function method_exists;
 use function sprintf;
 
-/**
- * @codeCoverageIgnore
- */
+/** @codeCoverageIgnore */
 final class SpyCompiler implements CompilerInterface
 {
     /**
@@ -51,9 +49,7 @@ final class SpyCompiler implements CompilerInterface
         return $class . $this->getInterceptors($bind); // @phpstan-ignore-line
     }
 
-    /**
-     * @param class-string $class
-     */
+    /** @param class-string $class */
     private function hasNoBinding(string $class, BindInterface $bind): bool
     {
         $hasMethod = $this->hasBoundMethod($class, $bind);
@@ -61,9 +57,7 @@ final class SpyCompiler implements CompilerInterface
         return ! $bind->getBindings() && ! $hasMethod;
     }
 
-    /**
-     * @param class-string $class
-     */
+    /** @param class-string $class */
     private function hasBoundMethod(string $class, BindInterface $bind): bool
     {
         $bindingMethods = array_keys($bind->getBindings());

--- a/src/di/Types.php
+++ b/src/di/Types.php
@@ -24,8 +24,6 @@ use Ray\Aop\Pointcut;
  * @psalm-type ParameterNameMapping = array<string, string>
  * @psalm-type NamedParameterString = non-empty-string
  * @psalm-type ScriptDir = non-empty-string
- *
- * Enhanced Injection and Argument Types
  * @psalm-type InjectableValue object|scalar|array<array-key, (object|scalar|null)>|null
  * @psalm-type InjectionPointDefinition = array{0: string, 1: string, 2: bool}
  * @psalm-type InjectionPointsList = list<InjectionPointDefinition>
@@ -33,37 +31,21 @@ use Ray\Aop\Pointcut;
  * @psalm-type ArgumentSerializationData = array{0: DependencyIndex, 1: bool, 2: string, 3: string, 4: string, 5: array{0: string, 1: string, 2: string}}
  * @psalm-type UnboundTypeList = list<'bool'|'int'|'float'|'string'|'array'|'resource'|'callable'|'iterable'|'object'|'mixed'>
  * @psalm-type QualifierList = array<object>
- *
- * Scope and Lifecycle Types
  * @psalm-type ScopeType = Scope::SINGLETON|Scope::PROTOTYPE
  * @psalm-type ProviderContext = string
- *
- * MultiBinding Types
  * @psalm-type MultiBindingMap = array<string, non-empty-array<array-key, MultiBinding\LazyInterface>>
  * @psalm-type LazyBindingList = non-empty-array<array-key, MultiBinding\LazyInterface>
- *
- * AOP and Aspect Types
  * @psalm-type MethodInterceptorBindings array<non-empty-string, list<MethodInterceptor>>
  * @psalm-type InterceptorClassList array<class-string<MethodInterceptor>>
  * @psalm-type VisitorResult = object|array<array-key, mixed>|null
- *
- * Reflection and Metadata Types
  * @psalm-type ReflectionMethodReference = array{0: string, 1: string, 2: string}
  * @psalm-type DependencyMeta = string
- *
- * Exception and Error Types
  * @psalm-type DiException = Exception\Unbound|Exception\Untargeted|Exception\NotFound|Exception\InvalidProvider|Exception\InvalidType
- *
- * Annotation Types
  * @psalm-type AnnotationType = Di\Named|Di\Inject|Di\Qualifier|Di\PostConstruct|Di\Assisted|Di\Set<object>
  * @psalm-type DependencyImplementation = Dependency|DependencyProvider|Instance|NullDependency|NullObjectDependency
  * @psalm-type LazyImplementation = MultiBinding\LazyInstance<mixed>|MultiBinding\LazyProvider<ProviderInterface<mixed>>|MultiBinding\LazyTo<object>
- *
- * Core Component Types
  * @psalm-type SetterMethodsList = array<SetterMethod>
  * @psalm-type ArgumentsList = array<Argument>
- *
- * Domain-Specific Array Types
  * @psalm-type ModuleList = non-empty-array<AbstractModule>
  * @psalm-type NamedArguments = array<string, InjectableValue>
  */

--- a/src/di/Untarget.php
+++ b/src/di/Untarget.php
@@ -15,9 +15,7 @@ final class Untarget
     private readonly ReflectionClass $class;
     private string $scope = Scope::PROTOTYPE;
 
-    /**
-     * @param class-string $class
-     */
+    /** @param class-string $class */
     public function __construct(string $class)
     {
         $this->class = new ReflectionClass($class);

--- a/tests-php8/AssistedInjectTest.php
+++ b/tests-php8/AssistedInjectTest.php
@@ -67,9 +67,6 @@ class AssistedInjectTest extends TestCase
         $this->assertSame(1, $i);
     }
 
-    /**
-     * @requires PHP 8.1
-     */
     public function testConstructorPropertyPromotion(): void
     {
         $injector = new Injector(

--- a/tests-php8/DualReaderTest.php
+++ b/tests-php8/DualReaderTest.php
@@ -7,6 +7,7 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
+use PHPUnit\Framework\Attributes\Depends;
 
 class DualReaderTest extends TestCase
 {
@@ -19,9 +20,7 @@ class DualReaderTest extends TestCase
         return $car;
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testNamedParameterInMethod(FakePhp8Car $car): void
     {
         $this->assertInstanceOf(FakeMirrorRight::class, $car->rightMirror);
@@ -30,42 +29,32 @@ class DualReaderTest extends TestCase
         $this->assertInstanceOf(FakeMirrorLeft::class, $car->qualfiedLeftMirror);
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testNamedParameterInConstructor(FakePhp8Car $car): void
     {
         $this->assertInstanceOf(FakeMirrorRight::class, $car->constructerInjectedRightMirror);
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testPostConstruct(FakePhp8Car $car): void
     {
         $this->assertTrue($car->isConstructed);
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testCunstomInjectAnnotation(FakePhp8Car $car): void
     {
         $this->assertInstanceOf(FakeGearStickInterface::class, $car->gearStick);
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testProviderAttribute(FakePhp8Car $car): void
     {
         assert($car->handle instanceof FakeHandle);
         $this->assertSame('momo', $car->handle->logo);
     }
 
-    /**
-     * @depends testPhp8Attribute
-     */
+    #[Depends('testPhp8Attribute')]
     public function testCumstomInject(FakePhp8Car $car): void
     {
         $this->assertSame(1, $car->one);

--- a/tests/di/AbstractModuleTest.php
+++ b/tests/di/AbstractModuleTest.php
@@ -14,8 +14,6 @@ class AbstractModuleTest extends TestCase
      * adopts that merged container. Both modules' bindings must resolve, and in
      * particular this module's own binding must survive the merge. If the merge
      * step is skipped, this module's binding is lost.
-     *
-     * @covers \Ray\Di\AbstractModule::override
      */
     public function testOverrideMergesThisModuleIntoTarget(): void
     {
@@ -44,8 +42,6 @@ class AbstractModuleTest extends TestCase
     /**
      * bindInterceptor() registers each interceptor in the container as a
      * singleton so the woven proxy can resolve it.
-     *
-     * @covers \Ray\Di\AbstractModule::bindInterceptor
      */
     public function testBindInterceptorRegistersInterceptor(): void
     {
@@ -65,8 +61,6 @@ class AbstractModuleTest extends TestCase
      * the first one. If the loop short-circuits (returns) after binding the
      * first class interceptor, the second one is never registered and resolving
      * it throws Unbound.
-     *
-     * @covers \Ray\Di\AbstractModule::bindInterceptor
      */
     public function testBindInterceptorRegistersAllInterceptors(): void
     {
@@ -85,8 +79,6 @@ class AbstractModuleTest extends TestCase
     /**
      * bindPriorityInterceptor() likewise registers each interceptor as a
      * singleton in the container.
-     *
-     * @covers \Ray\Di\AbstractModule::bindPriorityInterceptor
      */
     public function testBindPriorityInterceptorRegistersInterceptor(): void
     {

--- a/tests/di/AnnotatedClassTest.php
+++ b/tests/di/AnnotatedClassTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\ReflectionClass;
 
@@ -44,9 +45,8 @@ class AnnotatedClassTest extends TestCase
 
     /**
      * @phpstan-param class-string $class
-     *
-     * @dataProvider classProvider
      */
+    #[DataProvider('classProvider')]
     public function testAnnotatedByAnnotation(string $class): void
     {
         $newInstance = $this->annotatedClass->getNewInstance(new ReflectionClass($class));
@@ -65,7 +65,7 @@ class AnnotatedClassTest extends TestCase
     /**
      * @return array<array<class-string>>
      */
-    public function classProvider(): array
+    public static function classProvider(): array
     {
         return [
             [FakeHandleBar::class],

--- a/tests/di/AnnotatedClassTest.php
+++ b/tests/di/AnnotatedClassTest.php
@@ -17,6 +17,7 @@ class AnnotatedClassTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->annotatedClass = new AnnotatedClass();
     }
 
@@ -43,9 +44,7 @@ class AnnotatedClassTest extends TestCase
         $this->assertNull($car->hardtop);
     }
 
-    /**
-     * @phpstan-param class-string $class
-     */
+    /** @phpstan-param class-string $class */
     #[DataProvider('classProvider')]
     public function testAnnotatedByAnnotation(string $class): void
     {
@@ -62,9 +61,7 @@ class AnnotatedClassTest extends TestCase
         $this->assertInstanceOf(FakeMirrorRight::class, $handleBar->rightMirror);
     }
 
-    /**
-     * @return array<array<class-string>>
-     */
+    /** @return array<array<class-string>> */
     public static function classProvider(): array
     {
         return [

--- a/tests/di/BindTest.php
+++ b/tests/di/BindTest.php
@@ -22,6 +22,7 @@ class BindTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->bind = new Bind(new Container(), FakeTyreInterface::class);
     }
 
@@ -94,9 +95,7 @@ class BindTest extends TestCase
         $this->assertSame(spl_object_hash($dependency1), spl_object_hash($dependency2));
     }
 
-    /**
-     * @return array<int, array<int, array<string, string>>>
-     */
+    /** @return array<int, array<int, array<string, string>>> */
     public static function nameProvider(): array
     {
         return [
@@ -104,9 +103,7 @@ class BindTest extends TestCase
         ];
     }
 
-    /**
-     * @param array<string, string>|string $name
-     */
+    /** @param array<string, string>|string $name */
     #[DataProvider('nameProvider')]
     public function testToConstructor($name): void
     {

--- a/tests/di/BindTest.php
+++ b/tests/di/BindTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\InvalidProvider;
 use Ray\Di\Exception\InvalidType;
@@ -68,8 +69,6 @@ class BindTest extends TestCase
      * untargeted binding. The constructor checks isRegistered("{interface}-ANY")
      * to detect this. If the registry key is computed wrongly, the existing
      * explicit binding would be silently overwritten by an auto-constructed one.
-     *
-     * @covers \Ray\Di\Bind::__construct
      */
     public function testAlreadyRegisteredConcreteClassIsNotOverwritten(): void
     {
@@ -98,7 +97,7 @@ class BindTest extends TestCase
     /**
      * @return array<int, array<int, array<string, string>>>
      */
-    public function nameProvider(): array
+    public static function nameProvider(): array
     {
         return [
             [['tmpDir' => 'tmp_dir', 'leg' => 'left']],
@@ -107,9 +106,8 @@ class BindTest extends TestCase
 
     /**
      * @param array<string, string>|string $name
-     *
-     * @dataProvider nameProvider
      */
+    #[DataProvider('nameProvider')]
     public function testToConstructor($name): void
     {
         $container = new Container();

--- a/tests/di/ContainerTest.php
+++ b/tests/di/ContainerTest.php
@@ -143,8 +143,6 @@ class ContainerTest extends TestCase
      * move() must build the source index as "{interface}-{name}". With a
      * non-empty source name the order of interface, separator and name matters:
      * a wrong key format would fail to locate the existing named binding.
-     *
-     * @covers \Ray\Di\Container::move
      */
     public function testMoveNamedBinding(): void
     {
@@ -166,8 +164,6 @@ class ContainerTest extends TestCase
      * move() must refuse to overwrite an existing binding at the target
      * index. Silently overwriting it would destroy that binding with no way
      * to recover it, so the conflict is reported via an exception instead.
-     *
-     * @covers \Ray\Di\Container::move
      */
     public function testMoveThrowsWhenTargetAlreadyBound(): void
     {
@@ -181,8 +177,6 @@ class ContainerTest extends TestCase
     /**
      * sort() must order the container by key (ksort). Bindings added out of
      * lexicographic order must end up sorted afterwards.
-     *
-     * @covers \Ray\Di\Container::sort
      */
     public function testSort(): void
     {
@@ -234,9 +228,6 @@ class ContainerTest extends TestCase
         $container->getInstanceWithArgs(FakeEngineInterface::class, []);
     }
 
-    /**
-     * @covers \Ray\Di\Container::getInstanceWithArgs
-     */
     public function testUnbound(): void
     {
         $this->expectException(Unbound::class);
@@ -248,8 +239,6 @@ class ContainerTest extends TestCase
      * name that itself contains a hyphen (e.g. "type-bool") must be preserved
      * whole in the resulting Unbound message; splitting on every hyphen
      * truncates the name to its first segment.
-     *
-     * @covers \Ray\Di\Container::unbound
      */
     public function testUnboundPreservesHyphenatedBindName(): void
     {

--- a/tests/di/ContainerTest.php
+++ b/tests/di/ContainerTest.php
@@ -30,6 +30,7 @@ class ContainerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->container = new Container();
         $this->engine = new FakeEngine();
         (new Bind($this->container, FakeEngineInterface::class))->toInstance($this->engine);
@@ -210,7 +211,7 @@ class ContainerTest extends TestCase
         $container = new Container();
         //FakeConstantInterface
         (new Bind($container, ''))->annotatedWith(FakeConstant::class)->toInstance('kuma');
-        (new Bind($container, FakeConstantConsumer::class));
+        new Bind($container, FakeConstantConsumer::class);
         $instance = $container->getInstance(FakeConstantConsumer::class, Name::ANY);
         $this->assertSame('kuma', $instance->constantByConstruct);
         $this->assertSame('kuma', $instance->constantBySetter);
@@ -250,7 +251,7 @@ class ContainerTest extends TestCase
     public function testWeaveAspectsWithEmptyPointcuts(): void
     {
         $container = new Container();
-        (new Bind($container, FakeEngine::class));
+        new Bind($container, FakeEngine::class);
 
         // Should work fine even when no pointcuts are defined
         $tmpDir = sys_get_temp_dir();

--- a/tests/di/DependencyProviderTest.php
+++ b/tests/di/DependencyProviderTest.php
@@ -15,8 +15,6 @@ class DependencyProviderTest extends TestCase
      * exactly once. Tracking instantiation through `$instance !== null` instead
      * of an explicit flag re-runs the provider on every call when it returns
      * null, breaking the singleton contract.
-     *
-     * @covers \Ray\Di\DependencyProvider::inject
      */
     public function testSingletonProviderReturningNullIsInstantiatedOnce(): void
     {

--- a/tests/di/DependencyTest.php
+++ b/tests/di/DependencyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\Compiler;
 use Ray\Aop\Matcher;
@@ -41,7 +42,7 @@ class DependencyTest extends TestCase
      * @return Container[][]
      * @psalm-return array{0: array{0: Container}}
      */
-    public function containerProvider(): array
+    public static function containerProvider(): array
     {
         $container = new Container();
         (new Bind($container, FakeTyreInterface::class))->to(FakeTyre::class);
@@ -51,9 +52,7 @@ class DependencyTest extends TestCase
         return [[$container]];
     }
 
-    /**
-     * @dataProvider containerProvider
-     */
+    #[DataProvider('containerProvider')]
     public function testInject(Container $container): void
     {
         $car = $this->dependency->inject($container);
@@ -61,9 +60,7 @@ class DependencyTest extends TestCase
         $this->assertInstanceOf(FakeCar::class, $car);
     }
 
-    /**
-     * @dataProvider containerProvider
-     */
+    #[DataProvider('containerProvider')]
     public function testSetterInjection(Container $container): void
     {
         $car = $this->dependency->inject($container);
@@ -72,9 +69,7 @@ class DependencyTest extends TestCase
         $this->assertInstanceOf(FakeTyre::class, $car->frontTyre);
     }
 
-    /**
-     * @dataProvider containerProvider
-     */
+    #[DataProvider('containerProvider')]
     public function testPostConstruct(Container $container): void
     {
         $car = $this->dependency->inject($container);
@@ -82,9 +77,7 @@ class DependencyTest extends TestCase
         $this->assertTrue($car->isConstructed);
     }
 
-    /**
-     * @dataProvider containerProvider
-     */
+    #[DataProvider('containerProvider')]
     public function testPrototype(Container $container): void
     {
         $this->dependency->setScope(Scope::PROTOTYPE);
@@ -94,9 +87,7 @@ class DependencyTest extends TestCase
         $this->assertNotSame(spl_object_hash($car1), spl_object_hash($car2));
     }
 
-    /**
-     * @dataProvider containerProvider
-     */
+    #[DataProvider('containerProvider')]
     public function testSingleton(Container $container): void
     {
         $this->dependency->setScope(Scope::SINGLETON);
@@ -115,8 +106,6 @@ class DependencyTest extends TestCase
      * instead of an explicit flag would behave the same way here (the
      * instance is also dropped by __sleep()), but this test pins the
      * DependencyProvider-aligned $isInstantiated behaviour explicitly.
-     *
-     * @covers \Ray\Di\Dependency::inject
      */
     public function testSingletonAfterUnserializeReinstantiatesOnceThenCaches(): void
     {
@@ -167,9 +156,8 @@ class DependencyTest extends TestCase
      * constructor-injected engine and the setter-injected front tyre are present.
      * If the postConstruct call in injectWithArgs() is removed, isConstructed
      * stays false.
-     * @dataProvider containerProvider
-     * @covers \Ray\Di\Dependency::injectWithArgs
      */
+    #[DataProvider('containerProvider')]
     public function testInjectWithArgsPostConstruct(Container $container): void
     {
         $car = $this->dependency->injectWithArgs($container, [new FakeEngine()]);
@@ -182,10 +170,8 @@ class DependencyTest extends TestCase
      * The singleton fast-path of injectWithArgs() must return the very same
      * instance on repeated calls. If the early `return $this->instance` is
      * removed, a fresh instance is built every time and the two differ.
-     *
-     * @dataProvider containerProvider
-     * @covers \Ray\Di\Dependency::injectWithArgs
      */
+    #[DataProvider('containerProvider')]
     public function testInjectWithArgsSingleton(Container $container): void
     {
         $this->dependency->setScope(Scope::SINGLETON);
@@ -201,7 +187,6 @@ class DependencyTest extends TestCase
      * even though injectWithArgs() is called repeatedly. The recorded
      * postConstruct invocation count proves the cached instance short-circuits
      * before postConstruct runs again.
-     * @covers \Ray\Di\Dependency::injectWithArgs
      */
     public function testInjectWithArgsSingletonPostConstructRunsOnce(): void
     {

--- a/tests/di/InjectionPointTest.php
+++ b/tests/di/InjectionPointTest.php
@@ -54,9 +54,6 @@ class InjectionPointTest extends TestCase
      * unserialize() the ReflectionParameter must be reconstructed; otherwise
      * the typed $parameter property stays uninitialized and getParameter()/
      * getMethod()/getClass() raise an Error on first access.
-     *
-     * @covers \Ray\Di\InjectionPoint::__unserialize
-     * @covers \Ray\Di\InjectionPoint::__serialize
      */
     public function testSerializeRoundTripRestoresParameter(): void
     {

--- a/tests/di/InjectionPointsTest.php
+++ b/tests/di/InjectionPointsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 use function get_class;
@@ -33,9 +34,7 @@ class InjectionPointsTest extends TestCase
         return $setterMethods;
     }
 
-    /**
-     * @depends testInvoke
-     */
+    #[Depends('testInvoke')]
     public function testSetterMethod(SetterMethods $setterMethod): void
     {
         $car = new FakeCar(new FakeEngine());
@@ -46,9 +45,7 @@ class InjectionPointsTest extends TestCase
         $this->assertInstanceOf(FakeHardtop::class, $car->hardtop);
     }
 
-    /**
-     * @depends testInvoke
-     */
+    #[Depends('testInvoke')]
     public function testSetterMethodOptional(SetterMethods $setterMethod): void
     {
         $car = new FakeCar(new FakeEngine());

--- a/tests/di/InjectionPointsTest.php
+++ b/tests/di/InjectionPointsTest.php
@@ -17,6 +17,7 @@ class InjectionPointsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->injectionPoints = (new InjectionPoints())->addMethod('setTires')->addOptionalMethod('setHardtop');
     }
 

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -6,6 +6,8 @@ namespace Ray\Di;
 
 use LogicException;
 use PDO;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use Ray\Aop\NullInterceptor;
 use Ray\Di\Exception\Unbound;
@@ -46,8 +48,6 @@ class InjectorTest extends TestCase
      * An unbound concrete class is auto-registered as an untargeted binding:
      * getInstance() catches Untargeted, binds the class on the fly, then
      * resolves it. Removing that self-bind makes the retry recurse endlessly.
-     *
-     * @covers \Ray\Di\Injector::getInstance
      */
     public function testGetUnboundConcreteClassIsAutoBound(): void
     {
@@ -56,9 +56,6 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance);
     }
 
-    /**
-     * @covers \Ray\Di\Injector::getInstance
-     */
     public function testUnboundConcreteClassIsConstructedOnlyOnce(): void
     {
         FakeConstructCounter::$constructCount = 0;
@@ -72,8 +69,6 @@ class InjectorTest extends TestCase
     /**
      * A named request cannot be satisfied by just-in-time binding (which
      * registers under Name::ANY only), so it fails fast as Unbound.
-     *
-     * @covers \Ray\Di\Injector::getInstance
      */
     public function testUnboundConcreteClassWithNameThrowsUnbound(): void
     {
@@ -229,9 +224,7 @@ class InjectorTest extends TestCase
         return $injector;
     }
 
-    /**
-     * @depends testAnnotationBasedInjection
-     */
+    #[Depends('testAnnotationBasedInjection')]
     public function testSerialize(Injector $injector): void
     {
         $extractedInjector = unserialize(serialize($injector));
@@ -346,8 +339,6 @@ class InjectorTest extends TestCase
      * loop returned after the first class interceptor, leaving the rest unbound;
      * building the proxy then threw an uncaught Untargeted during weaving. Here
      * the woven instance must build AND both interceptors must run.
-     *
-     * @covers \Ray\Di\AbstractModule::bindInterceptor
      */
     public function testBindInterceptorWeavesAllInterceptors(): void
     {
@@ -402,7 +393,7 @@ class InjectorTest extends TestCase
         (new Injector())->getInstance(FakeConcreteClass::class);
     }
 
-    /** @requires OS ^Linux|^Darwin */
+    #[RequiresOperatingSystem('^Linux|^Darwin')]
     public function testIsOptionalValue(): void
     {
         if (! defined('HHVM_VERSION')) {
@@ -418,7 +409,7 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeInternalTypes::class, $types);
     }
 
-    /** @requires OS ^Linux|^Darwin */
+    #[RequiresOperatingSystem('^Linux|^Darwin')]
     public function testToConstructor(): void
     {
         $module = new class extends AbstractModule {
@@ -533,9 +524,6 @@ class InjectorTest extends TestCase
         $this->assertSame('a', $injector->getInstance('', 'var'));
     }
 
-    /**
-     * @requires PHP 8.0
-     */
     public function testProviderInjectWithSet(): void
     {
         $injector = new Injector(new class extends AbstractModule{

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -429,13 +429,13 @@ class InjectorTest extends TestCase
 
     public function testNullObject(): void
     {
-        $injector = (new Injector(new class extends AbstractModule {
+        $injector = new Injector(new class extends AbstractModule {
             protected function configure()
             {
                 $this->bind(FakeTyreInterface::class)->toNull();
                 $this->bind(FakeAopInterface::class)->toNull();
             }
-        }));
+        });
         $nullObject = $injector->getInstance(FakeTyreInterface::class);
         $this->assertInstanceOf(FakeTyreInterface::class, $nullObject);
         // a null object stubs every interface method to a no-op returning null
@@ -445,7 +445,7 @@ class InjectorTest extends TestCase
 
     public function testBindInterfeceInterceptor(): void
     {
-        $injector = (new Injector(new class extends AbstractModule {
+        $injector = new Injector(new class extends AbstractModule {
             protected function configure()
             {
                 $this->bind(FakeAop::class);
@@ -456,7 +456,7 @@ class InjectorTest extends TestCase
                     [FakeDoubleInterceptorInterface::class]
                 );
             }
-        }));
+        });
         $instance = $injector->getInstance(FakeAop::class);
         $result = $instance->returnSame(2);
         $this->assertSame(4, $result);
@@ -464,7 +464,7 @@ class InjectorTest extends TestCase
 
     public function testBindInterfeceNullInterceptor(): void
     {
-        $injector = (new Injector(new class extends AbstractModule {
+        $injector = new Injector(new class extends AbstractModule {
             protected function configure()
             {
                 $this->bind(FakeAop::class);
@@ -475,7 +475,7 @@ class InjectorTest extends TestCase
                     [FakeDoubleInterceptorInterface::class]
                 );
             }
-        }));
+        });
         $instance = $injector->getInstance(FakeAop::class);
         $result = $instance->returnSame(2);
         $this->assertSame(2, $result);

--- a/tests/di/ModuleCompositionTest.php
+++ b/tests/di/ModuleCompositionTest.php
@@ -41,9 +41,6 @@ class ModuleCompositionTest extends TestCase
     /**
      * A binding declared directly with bind() must override the same binding
      * coming from the constructor-chained module.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
-     * @covers \Ray\Di\AbstractModule::bind
      */
     public function testOwnBindOverridesConstructorChainedBinding(): void
     {
@@ -64,9 +61,6 @@ class ModuleCompositionTest extends TestCase
      * same binding coming from the constructor-chained module. ProdModule-style
      * context modules bind exclusively through install(), so if the chained
      * module won here, a prod context would silently run with dev bindings.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
-     * @covers \Ray\Di\AbstractModule::install
      */
     public function testInstallOverridesConstructorChainedBinding(): void
     {
@@ -90,9 +84,6 @@ class ModuleCompositionTest extends TestCase
     /**
      * bind() overrides a binding installed earlier in the same configure().
      * bind() is assertive: it always registers, no matter what is already there.
-     *
-     * @covers \Ray\Di\AbstractModule::bind
-     * @covers \Ray\Di\AbstractModule::install
      */
     public function testBindOverridesEarlierInstalledBinding(): void
     {
@@ -112,9 +103,6 @@ class ModuleCompositionTest extends TestCase
     /**
      * install() does not override a binding declared earlier with bind().
      * install() is polite: it only fills keys that are not yet bound.
-     *
-     * @covers \Ray\Di\AbstractModule::bind
-     * @covers \Ray\Di\AbstractModule::install
      */
     public function testEarlierBindSurvivesLaterInstall(): void
     {
@@ -134,8 +122,6 @@ class ModuleCompositionTest extends TestCase
     /**
      * When two install()ed modules bind the same key, the first install wins,
      * for the same reason install() never overrides: existing entries are kept.
-     *
-     * @covers \Ray\Di\AbstractModule::install
      */
     public function testFirstInstallWinsWhenTwoInstallsCollide(): void
     {
@@ -166,8 +152,6 @@ class ModuleCompositionTest extends TestCase
      * In a chain `new A(new B(new C()))` the outermost module wins, and for
      * keys the outermost does not bind, the next-outer module wins. This is
      * the "left context overrides right" rule of BEAR.Sunday contexts.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
      */
     public function testOuterModuleWinsAcrossConstructorChain(): void
     {
@@ -203,8 +187,6 @@ class ModuleCompositionTest extends TestCase
      * override() is the one route that replaces an existing binding: on a
      * colliding key the override module's binding wins over what configure()
      * declared before it.
-     *
-     * @covers \Ray\Di\AbstractModule::override
      */
     public function testOverrideModuleWinsOnCollision(): void
     {
@@ -231,9 +213,6 @@ class ModuleCompositionTest extends TestCase
      * constructor-chained module's binding. `bind(Concrete::class)->in(SINGLETON)`
      * is the documented idiom to singletonize a concrete class; it must not be
      * silently ignored just because the chained module already bound the class.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
-     * @covers \Ray\Di\AbstractModule::bind
      */
     public function testRebindScopeOverridesConstructorChainedBinding(): void
     {
@@ -263,9 +242,6 @@ class ModuleCompositionTest extends TestCase
      * FakeDoubleInterceptor outermost, returnSame(2) is (2 + 1) * 2 = 6;
      * if the chained FakeIncrementInterceptor wrapped it instead, the result
      * would be (2 * 2) + 1 = 5.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
-     * @covers \Ray\Di\AbstractModule::bindInterceptor
      */
     public function testOwnInterceptorWrapsConstructorChainedInterceptor(): void
     {
@@ -300,9 +276,6 @@ class ModuleCompositionTest extends TestCase
      * Within one configure(), an interceptor declared before install() wraps
      * the installed module's interceptor: pointcuts append in declaration
      * order and earlier means outermost. (2 + 1) * 2 = 6, as above.
-     *
-     * @covers \Ray\Di\AbstractModule::bindInterceptor
-     * @covers \Ray\Di\AbstractModule::install
      */
     public function testInterceptorDeclaredBeforeInstallWrapsInstalledInterceptor(): void
     {
@@ -337,9 +310,6 @@ class ModuleCompositionTest extends TestCase
      * Multibinding collections keep the same precedence direction: the module's
      * own entries come first in the Map, the constructor-chained module's
      * entries follow.
-     *
-     * @covers \Ray\Di\AbstractModule::__construct
-     * @covers \Ray\Di\MultiBinding\MultiBindings::merge
      */
     public function testOwnMultiBindingEntriesPrecedeConstructorChainedEntries(): void
     {

--- a/tests/di/MultiBinding/MultiBinderTest.php
+++ b/tests/di/MultiBinding/MultiBinderTest.php
@@ -13,9 +13,6 @@ use Ray\Di\FakeRobotInterface;
 use Ray\Di\MultiBinder;
 use Ray\Di\NullModule;
 
-/**
- * @requires PHP 8.0
- */
 class MultiBinderTest extends TestCase
 {
     public function testAdd(): void
@@ -48,8 +45,6 @@ class MultiBinderTest extends TestCase
      * interface registered in the shared MultiBindings. Binding interface A,
      * then calling setBinding() on a different interface B, must leave A's
      * bindings intact.
-     *
-     * @covers \Ray\Di\MultiBinder::setBinding
      */
     public function testSetBindingDoesNotClearOtherInterfaces(): void
     {

--- a/tests/di/MultiBinding/MultiBindingModuleTest.php
+++ b/tests/di/MultiBinding/MultiBindingModuleTest.php
@@ -51,9 +51,7 @@ class MultiBindingModuleTest extends TestCase
         };
     }
 
-    /**
-     * @return Map<FakeEngineInterface>
-     */
+    /** @return Map<FakeEngineInterface> */
     public function testInjectMap(): Map
     {
         $injector = new Injector($this->module);
@@ -63,9 +61,7 @@ class MultiBindingModuleTest extends TestCase
         return $consumer->engines;
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testMapInstance(Map $map): void
     {
@@ -73,9 +69,7 @@ class MultiBindingModuleTest extends TestCase
         $this->assertInstanceOf(FakeEngine2::class, $map['two']);
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testMapIteration(Map $map): void
     {
@@ -91,9 +85,7 @@ class MultiBindingModuleTest extends TestCase
         $this->assertInstanceOf(FakeEngine3::class, $items[0]);
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testIsSet(Map $map): void
     {
@@ -101,9 +93,7 @@ class MultiBindingModuleTest extends TestCase
         $this->assertTrue(isset($map['two']));
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testOffsetSet(Map $map): void
     {
@@ -112,9 +102,7 @@ class MultiBindingModuleTest extends TestCase
         $map['one'] = 1;
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testOffsetUnset(Map $map): void
     {
@@ -136,9 +124,7 @@ class MultiBindingModuleTest extends TestCase
         $map[] = new FakeEngine();
     }
 
-    /**
-     * @param Map<object> $map
-     */
+    /** @param Map<object> $map */
     #[Depends('testInjectMap')]
     public function testOffsetUnsetWithNullOffset(Map $map): void
     {

--- a/tests/di/MultiBinding/MultiBindingModuleTest.php
+++ b/tests/di/MultiBinding/MultiBindingModuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di\MultiBinding;
 
 use ArrayAccess;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\ReadOnlyMapAccess;
@@ -28,9 +29,6 @@ use function array_keys;
 use function count;
 use function iterator_to_array;
 
-/**
- * @requires PHP 8.0
- */
 class MultiBindingModuleTest extends TestCase
 {
     /** @var AbstractModule */
@@ -67,9 +65,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testMapInstance(Map $map): void
     {
         $this->assertInstanceOf(FakeEngine::class, $map['one']);
@@ -78,9 +75,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testMapIteration(Map $map): void
     {
         $this->assertContainsOnlyInstancesOf(FakeEngineInterface::class, $map);
@@ -97,9 +93,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testIsSet(Map $map): void
     {
         $this->assertTrue(isset($map['one']));
@@ -108,9 +103,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testOffsetSet(Map $map): void
     {
         $this->expectException(ReadOnlyMapAccess::class);
@@ -120,9 +114,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testOffsetUnset(Map $map): void
     {
         $this->expectException(ReadOnlyMapAccess::class);
@@ -134,9 +127,8 @@ class MultiBindingModuleTest extends TestCase
      * `$map[] = $value` invokes offsetSet() with a null offset.
      *
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testOffsetSetWithNullOffset(Map $map): void
     {
         $this->expectException(ReadOnlyMapAccess::class);
@@ -146,9 +138,8 @@ class MultiBindingModuleTest extends TestCase
 
     /**
      * @param Map<object> $map
-     *
-     * @depends testInjectMap
      */
+    #[Depends('testInjectMap')]
     public function testOffsetUnsetWithNullOffset(Map $map): void
     {
         $this->expectException(ReadOnlyMapAccess::class);

--- a/tests/di/NameTest.php
+++ b/tests/di/NameTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionParameter;
 
@@ -34,9 +35,7 @@ class NameTest extends TestCase
         $this->assertSame($expected, $boundName);
     }
 
-    /**
-     * @dataProvider keyPairStringProvider
-     */
+    #[DataProvider('keyPairStringProvider')]
     public function testKeyValuePairName(string $keyPairValueString): void
     {
         $name = new Name($keyPairValueString);
@@ -49,7 +48,7 @@ class NameTest extends TestCase
      * @return string[][]
      * @psalm-return array{0: array{0: string}, 1: array{0: string}, 2: array{0: string}, 3: array{0: string}}
      */
-    public function keyPairStringProvider(): array
+    public static function keyPairStringProvider(): array
     {
         return [
             ['engine=engine_name,var=var_name'],

--- a/tests/di/RenameTest.php
+++ b/tests/di/RenameTest.php
@@ -15,8 +15,6 @@ class RenameTest extends TestCase
      * introduced via install() -- not just constructor chaining -- can be
      * renamed. After the move, the new name resolves and the old (unnamed)
      * index is gone.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testRenamesBindingIntroducedByInstall(): void
     {
@@ -41,9 +39,6 @@ class RenameTest extends TestCase
      * container. rename() inside configure() is deferred and applied against
      * getContainer() after composition completes, so it must act on that
      * merged container, not on a stale reference captured before the swap.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
-     * @covers \Ray\Di\AbstractModule::override
      */
     public function testRenamesBindingAfterOverride(): void
     {
@@ -73,8 +68,6 @@ class RenameTest extends TestCase
     /**
      * When no binding exists at the source index, rename() must
      * surface Container::move()'s Unbound rather than silently no-op.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testThrowsUnboundWhenSourceMissing(): void
     {
@@ -94,8 +87,6 @@ class RenameTest extends TestCase
      * instead of silently overwriting it. The pre-existing binding at the
      * target index must remain resolvable afterward, proving move() aborted
      * before mutating the container.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testThrowsWhenTargetAlreadyBoundAndPreservesExistingBinding(): void
     {
@@ -129,8 +120,6 @@ class RenameTest extends TestCase
     /**
      * With $targetInterface omitted, the rename must stay within the same
      * interface -- only the binding name changes.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testRenameWithinSameInterfaceWhenTargetInterfaceOmitted(): void
     {
@@ -152,8 +141,6 @@ class RenameTest extends TestCase
      * With $targetInterface specified, the binding must move to a different
      * interface index entirely, not just get a new name under the source
      * interface.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testMovesToDifferentInterfaceWhenTargetInterfaceSpecified(): void
     {
@@ -177,8 +164,6 @@ class RenameTest extends TestCase
     /**
      * Renaming a binding to its own current name must be a no-op, not an
      * error. The existing binding must remain resolvable under the same name.
-     *
-     * @covers \Ray\Di\AbstractModule::rename
      */
     public function testSelfRenameIsNoOp(): void
     {

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -1,10 +1,10 @@
 {
     "require-dev": {
-        "doctrine/coding-standard": "^9.0",
+        "doctrine/coding-standard": "^14.0",
         "phpmd/phpmd": "^2.9",
         "phpmetrics/phpmetrics": "^2.7 || v3.0.0rc8",
         "phpstan/phpstan": "^2.0",
-        "squizlabs/php_codesniffer": "^3.5",
+        "squizlabs/php_codesniffer": "^4.0",
         "vimeo/psalm": "^6.8",
         "phpstan/phpstan-phpunit": "^2.0"
     },

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce58914cbf304b940e7e9f90cc3811e9",
+    "content-hash": "eb2c5612da115aab6879f4137d4ad5bc",
     "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
                 "shasum": ""
             },
             "require": {
@@ -28,7 +28,7 @@
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.23.1"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -78,7 +78,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+                "source": "https://github.com/amphp/amp/tree/v3.1.2"
             },
             "funding": [
                 {
@@ -86,7 +86,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-27T21:42:00+00:00"
+            "time": "2026-06-21T13:59:44+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -319,16 +319,16 @@
         },
         {
             "name": "amphp/parallel",
-            "version": "v2.3.2",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/parallel.git",
-                "reference": "321b45ae771d9c33a068186b24117e3cd1c48dce"
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/parallel/zipball/321b45ae771d9c33a068186b24117e3cd1c48dce",
-                "reference": "321b45ae771d9c33a068186b24117e3cd1c48dce",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81",
                 "shasum": ""
             },
             "require": {
@@ -348,7 +348,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -391,7 +391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/parallel/issues",
-                "source": "https://github.com/amphp/parallel/tree/v2.3.2"
+                "source": "https://github.com/amphp/parallel/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -399,7 +399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-27T21:55:40+00:00"
+            "time": "2026-05-16T16:54:01+00:00"
         },
         {
             "name": "amphp/parser",
@@ -465,16 +465,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.3",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/10941bf38de5c585aa2407b2ec4265d806d4eef2",
+                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2",
                 "shasum": ""
             },
             "require": {
@@ -486,7 +486,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -520,7 +520,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.6"
             },
             "funding": [
                 {
@@ -528,20 +528,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-16T16:33:53+00:00"
+            "time": "2026-06-27T16:15:40+00:00"
         },
         {
             "name": "amphp/process",
-            "version": "v2.0.3",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/process.git",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+                "reference": "583959df17d00304ad7b0b32285373f985935643"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "url": "https://api.github.com/repos/amphp/process/zipball/583959df17d00304ad7b0b32285373f985935643",
+                "reference": "583959df17d00304ad7b0b32285373f985935643",
                 "shasum": ""
             },
             "require": {
@@ -555,7 +555,7 @@
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -588,7 +588,7 @@
             "homepage": "https://amphp.org/process",
             "support": {
                 "issues": "https://github.com/amphp/process/issues",
-                "source": "https://github.com/amphp/process/tree/v2.0.3"
+                "source": "https://github.com/amphp/process/tree/v2.1.0"
             },
             "funding": [
                 {
@@ -596,28 +596,31 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-19T03:13:44+00:00"
+            "time": "2026-05-31T15:11:55+00:00"
         },
         {
             "name": "amphp/serialization",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -652,22 +655,28 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
             },
-            "time": "2020-03-25T21:39:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
         },
         {
             "name": "amphp/socket",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
                 "shasum": ""
             },
             "require": {
@@ -676,17 +685,17 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
                 "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "amphp/process": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -730,7 +739,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -738,7 +747,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-21T14:33:03+00:00"
+            "time": "2026-04-19T15:09:56+00:00"
         },
         {
             "name": "amphp/sync",
@@ -817,28 +826,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -876,7 +886,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -886,13 +896,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -1039,22 +1045,22 @@
         },
         {
             "name": "danog/advanced-json-rpc",
-            "version": "v3.2.2",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/danog/php-advanced-json-rpc.git",
-                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb"
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/aadb1c4068a88c3d0530cfe324b067920661efcb",
-                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
                 "shasum": ""
             },
             "require": {
                 "netresearch/jsonmapper": "^5",
                 "php": ">=8.1",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
             },
             "replace": {
                 "felixfbecker/php-advanced-json-rpc": "^3"
@@ -1085,9 +1091,9 @@
             "description": "A more advanced JSONRPC implementation",
             "support": {
                 "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
-                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.2"
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
             },
-            "time": "2025-02-14T10:55:15+00:00"
+            "time": "2026-01-12T21:07:10+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -1135,35 +1141,38 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1173,17 +1182,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -1203,10 +1211,29 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1247,23 +1274,23 @@
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "9.0.2",
+            "version": "14.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1"
+                "reference": "897a7dc209e49ee6cf04e689c41112df17967130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/35a2452c6025cb739c3244b3348bcd1604df07d1",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/897a7dc209e49ee6cf04e689c41112df17967130",
+                "reference": "897a7dc209e49ee6cf04e689c41112df17967130",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "slevomat/coding-standard": "^7.0.0",
-                "squizlabs/php_codesniffer": "^3.6.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0.0",
+                "php": "^7.4 || ^8.0",
+                "slevomat/coding-standard": "^8.23",
+                "squizlabs/php_codesniffer": "^4"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1287,6 +1314,7 @@
                 "code",
                 "coding",
                 "cs",
+                "dev",
                 "doctrine",
                 "rules",
                 "sniffer",
@@ -1296,35 +1324,35 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/coding-standard/issues",
-                "source": "https://github.com/doctrine/coding-standard/tree/9.0.2"
+                "source": "https://github.com/doctrine/coding-standard/tree/14.0.0"
             },
-            "time": "2021-04-12T15:11:14+00:00"
+            "time": "2025-09-21T18:21:47+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -1344,9 +1372,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -1525,33 +1553,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1579,6 +1612,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -1591,9 +1625,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -1603,7 +1639,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1611,26 +1647,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -1638,6 +1673,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1662,7 +1698,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -1687,7 +1723,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1695,20 +1731,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c"
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
                 "shasum": ""
             },
             "require": {
@@ -1744,26 +1780,25 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
             },
-            "time": "2024-09-08T10:20:00+00:00"
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -1802,22 +1837,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "openmetrics-php/exposition-text",
-            "version": "v0.4.2",
+            "version": "v0.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openmetrics-php/exposition-text.git",
-                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba"
+                "reference": "754e0003543f7b0f31c4bd46f88e5f2413f32c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openmetrics-php/exposition-text/zipball/4f65004f93e53eac4b9668879b92d3c200a851ba",
-                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba",
+                "url": "https://api.github.com/repos/openmetrics-php/exposition-text/zipball/754e0003543f7b0f31c4bd46f88e5f2413f32c40",
+                "reference": "754e0003543f7b0f31c4bd46f88e5f2413f32c40",
                 "shasum": ""
             },
             "require": {
@@ -1845,9 +1880,9 @@
             "description": "Implementation of the text exposition format of OpenMetrics",
             "support": {
                 "issues": "https://github.com/openmetrics-php/exposition-text/issues",
-                "source": "https://github.com/openmetrics-php/exposition-text/tree/v0.4.2"
+                "source": "https://github.com/openmetrics-php/exposition-text/tree/v0.4.3"
             },
-            "time": "2025-06-04T14:59:47+00:00"
+            "time": "2026-02-20T11:21:20+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -1913,6 +1948,57 @@
             "time": "2023-12-17T18:09:59+00:00"
         },
         {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.2.0",
             "source": {
@@ -1967,16 +2053,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.3",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -1984,9 +2070,9 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.5 || ~1.6.0",
@@ -1995,7 +2081,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -2025,44 +2112,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2025-08-01T19:43:32+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2083,9 +2170,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -2249,30 +2336,30 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.33.0",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/82a311fd3690fb2bf7b64d5c98f912b3dd746140",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -2290,17 +2377,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.33.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2024-10-13T11:25:22+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.32",
+            "version": "2.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e126cad1e30a99b137b8ed75a85a676450ebb227",
-                "reference": "e126cad1e30a99b137b8ed75a85a676450ebb227",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
                 "shasum": ""
             },
             "require": {
@@ -2322,6 +2409,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -2345,25 +2443,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-11T15:18:17+00:00"
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.8",
+            "version": "2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe"
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe",
-                "reference": "2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
                 "shasum": ""
             },
             "require": {
+                "phar-io/version": "^3.2",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.32"
+                "phpstan/phpstan": "^2.2.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -2373,7 +2472,8 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpstan-deprecation-rules": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^9.6",
+                "shipmonk/name-collision-detector": "^2.1"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -2394,11 +2494,14 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.8"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.18"
             },
-            "time": "2025-11-11T07:55:22+00:00"
+            "time": "2026-07-04T12:16:09+00:00"
         },
         {
             "name": "psr/container",
@@ -2613,16 +2716,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.7",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3"
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/09bf1bf7f7f574453efe43044b06fafe12216eb3",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
                 "shasum": ""
             },
             "require": {
@@ -2632,7 +2735,7 @@
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
+                "psalm/phar": "6.16.*"
             },
             "type": "library",
             "extra": {
@@ -2679,35 +2782,35 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.7"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
             },
-            "time": "2025-01-25T19:27:39+00:00"
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
+                "phpunit/phpunit": "^13.0",
                 "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -2740,54 +2843,66 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-05-15T04:58:09+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.2.1",
+            "version": "8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
+                "reference": "70a3b2150600122f87c59cae1c1b5902ba73798b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/70a3b2150600122f87c59cae1c1b5902ba73798b",
+                "reference": "70a3b2150600122f87c59cae1c1b5902ba73798b",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.5.1",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.2",
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
-                "phing/phing": "2.17.3",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.7.1",
-                "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
-                "phpstan/phpstan-strict-rules": "1.2.3",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+                "phing/phing": "3.0.1|3.1.2",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.2.2",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.30"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.x-dev"
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2795,9 +2910,13 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.30.1"
             },
             "funding": [
                 {
@@ -2809,20 +2928,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T10:58:12+00:00"
+            "time": "2026-06-27T11:26:35+00:00"
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.4.1",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "6a740f39415aee8886aea10333403adc77d50791"
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/6a740f39415aee8886aea10333403adc77d50791",
-                "reference": "6a740f39415aee8886aea10333403adc77d50791",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
                 "shasum": ""
             },
             "require": {
@@ -2865,7 +2984,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.4.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
             },
             "funding": [
                 {
@@ -2877,30 +2996,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-12T10:32:50+00:00"
+            "time": "2025-12-15T09:00:41+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
             },
             "bin": [
                 "bin/phpcbf",
@@ -2925,7 +3044,7 @@
                     "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
             "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
@@ -2956,26 +3075,26 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.3.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9d18eba95655a3152ae4c1d53c6cc34eb4d4a0b7"
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9d18eba95655a3152ae4c1d53c6cc34eb4d4a0b7",
-                "reference": "9d18eba95655a3152ae4c1d53c6cc34eb4d4a0b7",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
+                "reference": "7b665e443381ea7c4db03eb03b4bf79ea2b020eb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^7.1",
+                "symfony/filesystem": "^7.1|^8.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -2983,11 +3102,11 @@
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/finder": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3015,7 +3134,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.3.6"
+                "source": "https://github.com/symfony/config/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3035,51 +3154,43 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-02T08:04:43+00:00"
+            "time": "2026-06-09T07:51:57+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.6",
+            "version": "v8.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c28ad91448f86c5f6d9d2c70f0cf68bf135f252a"
+                "reference": "e2a77289192c413abfe54f1d507159f911a20728"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c28ad91448f86c5f6d9d2c70f0cf68bf135f252a",
-                "reference": "c28ad91448f86c5f6d9d2c70f0cf68bf135f252a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2a77289192c413abfe54f1d507159f911a20728",
+                "reference": "e2a77289192c413abfe54f1d507159f911a20728",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3113,7 +3224,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.6"
+                "source": "https://github.com/symfony/console/tree/v8.0.14"
             },
             "funding": [
                 {
@@ -3133,28 +3244,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-04T01:21:42+00:00"
+            "time": "2026-06-16T12:45:11+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.3.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "98af8bb46c56aedd9dd5a7f0414fc72bf2dcfe69"
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/98af8bb46c56aedd9dd5a7f0414fc72bf2dcfe69",
-                "reference": "98af8bb46c56aedd9dd5a7f0414fc72bf2dcfe69",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
+                "reference": "2c8c64a33e2e6911579e1ff79a8e06c27d48d402",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/service-contracts": "^3.5",
-                "symfony/var-exporter": "^6.4.20|^7.2.5"
+                "symfony/service-contracts": "^3.6",
+                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -3167,9 +3278,9 @@
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3197,7 +3308,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.3.6"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3217,20 +3328,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-31T10:11:11+00:00"
+            "time": "2026-06-24T07:41:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3243,7 +3354,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3268,7 +3379,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3280,24 +3391,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.3.6",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e9bcfd7837928ab656276fe00464092cc9e1826a",
-                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -3306,7 +3421,7 @@
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3334,7 +3449,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.3.6"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -3354,20 +3469,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T09:52:27+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -3417,7 +3532,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3437,20 +3552,107 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "name": "symfony/polyfill-deepclone",
+            "version": "v1.40.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "url": "https://github.com/symfony/polyfill-deepclone.git",
+                "reference": "dca4ccba5f360070b574414dce4c1e7a559844fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-deepclone/zipball/dca4ccba5f360070b574414dce4c1e7a559844fa",
+                "reference": "dca4ccba5f360070b574414dce4c1e7a559844fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "provide": {
+                "ext-deepclone": "*"
+            },
+            "suggest": {
+                "ext-deepclone": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\DeepClone\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the deepclone extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "deepclone",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-deepclone/tree/v1.40.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-12T07:27:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -3499,7 +3701,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3519,20 +3721,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -3584,7 +3786,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -3604,20 +3806,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -3669,7 +3871,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -3689,20 +3891,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -3749,7 +3951,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3769,20 +3971,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -3800,7 +4002,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3836,7 +4038,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3856,38 +4058,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.4",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f96476035142921000338bad71e5247fbc138872"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
-                "reference": "f96476035142921000338bad71e5247fbc138872",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3926,7 +4128,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.4"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3946,30 +4148,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:36:48+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.3.4",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4"
+                "reference": "75b74315b4e4be40e5534cf9c5cc30dd0907ed71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
-                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/75b74315b4e4be40e5534cf9c5cc30dd0907ed71",
+                "reference": "75b74315b4e4be40e5534cf9c5cc30dd0907ed71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-deepclone": "^1.40"
             },
             "require-dev": {
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3994,11 +4197,12 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "description": "Provides tools to export, instantiate, hydrate, clone and lazy-load PHP objects",
             "homepage": "https://symfony.com",
             "keywords": [
                 "clone",
                 "construct",
+                "deep-clone",
                 "export",
                 "hydrate",
                 "instantiate",
@@ -4007,7 +4211,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.3.4"
+                "source": "https://github.com/symfony/var-exporter/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4027,20 +4231,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T10:12:26+00:00"
+            "time": "2026-06-27T09:05:56+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.13.1",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51"
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
-                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
                 "shasum": ""
             },
             "require": {
@@ -4063,11 +4267,11 @@
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
                 "netresearch/jsonmapper": "^5.0",
                 "nikic/php-parser": "^5.0.0",
-                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^6.0 || ^7.0",
-                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3",
+                "symfony/console": "^6.0 || ^7.0 || ^8.0",
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
                 "symfony/polyfill-php84": "^1.31.0"
             },
             "provide": {
@@ -4089,7 +4293,7 @@
                 "psalm/plugin-phpunit": "^0.19",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^6.0 || ^7.0"
+                "symfony/process": "^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -4145,27 +4349,27 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-08-06T10:10:28+00:00"
+            "time": "2026-03-19T10:56:09+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.1",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-date": "*",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.2"
             },
             "suggest": {
                 "ext-intl": "",
@@ -4174,8 +4378,12 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4191,6 +4399,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
                 }
             ],
             "description": "Assertions to validate method input/output with nice error messages.",
@@ -4201,9 +4413,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2025-10-29T15:56:20+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],
@@ -4215,5 +4427,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Bumps PHP versions in CI tooling workflows.

| Workflow | Before | After |
|---|---|---|
| static-analysis | 8.4 | 8.5 |
| mutation-testing | 8.4 | 8.5 |
| coding-standards | 8.3 | 8.4 |
| demo | 8.3 | 8.4 |
| prefer-lowest | 8.2 | 8.2 (unchanged) |
| continuous-integration | 8.2-8.5 | 8.2-8.5 (unchanged) |

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated development and quality-assurance environments to use newer PHP versions.
  * Upgraded testing and coding-standard tooling for improved compatibility with current PHP ecosystems.
  * Refreshed test configuration and migrated test metadata to modern PHPUnit conventions.
* **Documentation**
  * Clarified exception behavior and standardized internal documentation formatting.
* **Quality Improvements**
  * Refined static-analysis and coding-standard configurations to improve consistency and validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->