### PR TITLE
Optimize bindings markdown generation

### DIFF
--- a/src/di/BindingsMarkdown.php
+++ b/src/di/BindingsMarkdown.php
@@ -4,13 +4,24 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
+use Ray\Aop\AbstractMatcher;
+use Ray\Aop\BuiltinMatcher;
 use Throwable;
 
 use function count;
+use function file_get_contents;
 use function file_put_contents;
+use function hash;
+use function hash_equals;
 use function implode;
+use function is_file;
+use function is_object;
+use function is_string;
 use function ksort;
+use function serialize;
+use function sort;
 use function sprintf;
+use function trim;
 
 /**
  * Emit the composed container as bindings.md next to the generated classes
@@ -23,13 +34,97 @@ use function sprintf;
  */
 final class BindingsMarkdown
 {
+    /** Bump when the rendered format or signature inputs change. */
+    private const SIGNATURE_VERSION = 1;
+
     public function __invoke(Container $container, string $classDir): void
     {
         try {
-            file_put_contents($classDir . '/bindings.md', $this->render($container));
+            $markdownFile = $classDir . '/bindings.md';
+            $signatureFile = $classDir . '/bindings.md.signature';
+            $signature = $this->signature($container);
+            if ($signature !== null && $this->isCached($markdownFile, $signatureFile, $signature)) {
+                return;
+            }
+
+            $written = file_put_contents($markdownFile, $this->render($container));
+            if ($written === false || $signature === null) {
+                return;
+            }
+
+            file_put_contents($signatureFile, $signature);
         } catch (Throwable) { // @codeCoverageIgnoreStart
             // best-effort: never break construction for a diagnostics file
         } // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Return a signature of inputs that affect resolved bindings
+     *
+     * Composition provenance is intentionally excluded: if the final bindings
+     * and pointcuts are unchanged, the existing diagnostics file is reused.
+     */
+    private function signature(Container $container): ?string
+    {
+        try {
+            $bindings = [];
+            foreach ($container->getContainer() as $index => $dependency) {
+                $bindings[] = $index . "\0" . (string) $dependency;
+            }
+
+            sort($bindings);
+
+            return hash(
+                'sha256',
+                serialize([self::SIGNATURE_VERSION, $bindings, $this->pointcutSignature($container)]),
+            );
+        } catch (Throwable) { // @codeCoverageIgnoreStart
+            return null;
+        } // @codeCoverageIgnoreEnd
+    }
+
+    /** @return list<array{string, string, string, list<string>}> */
+    private function pointcutSignature(Container $container): array
+    {
+        $signature = [];
+        foreach ($container->getPointcuts() as $pointcut) {
+            $interceptors = [];
+            foreach ($pointcut->interceptors as $interceptor) {
+                $interceptors[] = is_object($interceptor) ? $interceptor::class : $interceptor;
+            }
+
+            $signature[] = [
+                $pointcut::class,
+                $this->matcherSignature($pointcut->classMatcher),
+                $this->matcherSignature($pointcut->methodMatcher),
+                $interceptors,
+            ];
+        }
+
+        return $signature;
+    }
+
+    private function matcherSignature(AbstractMatcher $matcher): string
+    {
+        if ($matcher instanceof BuiltinMatcher) {
+            return serialize($matcher);
+        }
+
+        return serialize([$matcher::class, $matcher->getArguments()]);
+    }
+
+    private function isCached(string $markdownFile, string $signatureFile, string $signature): bool
+    {
+        if (! is_file($markdownFile) || ! is_file($signatureFile)) {
+            return false;
+        }
+
+        $cachedSignature = file_get_contents($signatureFile);
+        if (! is_string($cachedSignature)) {
+            return false; // @codeCoverageIgnore
+        }
+
+        return hash_equals($signature, trim($cachedSignature));
     }
 
     private function render(Container $container): string

--- a/src/di/BindingsMarkdown.php
+++ b/src/di/BindingsMarkdown.php
@@ -48,11 +48,9 @@ final class BindingsMarkdown
             }
 
             $written = file_put_contents($markdownFile, $this->render($container));
-            if ($written === false || $signature === null) {
-                return;
+            if ($written !== false && $signature !== null) {
+                file_put_contents($signatureFile, $signature);
             }
-
-            file_put_contents($signatureFile, $signature);
         } catch (Throwable) { // @codeCoverageIgnoreStart
             // best-effort: never break construction for a diagnostics file
         } // @codeCoverageIgnoreEnd

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -53,6 +53,23 @@ final class Dependency implements DependencyInterface, AcceptInterface
     }
 
     /**
+     * Return the AOP-aware description without mutating this dependency
+     *
+     * @param PointcutList $pointcuts
+     *
+     * @internal
+     */
+    public function toStringWithAspects(CompilerInterface $compiler, array $pointcuts): string
+    {
+        $aspect = $this->compileAspects($compiler, $pointcuts);
+        if ($aspect === null) {
+            return (string) $this;
+        }
+
+        return sprintf('(dependency) %s', $aspect[0]);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function register(array &$container, Bind $bind): void
@@ -127,27 +144,45 @@ final class Dependency implements DependencyInterface, AcceptInterface
     /** @param PointcutList $pointcuts */
     public function weaveAspects(CompilerInterface $compiler, array $pointcuts): void
     {
+        $aspect = $this->compileAspects($compiler, $pointcuts);
+        if ($aspect === null) {
+            return;
+        }
+
+        [$class, $bind] = $aspect;
+        $this->newInstance->weaveAspects($class, $bind);
+    }
+
+    /**
+     * @param PointcutList $pointcuts
+     *
+     * @return array{class-string, AopBind}|null
+     */
+    private function compileAspects(CompilerInterface $compiler, array $pointcuts): ?array
+    {
+        if ($pointcuts === []) {
+            return null;
+        }
+
         $class = (string) $this->newInstance;
         $reflection = new ReflectionClass($class);
         if ($reflection->isFinal()) {
-            return;
+            return null;
         }
 
         $isInterceptor = $reflection->implementsInterface(MethodInterceptor::class);
         $isWeaved = $reflection->implementsInterface(WeavedInterface::class);
         if ($isInterceptor || $isWeaved) {
-            return;
+            return null;
         }
 
         $bind = new AopBind();
-        $className = (string) $this->newInstance;
-        $bind->bind($className, $pointcuts);
+        $bind->bind($class, $pointcuts);
         if (! $bind->getBindings()) {
-            return;
+            return null;
         }
 
-        $class = $compiler->compile($className, $bind);
-        $this->newInstance->weaveAspects($class, $bind);
+        return [$compiler->compile($class, $bind), $bind];
     }
 
     /** @inheritDoc */

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -59,7 +59,7 @@ final class Dependency implements DependencyInterface, AcceptInterface
      *
      * @internal
      */
-    public function toStringWithAspects(CompilerInterface $compiler, array $pointcuts): string
+    public function toStringWithAspects(SpyCompiler $compiler, array $pointcuts): string
     {
         $aspect = $this->compileAspects($compiler, $pointcuts);
         if ($aspect === null) {

--- a/src/di/ModuleString.php
+++ b/src/di/ModuleString.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-use function assert;
 use function implode;
-use function serialize;
 use function sort;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
 use function substr;
-use function unserialize;
 
 use const PHP_EOL;
 
@@ -23,16 +20,20 @@ final class ModuleString
     public function __invoke(Container $container, array $pointcuts): string
     {
         $log = [];
-        /** @psalm-suppress MixedAssignment */
-        $container = unserialize(serialize($container), ['allowed_classes' => true]);
-        assert($container instanceof Container);
+        /** @var array<string, string> $dependencyStrings */
+        $dependencyStrings = [];
         $spy = new SpyCompiler();
         foreach ($container->getContainer() as $dependencyIndex => $dependency) {
+            $dependencyString = (string) $dependency;
             if ($dependency instanceof Dependency) {
-                $dependency->weaveAspects($spy, $pointcuts);
+                if (! isset($dependencyStrings[$dependencyString])) {
+                    $dependencyStrings[$dependencyString] = $dependency->toStringWithAspects($spy, $pointcuts);
+                }
+
+                $dependencyString = $dependencyStrings[$dependencyString];
             }
 
-            $log[] = sprintf('%s => %s', $dependencyIndex, $this->label($dependencyIndex, (string) $dependency));
+            $log[] = sprintf('%s => %s', $dependencyIndex, $this->label($dependencyIndex, $dependencyString));
         }
 
         sort($log);

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -6,11 +6,8 @@ namespace Ray\Di;
 
 use Closure;
 use PHPUnit\Framework\TestCase;
-use Ray\Aop\AbstractMatcher;
 use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
-use ReflectionClass;
-use ReflectionMethod;
 use RuntimeException;
 
 use function assert;
@@ -181,26 +178,7 @@ class BindingsMarkdownTest extends TestCase
     {
         $container = new Container();
         (new Bind($container, FakeAopInterface::class, self::class))->to(FakeAop::class);
-        $classMatcher = new class extends AbstractMatcher {
-            public int $matches = 0;
-
-            /** @param array<array-key, mixed> $arguments */
-            public function matchesClass(ReflectionClass $class, array $arguments): bool
-            {
-                unset($class, $arguments);
-                $this->matches++;
-
-                return true;
-            }
-
-            /** @param array<array-key, mixed> $arguments */
-            public function matchesMethod(ReflectionMethod $method, array $arguments): bool
-            {
-                unset($method, $arguments);
-
-                return true;
-            }
-        };
+        $classMatcher = new FakeCountingMatcher();
         $container->addPointcut(new Pointcut($classMatcher, (new Matcher())->any(), [FakeDoubleInterceptor::class]));
         $writer = new BindingsMarkdown();
         $writer($container, $this->classDir);

--- a/tests/di/BindingsMarkdownTest.php
+++ b/tests/di/BindingsMarkdownTest.php
@@ -6,10 +6,16 @@ namespace Ray\Di;
 
 use Closure;
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\AbstractMatcher;
+use Ray\Aop\Matcher;
+use Ray\Aop\Pointcut;
+use ReflectionClass;
+use ReflectionMethod;
 use RuntimeException;
 
 use function assert;
 use function file_get_contents;
+use function file_put_contents;
 use function glob;
 use function is_dir;
 use function is_string;
@@ -90,17 +96,15 @@ class BindingsMarkdownTest extends TestCase
         $this->assertStringContainsString('8 bindings · 6 modules · 1 replaced · 1 discarded', $markdown);
     }
 
-    /**
-     * A binding ModuleString cannot serialize (a closure instance) makes the
-     * emission fail, but construction must still succeed — the diagnostics
-     * artifact is best-effort.
-     */
-    public function testConstructionSucceedsWhenMarkdownCannotBeWritten(): void
+    /** A closure binding is rendered without serializing the container. */
+    public function testClosureBindingIsWrittenToMarkdown(): void
     {
         $injector = new Injector(new FakeClosureBindModule(), $this->classDir);
 
         $this->assertInstanceOf(Closure::class, $injector->getInstance('', 'callback'));
-        $this->assertFileDoesNotExist($this->classDir . '/bindings.md');
+        $markdown = file_get_contents($this->classDir . '/bindings.md');
+        assert(is_string($markdown));
+        $this->assertStringContainsString('-callback => (object) Closure', $markdown);
     }
 
     /**
@@ -122,5 +126,90 @@ class BindingsMarkdownTest extends TestCase
         assert(is_string($markdown));
 
         $this->assertStringContainsString(FakeEngine::class . '- => (untargeted)', $markdown);
+    }
+
+    /** An unchanged binding surface reuses the existing markdown. */
+    public function testUnchangedBindingsUseSignatureCache(): void
+    {
+        $container = (new FakeLogStringModule())->getContainer();
+        $writer = new BindingsMarkdown();
+        $writer($container, $this->classDir);
+        $this->assertFileExists($this->classDir . '/bindings.md.signature');
+        file_put_contents($this->classDir . '/bindings.md', 'cached');
+
+        $writer($container, $this->classDir);
+
+        $this->assertSame('cached', file_get_contents($this->classDir . '/bindings.md'));
+    }
+
+    /** A changed resolved binding invalidates the cached markdown. */
+    public function testBindingChangeInvalidatesSignatureCache(): void
+    {
+        $container = new Container();
+        (new Bind($container, '', self::class))->annotatedWith('value')->toInstance(1);
+        $writer = new BindingsMarkdown();
+        $writer($container, $this->classDir);
+
+        (new Bind($container, '', self::class))->annotatedWith('value')->toInstance(2);
+        $writer($container, $this->classDir);
+
+        $markdown = file_get_contents($this->classDir . '/bindings.md');
+        assert(is_string($markdown));
+        $this->assertStringContainsString('-value => (integer) 2', $markdown);
+    }
+
+    /** Provenance-only changes intentionally retain the cached markdown. */
+    public function testProvenanceChangeDoesNotInvalidateSignatureCache(): void
+    {
+        $first = new Container();
+        (new Bind($first, '', 'FirstModule'))->annotatedWith('value')->toInstance(1);
+        $second = new Container();
+        (new Bind($second, '', 'SecondModule'))->annotatedWith('value')->toInstance(1);
+        $writer = new BindingsMarkdown();
+        $writer($first, $this->classDir);
+
+        $writer($second, $this->classDir);
+
+        $markdown = file_get_contents($this->classDir . '/bindings.md');
+        assert(is_string($markdown));
+        $this->assertStringContainsString('@FirstModule', $markdown);
+        $this->assertStringNotContainsString('@SecondModule', $markdown);
+    }
+
+    /** Matcher runtime state is not part of the declarative pointcut signature. */
+    public function testMatcherRuntimeStateDoesNotInvalidateSignatureCache(): void
+    {
+        $container = new Container();
+        (new Bind($container, FakeAopInterface::class, self::class))->to(FakeAop::class);
+        $classMatcher = new class extends AbstractMatcher {
+            public int $matches = 0;
+
+            /** @param array<array-key, mixed> $arguments */
+            public function matchesClass(ReflectionClass $class, array $arguments): bool
+            {
+                unset($class, $arguments);
+                $this->matches++;
+
+                return true;
+            }
+
+            /** @param array<array-key, mixed> $arguments */
+            public function matchesMethod(ReflectionMethod $method, array $arguments): bool
+            {
+                unset($method, $arguments);
+
+                return true;
+            }
+        };
+        $container->addPointcut(new Pointcut($classMatcher, (new Matcher())->any(), [FakeDoubleInterceptor::class]));
+        $writer = new BindingsMarkdown();
+        $writer($container, $this->classDir);
+        $matches = $classMatcher->matches;
+        file_put_contents($this->classDir . '/bindings.md', 'cached');
+
+        $writer($container, $this->classDir);
+
+        $this->assertSame($matches, $classMatcher->matches);
+        $this->assertSame('cached', file_get_contents($this->classDir . '/bindings.md'));
     }
 }

--- a/tests/di/Fake/FakeClosureBindModule.php
+++ b/tests/di/Fake/FakeClosureBindModule.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Di;
 
-/**
- * Binds a closure via toInstance() — an unserializable value.
- *
- * ModuleString serializes the container, so composing this makes bindings.md
- * emission fail; construction must still succeed (best-effort).
- */
+/** Binds an unserializable closure via toInstance(). */
 class FakeClosureBindModule extends AbstractModule
 {
     protected function configure(): void

--- a/tests/di/Fake/FakeCountingMatcher.php
+++ b/tests/di/Fake/FakeCountingMatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\AbstractMatcher;
+use ReflectionClass;
+use ReflectionMethod;
+
+final class FakeCountingMatcher extends AbstractMatcher
+{
+    public int $matches = 0;
+
+    /** @param array<array-key, mixed> $arguments */
+    public function matchesClass(ReflectionClass $class, array $arguments): bool
+    {
+        unset($class, $arguments);
+        $this->matches++;
+
+        return true;
+    }
+
+    /** @param array<array-key, mixed> $arguments */
+    public function matchesMethod(ReflectionMethod $method, array $arguments): bool
+    {
+        unset($method, $arguments);
+
+        return true;
+    }
+}

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -70,6 +70,18 @@ Ray\Di\FakeDoubleInterceptor- => (untargeted)
 Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider'), $normalize($string));
     }
 
+    public function testToStringWithoutPointcuts(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeEngine::class);
+            }
+        };
+
+        $this->assertSame(FakeEngine::class . '- => (untargeted)', (string) $module);
+    }
+
     /** Identical target classes share one AOP preview without mutating either dependency. */
     public function testToStringCachesAspectPreview(): void
     {

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\AbstractMatcher;
+use Ray\Aop\Matcher;
 use Ray\Di\Exception\NotFound;
+use ReflectionClass;
+use ReflectionMethod;
 
 use function str_replace;
 
@@ -64,5 +68,55 @@ class ModuleTest extends TestCase
 Ray\Di\FakeAopInterface- => (dependency) Ray\Di\FakeAop (aop) +returnSame(Ray\Di\FakeDoubleInterceptor)
 Ray\Di\FakeDoubleInterceptor- => (untargeted)
 Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider'), $normalize($string));
+    }
+
+    /** Identical target classes share one AOP preview without mutating either dependency. */
+    public function testToStringCachesAspectPreview(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeAopInterface::class)->annotatedWith('one')->to(FakeAop::class);
+                $this->bind(FakeAopInterface::class)->annotatedWith('two')->to(FakeAop::class);
+            }
+        };
+        $classMatcher = new class extends AbstractMatcher {
+            public int $matches = 0;
+
+            /** @param array<array-key, mixed> $arguments */
+            public function matchesClass(ReflectionClass $class, array $arguments): bool
+            {
+                unset($class, $arguments);
+                $this->matches++;
+
+                return true;
+            }
+
+            /** @param array<array-key, mixed> $arguments */
+            public function matchesMethod(ReflectionMethod $method, array $arguments): bool
+            {
+                unset($method, $arguments);
+
+                return true;
+            }
+        };
+        $module->bindInterceptor($classMatcher, (new Matcher())->any(), [FakeDoubleInterceptor::class]);
+        $container = $module->getContainer()->getContainer();
+        $first = $container[FakeAopInterface::class . '-one'];
+        $second = $container[FakeAopInterface::class . '-two'];
+
+        $moduleString = (string) $module;
+
+        $this->assertSame(1, $classMatcher->matches);
+        $this->assertSame('(dependency) ' . FakeAop::class, (string) $first);
+        $this->assertSame('(dependency) ' . FakeAop::class, (string) $second);
+        $this->assertStringContainsString(
+            FakeAopInterface::class . '-one => (dependency) ' . FakeAop::class . ' (aop)',
+            $moduleString,
+        );
+        $this->assertStringContainsString(
+            FakeAopInterface::class . '-two => (dependency) ' . FakeAop::class . ' (aop)',
+            $moduleString,
+        );
     }
 }

--- a/tests/di/ModuleTest.php
+++ b/tests/di/ModuleTest.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
-use Ray\Aop\AbstractMatcher;
 use Ray\Aop\Matcher;
 use Ray\Di\Exception\NotFound;
-use ReflectionClass;
-use ReflectionMethod;
 
 use function str_replace;
 
@@ -92,26 +89,7 @@ Ray\Di\FakeRobotInterface- => (provider) (dependency) Ray\Di\FakeRobotProvider')
                 $this->bind(FakeAopInterface::class)->annotatedWith('two')->to(FakeAop::class);
             }
         };
-        $classMatcher = new class extends AbstractMatcher {
-            public int $matches = 0;
-
-            /** @param array<array-key, mixed> $arguments */
-            public function matchesClass(ReflectionClass $class, array $arguments): bool
-            {
-                unset($class, $arguments);
-                $this->matches++;
-
-                return true;
-            }
-
-            /** @param array<array-key, mixed> $arguments */
-            public function matchesMethod(ReflectionMethod $method, array $arguments): bool
-            {
-                unset($method, $arguments);
-
-                return true;
-            }
-        };
+        $classMatcher = new FakeCountingMatcher();
         $module->bindInterceptor($classMatcher, (new Matcher())->any(), [FakeDoubleInterceptor::class]);
         $container = $module->getContainer()->getContainer();
         $first = $container[FakeAopInterface::class . '-one'];


### PR DESCRIPTION
## Summary

- remove container serialization from `ModuleString` and preview AOP bindings without mutating dependencies
- reuse AOP descriptions for repeated dependency classes
- cache `bindings.md` with a signature of resolved bindings and declarative pointcuts
- render closure instance bindings successfully

## Why

Generating `bindings.md` previously serialized and unserialized the entire container, then repeated AOP matcher work for identical target classes. This added avoidable cost and prevented diagnostics output when a binding contained an unserializable closure.

The signature sidecar now avoids recalculating and rewriting identical diagnostics while intentionally ignoring provenance-only changes.

## Validation

- `composer cs-fix`
- `composer tests` (266 tests, 454 assertions; Psalm: no errors)
- BeMart AppModule benchmark: `ModuleString` median reduced from about 1.31 ms to 0.49 ms
- BeMart signature cache hit: about 0.21 ms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signature-based caching for generated DI bindings documentation to avoid unnecessary regeneration.
  * Dependency and module previews are now aspect-aware, improving AOP/interceptor labeling.
  * Module string/log generation now reuses cached aspect-applied dependency strings for repeated dependencies.
  * Closure-based bindings are rendered into `bindings.md`.

* **Bug Fixes**
  * Diagnostics/artifact generation issues no longer block container construction.
  * Cached documentation is preserved when bindings are unchanged, and not invalidated by matcher runtime state or provenance-only changes.

* **Tests**
  * Expanded coverage for bindings caching behavior and updated closure-binding expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->