### PR TITLE
Fix assisted injection re-entry

### DIFF
--- a/src/di/AssistedInjectInterceptor.php
+++ b/src/di/AssistedInjectInterceptor.php
@@ -14,6 +14,7 @@ use ReflectionAttribute;
 use ReflectionNamedType;
 use ReflectionParameter;
 
+use function array_key_exists;
 use function assert;
 use function in_array;
 
@@ -62,12 +63,12 @@ final class AssistedInjectInterceptor implements MethodInterceptor
      */
     private function getNamedArguments(MethodInvocation $invocation): array
     {
-        $args = $invocation->getArguments();
+        $args = $invocation->getArguments()->getArrayCopy();
         $params = $invocation->getMethod()->getParameters();
         $namedParams = [];
         foreach ($params as $param) {
             $pos = $param->getPosition();
-            if (isset($args[$pos])) {
+            if (array_key_exists($pos, $args)) {
                 /** @psalm-suppress MixedAssignment */
                 $namedParams[$param->getName()] = $args[$pos];
             }

--- a/src/di/AssistedInjectInterceptor.php
+++ b/src/di/AssistedInjectInterceptor.php
@@ -15,9 +15,7 @@ use ReflectionNamedType;
 use ReflectionParameter;
 
 use function assert;
-use function call_user_func_array;
 use function in_array;
-use function is_callable;
 
 /**
  * @psalm-import-type NamedArguments from Types
@@ -52,10 +50,9 @@ final class AssistedInjectInterceptor implements MethodInterceptor
             }
         }
 
-        $callable = [$invocation->getThis(), $invocation->getMethod()->getName()];
-        assert(is_callable($callable));
+        $invocation->getArguments()->exchangeArray($namedArguments);
 
-        return call_user_func_array($callable, $namedArguments);
+        return $invocation->proceed();
     }
 
     /**

--- a/tests/di/AssistedTest.php
+++ b/tests/di/AssistedTest.php
@@ -44,6 +44,15 @@ class AssistedTest extends TestCase
         $this->assertInstanceOf(FakeRobot::class, $assistedDependency2);
     }
 
+    public function testAssistedAfterOmittedDefaultArgument(): void
+    {
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        [$value, $assistedDependency] = $consumer->assistAfterDefault();
+
+        $this->assertSame('default', $value);
+        $this->assertInstanceOf(FakeRobot::class, $assistedDependency);
+    }
+
     public function testAssistedMethodInvocation(): void
     {
         $assistedConsumer = (new Injector(new FakeAssistedDbModule()))->getInstance(FakeAssistedParamsConsumer::class);

--- a/tests/di/AssistedTest.php
+++ b/tests/di/AssistedTest.php
@@ -53,6 +53,15 @@ class AssistedTest extends TestCase
         $this->assertInstanceOf(FakeRobot::class, $assistedDependency);
     }
 
+    public function testAssistedPreservesExplicitNullArgument(): void
+    {
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        [$value, $assistedDependency] = $consumer->assistAfterDefault(null);
+
+        $this->assertNull($value);
+        $this->assertInstanceOf(FakeRobot::class, $assistedDependency);
+    }
+
     public function testAssistedMethodInvocation(): void
     {
         $assistedConsumer = (new Injector(new FakeAssistedDbModule()))->getInstance(FakeAssistedParamsConsumer::class);

--- a/tests/di/Fake/FakeAssistedConsumer.php
+++ b/tests/di/Fake/FakeAssistedConsumer.php
@@ -34,4 +34,10 @@ class FakeAssistedConsumer
     {
         return [$var2, $robot];
     }
+
+    /** @return array{string, FakeRobotInterface|null} */
+    public function assistAfterDefault(string $value = 'default', #[Assisted] ?FakeRobotInterface $robot = null): array
+    {
+        return [$value, $robot];
+    }
 }

--- a/tests/di/Fake/FakeAssistedConsumer.php
+++ b/tests/di/Fake/FakeAssistedConsumer.php
@@ -35,8 +35,8 @@ class FakeAssistedConsumer
         return [$var2, $robot];
     }
 
-    /** @return array{string, FakeRobotInterface|null} */
-    public function assistAfterDefault(string $value = 'default', #[Assisted] ?FakeRobotInterface $robot = null): array
+    /** @return array{string|null, FakeRobotInterface|null} */
+    public function assistAfterDefault(?string $value = 'default', #[Assisted] ?FakeRobotInterface $robot = null): array
     {
         return [$value, $robot];
     }


### PR DESCRIPTION
## Problem

Ray.Aop 2.22 dispatches a weaved method through a parent-call closure. `AssistedInjectInterceptor` instead called the method directly on the weaved object after resolving assisted arguments, which re-entered the same interceptor indefinitely.

## Changes

- replace the invocation arguments with the resolved named arguments
- resume the interceptor chain with `MethodInvocation::proceed()`
- cover an assisted parameter that follows an omitted optional argument

This keeps named/default argument semantics while allowing Ray.Aop to use its normal parent dispatch.

## Validation

- `composer tests` — 268 tests, 457 assertions
- `composer pcov` — 100% classes, methods, and lines
- targeted Infection run — 93% MSI (project threshold: 90%)
- CodeRabbit CLI review — no findings on the tracked diff
- Ray.Compiler integration with Ray.Aop 2.22.0 and this Ray.Di branch — 99 tests, 187 assertions

This unblocks the latest-dependency test failure observed in ray-di/Ray.Compiler#138.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed assisted dependency injection to correctly handle omitted defaulted and nullable arguments.
  - Ensured named-argument mapping is applied reliably during invocation, including cases where an argument is explicitly passed as `null`.

- **Tests**
  - Added PHPUnit coverage for assisted injection after omitting a default argument.
  - Added coverage for preserving an explicit `null` argument while still injecting the assisted dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->