### PR TITLE
Restore the rename()-then-rebind decorator idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 - Add a binding provenance log and emit `bindings.md` during module composition ([#323](https://github.com/ray-di/Ray.Di/pull/323)).
 - Add a reusable `Ray\Bindings\BindingsHtml` viewer and the `bin/bindings-html` command ([#325](https://github.com/ray-di/Ray.Di/pull/325)).
-- Detect circular dependencies and report them with a dedicated exception, and add the official `AbstractModule::renameBinding()` API ([#319](https://github.com/ray-di/Ray.Di/pull/319)).
+- Detect circular dependencies and report them with a dedicated exception, and add the official `AbstractModule::rename()` API ([#319](https://github.com/ray-di/Ray.Di/pull/319)).
 
 ### Changed
 

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -59,7 +59,7 @@ abstract class AbstractModule implements Stringable
             $this->getContainer()->merge($module->getContainer());
         }
 
-        $this->applyPendingRenames();
+        $this->discardPendingRenames();
     }
 
     public function __toString(): string
@@ -149,10 +149,13 @@ abstract class AbstractModule implements Stringable
      *
      * A binding already composed when rename() runs — own bind() or install() —
      * moves on the spot, so a later bind() to the vacated slot decorates it.
-     * Inside configure() a source that has not composed yet arrives with the
-     * constructor-chained module, so the rename is applied to that module's
-     * bindings when composition completes; the exceptions below then surface
-     * from the constructor.
+     * Inside configure() a source that has not composed yet must arrive with
+     * the constructor-chained module: the rename is applied to that module's
+     * bindings just before they merge, and a source missing there surfaces the
+     * exceptions below from the constructor. Without a chained module such a
+     * rename is dropped — a no-op, as everywhere in 2.x. Renaming a source
+     * that a later install() introduces is therefore not supported: install
+     * first, then rename.
      *
      * @param string $interface       Interface
      * @param string $newName         New binding name
@@ -202,7 +205,7 @@ abstract class AbstractModule implements Stringable
         $this->matcher = new Matcher();
         $this->isConfiguring = true;
         $this->configure();
-        $this->applyPendingRenames();
+        $this->discardPendingRenames();
     }
 
     private function hasBinding(string $interface, string $name): bool
@@ -211,22 +214,17 @@ abstract class AbstractModule implements Stringable
     }
 
     /**
-     * Apply pending renames whose source arrived in the given container, consuming them
+     * Apply pending renames to the constructor-chained container, consuming them
      *
      * The move happens before the merge, so the vacated slot stays free for
-     * whatever configure() declared there.
+     * whatever configure() declared there. A source missing from the chained
+     * container is an error, exactly as moving on it was in 2.20 — the pending
+     * rename must never fall through to the module's own container, where
+     * configure() may have re-bound the source index with a decorator.
      */
     private function applyPendingRenamesTo(Container $container): void
     {
-        $remaining = [];
-        foreach ($this->pendingRenames as $rename) {
-            [$interface, $newName, $sourceName, $targetInterface] = $rename;
-            if (! isset($container->getContainer()[$interface . '-' . $sourceName])) {
-                $remaining[] = $rename;
-
-                continue;
-            }
-
+        foreach ($this->pendingRenames as [$interface, $newName, $sourceName, $targetInterface]) {
             if ($this->hasBinding($targetInterface, $newName)) {
                 throw new RenameTargetAlreadyBound(sprintf("'%s-%s'", $targetInterface, $newName));
             }
@@ -234,16 +232,19 @@ abstract class AbstractModule implements Stringable
             $container->move($interface, $sourceName, $targetInterface, $newName);
         }
 
-        $this->pendingRenames = $remaining;
+        $this->pendingRenames = [];
     }
 
-    private function applyPendingRenames(): void
+    /**
+     * End composition, dropping renames no chained module could satisfy
+     *
+     * Without a constructor-chained module a pending rename has no source to
+     * arrive: it is dropped, as rename() in that position has been a no-op
+     * for the whole 2.x line.
+     */
+    private function discardPendingRenames(): void
     {
         $this->isConfiguring = false;
-        foreach ($this->pendingRenames as [$interface, $newName, $sourceName, $targetInterface]) {
-            $this->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
-        }
-
         $this->pendingRenames = [];
     }
 }

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -9,11 +9,13 @@ use Ray\Aop\Matcher;
 use Ray\Aop\Pointcut;
 use Ray\Aop\PriorityPointcut;
 use Ray\Bindings\ModuleVisitorInterface;
+use Ray\Di\Exception\RenameTargetAlreadyBound;
 use Stringable;
 
 use function assert;
 use function class_exists;
 use function interface_exists;
+use function sprintf;
 
 /**
  * @psalm-import-type BindableInterface from Types
@@ -33,7 +35,7 @@ abstract class AbstractModule implements Stringable
     private ?Container $container = null;
 
     /**
-     * Renames requested while configure() runs, applied after composition completes
+     * Renames deferred until the constructor-chained module arrives
      *
      * @var list<array{string, string, string, string}> [$interface, $newName, $sourceName, $targetInterface]
      */
@@ -53,6 +55,7 @@ abstract class AbstractModule implements Stringable
         // bind(), install()ed bindings, pointcuts — takes priority over the
         // chained module's, as in `new ProdModule(new AppModule())`.
         if ($module instanceof self) {
+            $this->applyPendingRenamesTo($module->getContainer());
             $this->getContainer()->merge($module->getContainer());
         }
 
@@ -142,9 +145,14 @@ abstract class AbstractModule implements Stringable
      * Renames an existing binding from $sourceName to $newName, optionally
      * moving it to a different interface. Works on the module's own container,
      * so bindings introduced via constructor chaining, install(), or override()
-     * are all reachable. Inside configure() the rename is deferred until module
-     * composition completes (the constructor-chained module is merged after
-     * configure()); the exceptions below then surface from the constructor.
+     * are all reachable.
+     *
+     * A binding already composed when rename() runs — own bind() or install() —
+     * moves on the spot, so a later bind() to the vacated slot decorates it.
+     * Inside configure() a source that has not composed yet arrives with the
+     * constructor-chained module, so the rename is applied to that module's
+     * bindings when composition completes; the exceptions below then surface
+     * from the constructor.
      *
      * @param string $interface       Interface
      * @param string $newName         New binding name
@@ -157,7 +165,7 @@ abstract class AbstractModule implements Stringable
     public function rename(string $interface, string $newName, string $sourceName = Name::ANY, string $targetInterface = ''): void
     {
         $targetInterface = $targetInterface ?: $interface;
-        if ($this->isConfiguring) {
+        if ($this->isConfiguring && ! $this->hasBinding($interface, $sourceName)) {
             $this->pendingRenames[] = [$interface, $newName, $sourceName, $targetInterface];
 
             return;
@@ -195,6 +203,38 @@ abstract class AbstractModule implements Stringable
         $this->isConfiguring = true;
         $this->configure();
         $this->applyPendingRenames();
+    }
+
+    private function hasBinding(string $interface, string $name): bool
+    {
+        return isset($this->getContainer()->getContainer()[$interface . '-' . $name]);
+    }
+
+    /**
+     * Apply pending renames whose source arrived in the given container, consuming them
+     *
+     * The move happens before the merge, so the vacated slot stays free for
+     * whatever configure() declared there.
+     */
+    private function applyPendingRenamesTo(Container $container): void
+    {
+        $remaining = [];
+        foreach ($this->pendingRenames as $rename) {
+            [$interface, $newName, $sourceName, $targetInterface] = $rename;
+            if (! isset($container->getContainer()[$interface . '-' . $sourceName])) {
+                $remaining[] = $rename;
+
+                continue;
+            }
+
+            if ($this->hasBinding($targetInterface, $newName)) {
+                throw new RenameTargetAlreadyBound(sprintf("'%s-%s'", $targetInterface, $newName));
+            }
+
+            $container->move($interface, $sourceName, $targetInterface, $newName);
+        }
+
+        $this->pendingRenames = $remaining;
     }
 
     private function applyPendingRenames(): void

--- a/tests/di/Fake/FakeRobotDecorator.php
+++ b/tests/di/Fake/FakeRobotDecorator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Wraps another FakeRobotInterface, exposing it to prove what a decorator received.
+ */
+class FakeRobotDecorator implements FakeRobotInterface
+{
+    public function __construct(
+        public readonly FakeRobotInterface $inner
+    ) {
+    }
+}

--- a/tests/di/RenameDecoratorTest.php
+++ b/tests/di/RenameDecoratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\Unbound;
 
 /**
  * Pins the rename()-then-rebind decorator idiom
@@ -82,5 +83,33 @@ class RenameDecoratorTest extends TestCase
 
         $this->assertInstanceOf(FakeRobotDecorator::class, $decorator);
         $this->assertInstanceOf(FakeRobot::class, $decorator->inner);
+    }
+
+    /**
+     * When the chained module fails to provide the source -- an application
+     * without a RouterInterface handed to CliModule -- construction must fail
+     * loudly, as moving on the chained container did in 2.20. The pending
+     * rename must never fall through to the module's own container, where it
+     * would move the decorator onto the source's new name: the decorator then
+     * injects itself, and the unnamed index resolves to nothing.
+     */
+    public function testMissingSourceInChainedModuleFailsAtConstruction(): void
+    {
+        $emptyChained = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+
+        $this->expectException(Unbound::class);
+
+        new class ($emptyChained) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
     }
 }

--- a/tests/di/RenameDecoratorTest.php
+++ b/tests/di/RenameDecoratorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the rename()-then-rebind decorator idiom
+ *
+ * A module moves an existing binding aside with rename(), then binds its own
+ * implementation to the vacated index and injects the moved one by its new
+ * name. That is how a module decorates a binding it does not own.
+ *
+ * This is not a hypothetical: `BEAR\Package\Context\CliModule` composes the
+ * whole CLI context this way -- it renames the application's RouterInterface
+ * to 'original' and binds CliRouter over it, which injects the original router
+ * with #[Named('original')]. BEAR.Defer (TransferInterface) and BEAR.DevTools
+ * (RenderInterface) do the same. A change that flips an assertion here breaks
+ * every BEAR.Sunday console application; fix the change, not the test.
+ *
+ * The pinned order is deliberate. rename() is called while configure() runs,
+ * before the constructor-chained module that owns the source binding has been
+ * merged, so a decorator must be able to name a binding that has not composed
+ * yet.
+ */
+class RenameDecoratorTest extends TestCase
+{
+    /**
+     * The source binding arrives with the constructor-chained module, as an
+     * application module hands RouterInterface to CliModule.
+     */
+    public function testDecoratesConstructorChainedBinding(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+        $container = $module->getContainer();
+
+        $decorator = $container->getInstance(FakeRobotInterface::class, Name::ANY);
+        $this->assertInstanceOf(FakeRobotDecorator::class, $decorator);
+        $this->assertInstanceOf(FakeRobot::class, $decorator->inner);
+    }
+
+    /** The moved binding stays reachable under its new name, as the decorator injects it. */
+    public function testMovedBindingIsInjectableByItsNewName(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+
+        $original = $module->getContainer()->getInstance(FakeRobotInterface::class, 'original');
+
+        $this->assertInstanceOf(FakeRobot::class, $original);
+    }
+
+    /** The same idiom against an already-composed source: install() has merged the binding. */
+    public function testDecoratesInstalledBinding(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new FakeToBindModule());
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+
+        $decorator = $module->getContainer()->getInstance(FakeRobotInterface::class, Name::ANY);
+
+        $this->assertInstanceOf(FakeRobotDecorator::class, $decorator);
+        $this->assertInstanceOf(FakeRobot::class, $decorator->inner);
+    }
+}

--- a/tests/di/RenameTest.php
+++ b/tests/di/RenameTest.php
@@ -100,13 +100,14 @@ class RenameTest extends TestCase
     }
 
     /**
-     * When no binding exists at the source index, rename() must
-     * surface Container::move()'s Unbound rather than silently no-op.
+     * With no constructor-chained module to supply the source, a rename whose
+     * source never composed is dropped -- rename() in that position has been a
+     * silent no-op for the whole 2.x line, and `composer update` must not turn
+     * long-dormant rename() calls into constructor-time errors. Existing
+     * bindings stay untouched.
      */
-    public function testThrowsUnboundWhenSourceMissing(): void
+    public function testMissingSourceWithoutChainedModuleIsNoOp(): void
     {
-        $this->expectException(Unbound::class);
-
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
@@ -114,6 +115,10 @@ class RenameTest extends TestCase
                 $this->rename(FakeRobotInterface::class, 'renamed', 'does-not-exist');
             }
         };
+
+        $instance = $module->getContainer()->getInstance(FakeRobotInterface::class, Name::ANY);
+
+        $this->assertInstanceOf(FakeRobot::class, $instance);
     }
 
     /**

--- a/tests/di/RenameTest.php
+++ b/tests/di/RenameTest.php
@@ -201,6 +201,25 @@ class RenameTest extends TestCase
     }
 
     /**
+     * Cross-interface rename works on a source that arrives with the
+     * constructor-chained module too: $targetInterface must travel the
+     * deferred path intact.
+     */
+    public function testMovesConstructorChainedBindingToDifferentInterface(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'moved', Name::ANY, FakeCarInterface::class);
+            }
+        };
+        $container = $module->getContainer();
+
+        $this->assertInstanceOf(FakeRobot::class, $container->getInstance(FakeCarInterface::class, 'moved'));
+        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-' . Name::ANY, $container->getContainer());
+    }
+
+    /**
      * Renaming a binding to its own current name must be a no-op, not an
      * error. The existing binding must remain resolvable under the same name.
      */

--- a/tests/di/RenameTest.php
+++ b/tests/di/RenameTest.php
@@ -66,6 +66,40 @@ class RenameTest extends TestCase
     }
 
     /**
+     * A deferred rename whose source never arrives -- not with the chained
+     * module either -- must still surface Unbound, not vanish.
+     */
+    public function testThrowsUnboundWhenDeferredSourceNeverArrives(): void
+    {
+        $this->expectException(Unbound::class);
+
+        new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                // FakeToBindModule binds FakeRobotInterface, never FakeEngineInterface
+                $this->rename(FakeEngineInterface::class, 'renamed');
+            }
+        };
+    }
+
+    /**
+     * When configure() has bound the index a deferred rename targets, the
+     * rename must be rejected rather than lose that binding to the merge.
+     */
+    public function testThrowsWhenDeferredRenameTargetIsAlreadyBound(): void
+    {
+        $this->expectException(RenameTargetAlreadyBound::class);
+
+        new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'renamed');
+                $this->bind(FakeRobotInterface::class)->annotatedWith('renamed')->to(FakeRobot2::class);
+            }
+        };
+    }
+
+    /**
      * When no binding exists at the source index, rename() must
      * surface Container::move()'s Unbound rather than silently no-op.
      */


### PR DESCRIPTION
## What broke

A module moves an existing binding aside with `rename()`, binds its own implementation to the vacated index, and injects the moved one by its new name. That is how a module decorates a binding it does not own:

```php
$this->rename(RouterInterface::class, 'original');
$this->bind(RouterInterface::class)->to(CliRouter::class);   // CliRouter injects #[Named('original')]
```

That is not a hypothetical — it is `BEAR\Package\Context\CliModule`, i.e. the CLI context of every BEAR.Sunday application. BEAR.Defer (`TransferInterface`) and BEAR.DevTools (`RenderInterface`) build on the same order.

2.21.0 (`569e871e`) deferred every configure()-time `rename()` until composition completes. By then the decorator itself occupies the source index, so the rename moves **the decorator** onto `'original'` — it injects itself, and the unnamed index is left unbound. Verified against the released packages:

```
ray/di 2.22.0 / bear/package 1.20.1
  → Unbound: 'BEAR\Sunday\Extension\Router\RouterInterface-'
this branch / bear/package 1.20.1   (unmodified)
  → RouterInterface = BEAR\Package\Provide\Router\CliRouter
```

## Why review missed it, and how this PR is built

Nothing pinned the idiom: the 2.21 redesign passed the whole suite — including the composition contract layer — while breaking the core framework's CLI context. So every behavior change here lands red-first, and each red commit records its exact failures:

1. **`Add red spec for the rename()-then-rebind decorator idiom`** — three tests, failing on `2.x` (`Unbound` twice, and a `CircularDependency original -> original` that exposes the self-injection mechanism)
2. **`Restore the decorator idiom: turn the red rename spec green`** — the two-phase fix
3. **`Add red spec for missing-source renames`** — a three-agent review of commits 1–2 found the fix itself repeated the original sin: it only pinned a chained module that *supplies* the source. When it does not (an application without the expected binding handed to `CliModule`), the pending rename fell through to the module's own container and moved the decorator — construction succeeded with a silently broken container. Two specs pin the 2.20 semantics for both missing-source positions.
4. **`Resolve pending renames on the chained container only`** — turns them green, plus the reviewer-requested cross-interface deferred-rename pin
5. **`docs: correct the 2.21.0 changelog to the shipped rename() API`** — the entry credited a `renameBinding()` API that no release ships

## The semantics (2.20-exact for existing code)

For each position of the source when `rename()` runs inside `configure()`:

| source position | behavior |
| --- | --- |
| own container (`bind()`/`install()` before rename) | moved on the spot — a later `bind()` decorates it |
| constructor-chained module | moved just before its merge |
| chained module present, source missing | `Unbound` at construction (as moving on the chained container threw in 2.20) |
| no chained module, source missing | dropped — the 2.x no-op; `composer update` must not turn dormant `rename()` calls into constructor-time errors |

A pending rename never falls back onto the module's own container. Renaming a source that a later `install()` introduces stays unsupported as in every 2.x release (now documented: install first, then rename). The missing-source exception contract that commit 2 briefly carried was introduced by the 2.21 redesign itself, not by 2.x history — per the manual's no-BC-break promise, universal missing-source exceptions belong to a major version.

## Verification

- 288 tests green; `AbstractModule` at 100% line and method coverage; cs / Psalm / PHPStan clean (`composer tests` exit 0)
- Each red commit reproduces its recorded failures on checkout; the following commit turns them green
- BEAR.Package 1.20.1, unmodified, resolves `RouterInterface` to `CliRouter` against this branch; on 2.22.0 it throws `Unbound`
- BEAR.Defer (broken on 2.22.0) passes unmodified, 13/13
- Reviewed by three independent agents (glm, codex, kimi); the blocking finding and both BC recommendations are incorporated. Out of scope by design: applying pending renames at `install()` merges (would make the rename target order-dependent and is a new feature for a never-supported ordering) and hardening `Container::move()` to throw plain `Unbound` for concrete-class sources (worth a separate PR)

## Note on the released versions

2.21.0, 2.21.1 and 2.22.0 all carry the break and have been removed from Packagist (each had zero installs), so `composer update` currently resolves to 2.20.0. Whatever version this ships as should carry release notes for the 2.21-cycle rename change that this PR keeps: `rename()` now reaches bindings introduced by `install()`/`override()` (previously a silent no-op or misdirected), while missing-source behavior stays 2.20-compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queued `rename()` behavior during constructor chaining so vacated slots can be filled by the composing module’s declarations.
  * Strengthened `rename()`-then-rebind for both constructor-chained and already-installed bindings.
  * Deferred renames now correctly throw `Unbound` when the source never arrives, and `RenameTargetAlreadyBound` on target collisions.
* **Tests**
  * Expanded rename test scenarios for deferred sources, missing sources, and cross-interface moves.
  * Added a dedicated decorator test suite and a fake decorator implementation to validate rename-then-rebind decoration behavior.
* **Documentation**
  * Updated the changelog entry to reference the official `rename()` API name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->