### PR TITLE
Restore rename() to its wrapper transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Restore `AbstractModule::rename()` to the wrapper transformation it is in every released 2.x version: it moves a binding of the module it wraps, so a module can move a binding aside, bind its own implementation over it, and inject the moved one by its new name. 2.21.0 made the module's own container the subject and deferred the rename past composition, which renamed the decorator onto its own inner name — breaking `BEAR\Package\Context\CliModule` and with it the CLI context of every BEAR.Sunday application, as well as BEAR.Defer and BEAR.DevTools. 2.21.0, 2.21.1 and 2.22.0 carry the break and were removed from Packagist.
+- Renaming a binding composed by the renaming module itself, through `bind()`, `install()` or `override()`, is not supported and never was; only the wrapped module's bindings can be renamed.
+
 ## 2.22.0 - 2026-07-16
 
 ### Added
@@ -42,7 +49,7 @@
 
 - Add a binding provenance log and emit `bindings.md` during module composition ([#323](https://github.com/ray-di/Ray.Di/pull/323)).
 - Add a reusable `Ray\Bindings\BindingsHtml` viewer and the `bin/bindings-html` command ([#325](https://github.com/ray-di/Ray.Di/pull/325)).
-- Detect circular dependencies and report them with a dedicated exception, and add the official `AbstractModule::renameBinding()` API ([#319](https://github.com/ray-di/Ray.Di/pull/319)).
+- Detect circular dependencies and report them with a dedicated exception ([#319](https://github.com/ray-di/Ray.Di/pull/319)).
 
 ### Changed
 

--- a/src/di/AbstractModule.php
+++ b/src/di/AbstractModule.php
@@ -26,28 +26,19 @@ abstract class AbstractModule implements Stringable
     protected $matcher;
 
     /**
+     * The module this one wraps — the subject of rename()
+     *
      * @var ?AbstractModule
-     * @deprecated Unused since rename() now operates on getContainer().
      */
     protected $lastModule;
     private ?Container $container = null;
 
-    /**
-     * Renames requested while configure() runs, applied after composition completes
-     *
-     * @var list<array{string, string, string, string}> [$interface, $newName, $sourceName, $targetInterface]
-     */
-    private array $pendingRenames = [];
-    private bool $isConfiguring = false;
-
     public function __construct(
         ?self $module = null
     ) {
-        /** @psalm-suppress DeprecatedProperty kept for BC */
         $this->lastModule = $module;
         $this->container = new Container();
         $this->matcher = new Matcher();
-        $this->isConfiguring = true;
         $this->configure();
         // Merged after configure() so that everything configure() declared —
         // bind(), install()ed bindings, pointcuts — takes priority over the
@@ -55,8 +46,6 @@ abstract class AbstractModule implements Stringable
         if ($module instanceof self) {
             $this->getContainer()->merge($module->getContainer());
         }
-
-        $this->applyPendingRenames();
     }
 
     public function __toString(): string
@@ -137,33 +126,31 @@ abstract class AbstractModule implements Stringable
     }
 
     /**
-     * Rename a binding
+     * Rename a binding of the wrapped module
      *
-     * Renames an existing binding from $sourceName to $newName, optionally
-     * moving it to a different interface. Works on the module's own container,
-     * so bindings introduced via constructor chaining, install(), or override()
-     * are all reachable. Inside configure() the rename is deferred until module
-     * composition completes (the constructor-chained module is merged after
-     * configure()); the exceptions below then surface from the constructor.
+     * Moves a binding the wrapped module made from $sourceName to $newName,
+     * optionally onto a different interface, so this module can bind its own
+     * implementation over the vacated index and inject the moved one by its
+     * new name — the wrapper transformation a decorator module is built on.
+     *
+     * The subject is always the wrapped module, never the bindings this module
+     * is declaring: renaming reaches the past. With nothing wrapped there is no
+     * past to rewire and the call does nothing.
      *
      * @param string $interface       Interface
      * @param string $newName         New binding name
      * @param string $sourceName      Original binding name
      * @param string $targetInterface Target interface to move the binding to (default: same as $interface)
      *
-     * @throws Exception\Unbound                 When no binding exists at $interface-$sourceName.
+     * @throws Exception\Unbound                 When the wrapped module has no binding at $interface-$sourceName.
      * @throws Exception\RenameTargetAlreadyBound When a binding already exists at the target index.
      */
     public function rename(string $interface, string $newName, string $sourceName = Name::ANY, string $targetInterface = ''): void
     {
         $targetInterface = $targetInterface ?: $interface;
-        if ($this->isConfiguring) {
-            $this->pendingRenames[] = [$interface, $newName, $sourceName, $targetInterface];
-
-            return;
+        if ($this->lastModule instanceof self) {
+            $this->lastModule->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
         }
-
-        $this->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
     }
 
     /**
@@ -192,18 +179,6 @@ abstract class AbstractModule implements Stringable
     {
         $this->container = new Container();
         $this->matcher = new Matcher();
-        $this->isConfiguring = true;
         $this->configure();
-        $this->applyPendingRenames();
-    }
-
-    private function applyPendingRenames(): void
-    {
-        $this->isConfiguring = false;
-        foreach ($this->pendingRenames as [$interface, $newName, $sourceName, $targetInterface]) {
-            $this->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
-        }
-
-        $this->pendingRenames = [];
     }
 }

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -138,10 +138,9 @@ LOG;
      */
     public function testRenameRecordsMoveEventAndTransfersProvenance(): void
     {
-        $module = new class extends AbstractModule {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
             protected function configure(): void
             {
-                $this->install(new FakeToBindModule());
                 $this->rename(FakeRobotInterface::class, 'renamed');
             }
         };

--- a/tests/di/Fake/FakeRobotDecorator.php
+++ b/tests/di/Fake/FakeRobotDecorator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Wraps another FakeRobotInterface, exposing it to prove what a decorator received.
+ */
+class FakeRobotDecorator implements FakeRobotInterface
+{
+    public function __construct(
+        public readonly FakeRobotInterface $inner
+    ) {
+    }
+}

--- a/tests/di/RenameDecoratorTest.php
+++ b/tests/di/RenameDecoratorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\Unbound;
+
+/**
+ * Pins rename() as a wrapper transformation
+ *
+ * rename() rewires a binding that was made before this module existed: the
+ * module wraps another, moves the binding it is about to replace aside, binds
+ * its own implementation over it, and injects the moved one by its new name.
+ *
+ * That shape is the whole reason rename() exists. `BEAR\Package\Context\CliModule`
+ * composes every BEAR.Sunday console application with it — the application's
+ * RouterInterface moves to 'original' and CliRouter binds over it, injecting the
+ * original with #[Named('original')] — and BEAR.Defer (TransferInterface) and
+ * BEAR.DevTools (RenderInterface) do the same. A change that flips an assertion
+ * here breaks all three; fix the change, not the test.
+ *
+ * The subject is always the wrapped module's container. That is what makes the
+ * ordering rule a single sentence: rename() reaches the past, never the bindings
+ * this module is declaring right now. Renaming is therefore a no-op with nothing
+ * wrapped, and the source must be found in what was wrapped.
+ */
+class RenameDecoratorTest extends TestCase
+{
+    /** The wrapped module's binding is moved aside and replaced, as in CliModule. */
+    public function testDecoratesWrappedBinding(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+
+        $decorator = $module->getContainer()->getInstance(FakeRobotInterface::class, Name::ANY);
+
+        $this->assertInstanceOf(FakeRobotDecorator::class, $decorator);
+        $this->assertInstanceOf(FakeRobot::class, $decorator->inner);
+    }
+
+    /** The moved binding stays reachable under its new name, as the decorator injects it. */
+    public function testMovedBindingIsInjectableByItsNewName(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+
+        $original = $module->getContainer()->getInstance(FakeRobotInterface::class, 'original');
+
+        $this->assertInstanceOf(FakeRobot::class, $original);
+    }
+
+    /**
+     * A wrapped module without the expected binding is a configuration error,
+     * and saying so at construction is the whole value of naming the past: the
+     * decorator must never be mistaken for the binding it meant to move.
+     */
+    public function testMissingSourceInWrappedModuleThrows(): void
+    {
+        $emptyWrapped = new class extends AbstractModule {
+            protected function configure(): void
+            {
+            }
+        };
+
+        $this->expectException(Unbound::class);
+
+        new class ($emptyWrapped) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'original');
+                $this->bind(FakeRobotInterface::class)
+                    ->toConstructor(FakeRobotDecorator::class, ['inner' => 'original']);
+            }
+        };
+    }
+
+    /**
+     * With nothing wrapped there is no past to rewire, so rename() does nothing
+     * -- as it has for the whole 2.x line. It must not reach into the bindings
+     * this module is declaring, which is how a decorator ends up renamed onto
+     * its own inner name and injecting itself.
+     */
+    public function testRenamingWithNothingWrappedIsNoOp(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new FakeToBindModule());
+                $this->rename(FakeRobotInterface::class, 'original');
+            }
+        };
+        $container = $module->getContainer();
+
+        $this->assertInstanceOf(FakeRobot::class, $container->getInstance(FakeRobotInterface::class, Name::ANY));
+        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-original', $container->getContainer());
+    }
+}

--- a/tests/di/RenameTest.php
+++ b/tests/di/RenameTest.php
@@ -8,100 +8,110 @@ use PHPUnit\Framework\TestCase;
 use Ray\Di\Exception\RenameTargetAlreadyBound;
 use Ray\Di\Exception\Unbound;
 
+/**
+ * Pins the mechanics of renaming a wrapped module's binding
+ *
+ * The wrapper transformation itself — move aside, bind over, inject the moved
+ * one — is pinned by {@see RenameDecoratorTest}. This covers what a rename does
+ * to the index: which name it lands on, which interface, and how it refuses.
+ */
 class RenameTest extends TestCase
 {
     /**
-     * rename() must operate on getContainer() directly, so a binding
-     * introduced via install() -- not just constructor chaining -- can be
-     * renamed. After the move, the new name resolves and the old (unnamed)
-     * index is gone.
+     * With $targetInterface omitted, the rename stays within the same
+     * interface -- only the binding name changes.
      */
-    public function testRenamesBindingIntroducedByInstall(): void
+    public function testRenameWithinSameInterfaceWhenTargetInterfaceOmitted(): void
     {
-        $module = new class extends AbstractModule {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
             protected function configure(): void
             {
-                $this->install(new FakeToBindModule());
                 $this->rename(FakeRobotInterface::class, 'renamed');
+            }
+        };
+        $array = $module->getContainer()->getContainer();
+
+        $this->assertArrayHasKey(FakeRobotInterface::class . '-renamed', $array);
+        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-' . Name::ANY, $array);
+    }
+
+    /**
+     * With $targetInterface specified, the binding moves to a different
+     * interface index entirely, not just a new name under the source one.
+     */
+    public function testMovesToDifferentInterfaceWhenTargetInterfaceSpecified(): void
+    {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->rename(FakeRobotInterface::class, 'moved', Name::ANY, FakeCarInterface::class);
             }
         };
         $container = $module->getContainer();
 
-        $instance = $container->getInstance(FakeRobotInterface::class, 'renamed');
-        $this->assertInstanceOf(FakeRobot::class, $instance);
-
-        $this->expectException(Unbound::class);
-        $container->getInstance(FakeRobotInterface::class, Name::ANY);
+        $this->assertInstanceOf(FakeRobot::class, $container->getInstance(FakeCarInterface::class, 'moved'));
+        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-' . Name::ANY, $container->getContainer());
     }
 
     /**
-     * override() replaces $this->container with the target module's (merged)
-     * container. rename() inside configure() is deferred and applied against
-     * getContainer() after composition completes, so it must act on that
-     * merged container, not on a stale reference captured before the swap.
+     * Renaming a binding to its own current name is a no-op, not an error.
+     * The existing binding remains resolvable under the same name.
      */
-    public function testRenamesBindingAfterOverride(): void
+    public function testSelfRenameIsNoOp(): void
     {
-        $module = new class extends AbstractModule {
+        $module = new class (new FakeToBindModule()) extends AbstractModule {
             protected function configure(): void
             {
-                $this->install(new FakeToBindModule());
-                $this->override(new class extends AbstractModule {
-                    protected function configure(): void
-                    {
-                        $this->bind(FakeEngineInterface::class)->toInstance(new FakeEngine());
-                    }
-                });
-                $this->rename(FakeRobotInterface::class, 'renamed');
+                $this->rename(FakeRobotInterface::class, Name::ANY, Name::ANY);
             }
         };
-        $container = $module->getContainer();
 
-        // the renamed binding, originally introduced before override(), is reachable
-        $instance = $container->getInstance(FakeRobotInterface::class, 'renamed');
+        $instance = $module->getContainer()->getInstance(FakeRobotInterface::class, Name::ANY);
+
         $this->assertInstanceOf(FakeRobot::class, $instance);
-
-        // and the override target's own binding survived alongside it
-        $this->assertInstanceOf(FakeEngine::class, $container->getInstance(FakeEngineInterface::class, Name::ANY));
     }
 
     /**
-     * When no binding exists at the source index, rename() must
-     * surface Container::move()'s Unbound rather than silently no-op.
+     * When the wrapped module has no binding at the source index, rename()
+     * surfaces Container::move()'s Unbound rather than silently no-op.
      */
     public function testThrowsUnboundWhenSourceMissing(): void
     {
         $this->expectException(Unbound::class);
 
-        $module = new class extends AbstractModule {
+        new class (new FakeToBindModule()) extends AbstractModule {
             protected function configure(): void
             {
-                $this->install(new FakeToBindModule());
                 $this->rename(FakeRobotInterface::class, 'renamed', 'does-not-exist');
             }
         };
     }
 
     /**
-     * Renaming onto an index that already has a binding must be rejected
-     * instead of silently overwriting it. The pre-existing binding at the
-     * target index must remain resolvable afterward, proving move() aborted
-     * before mutating the container.
+     * Renaming onto an index that already has a binding is rejected instead of
+     * silently overwriting it. The pre-existing binding at the target index
+     * remains resolvable afterward, proving move() aborted before mutating the
+     * container.
      */
     public function testThrowsWhenTargetAlreadyBoundAndPreservesExistingBinding(): void
     {
-        $module = new class extends AbstractModule {
+        $wrapped = new class extends AbstractModule {
             protected function configure(): void
             {
-                $this->install(new FakeToBindModule());
-                // occupy the target index before attempting the rename
+                $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+                // occupy the target index before the rename is attempted
                 $this->bind(FakeRobotInterface::class)->annotatedWith('renamed')->to(FakeRobot2::class);
             }
         };
 
         $threw = false;
         try {
-            $module->rename(FakeRobotInterface::class, 'renamed');
+            new class ($wrapped) extends AbstractModule {
+                protected function configure(): void
+                {
+                    $this->rename(FakeRobotInterface::class, 'renamed');
+                }
+            };
         } catch (RenameTargetAlreadyBound $e) {
             $threw = true;
         }
@@ -109,74 +119,9 @@ class RenameTest extends TestCase
         $this->assertTrue($threw, 'RenameTargetAlreadyBound was not thrown');
 
         // the pre-existing binding at the target index was not destroyed
-        $instance = $module->getContainer()->getInstance(FakeRobotInterface::class, 'renamed');
-        $this->assertInstanceOf(FakeRobot2::class, $instance);
-
+        $container = $wrapped->getContainer();
+        $this->assertInstanceOf(FakeRobot2::class, $container->getInstance(FakeRobotInterface::class, 'renamed'));
         // and the source binding was left untouched since the move aborted
-        $source = $module->getContainer()->getInstance(FakeRobotInterface::class, Name::ANY);
-        $this->assertInstanceOf(FakeRobot::class, $source);
-    }
-
-    /**
-     * With $targetInterface omitted, the rename must stay within the same
-     * interface -- only the binding name changes.
-     */
-    public function testRenameWithinSameInterfaceWhenTargetInterfaceOmitted(): void
-    {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->install(new FakeToBindModule());
-                $this->rename(FakeRobotInterface::class, 'renamed');
-            }
-        };
-        $container = $module->getContainer();
-        $array = $container->getContainer();
-
-        $this->assertArrayHasKey(FakeRobotInterface::class . '-renamed', $array);
-        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-' . Name::ANY, $array);
-    }
-
-    /**
-     * With $targetInterface specified, the binding must move to a different
-     * interface index entirely, not just get a new name under the source
-     * interface.
-     */
-    public function testMovesToDifferentInterfaceWhenTargetInterfaceSpecified(): void
-    {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->install(new FakeToBindModule());
-                $this->rename(FakeRobotInterface::class, 'moved', Name::ANY, FakeCarInterface::class);
-            }
-        };
-        $container = $module->getContainer();
-        $array = $container->getContainer();
-
-        $this->assertArrayHasKey(FakeCarInterface::class . '-moved', $array);
-        $this->assertArrayNotHasKey(FakeRobotInterface::class . '-' . Name::ANY, $array);
-
-        $instance = $container->getInstance(FakeCarInterface::class, 'moved');
-        $this->assertInstanceOf(FakeRobot::class, $instance);
-    }
-
-    /**
-     * Renaming a binding to its own current name must be a no-op, not an
-     * error. The existing binding must remain resolvable under the same name.
-     */
-    public function testSelfRenameIsNoOp(): void
-    {
-        $module = new class extends AbstractModule {
-            protected function configure(): void
-            {
-                $this->install(new FakeToBindModule());
-                $this->rename(FakeRobotInterface::class, Name::ANY, Name::ANY);
-            }
-        };
-        $container = $module->getContainer();
-
-        $instance = $container->getInstance(FakeRobotInterface::class, Name::ANY);
-        $this->assertInstanceOf(FakeRobot::class, $instance);
+        $this->assertInstanceOf(FakeRobot::class, $container->getInstance(FakeRobotInterface::class, Name::ANY));
     }
 }


### PR DESCRIPTION
Supersedes #332, which repaired the 2.21 `rename()` redesign from the inside. Reviewers (glm, codex, kimi, and a fourth pass) converged on the redesign itself being the defect, so this removes it instead.

## What rename() is

A module wraps another, moves the binding it is about to replace aside, binds its own implementation over it, and injects the moved one by its new name:

```php
$this->rename(RouterInterface::class, 'original');
$this->bind(RouterInterface::class)->to(CliRouter::class);   // CliRouter injects #[Named('original')]
```

That is `BEAR\Package\Context\CliModule` — the CLI context of every BEAR.Sunday application — and BEAR.Defer (`TransferInterface`) and BEAR.DevTools (`RenderInterface`) are the same shape. The subject is always the wrapped module. That keeps the ordering rule to one sentence: **rename() reaches the past, never the bindings this module is declaring right now.**

## What broke

2.21.0 (`569e871e`) made the module's own container the subject. But the subject of a rename is by definition a binding made before this module existed, and the own container cannot hold it when `rename()` runs — `configure()` completes before the wrapped module merges, precisely so this module's declarations win. So the rename had to be deferred past the merge, by which point the decorator occupied the source index and was renamed onto its own inner name:

```
ray/di 2.22.0 / bear/package 1.20.1
  → Unbound: 'BEAR\Sunday\Extension\Router\RouterInterface-'
this branch / bear/package 1.20.1   (unmodified)
  → RouterInterface = BEAR\Package\Provide\Router\CliRouter
```

2.21.0, 2.21.1 and 2.22.0 all carry it and were removed from Packagist (each had zero installs), so `composer update` currently resolves to 2.20.0.

## The change

`rename()` returns to what every released 2.x version shipped:

```php
if ($this->lastModule instanceof self) {
    $this->lastModule->getContainer()->move($interface, $sourceName, $targetInterface, $newName);
}
```

Everything added to contain the deferral — `pendingRenames`, `isConfiguring`, `hasBinding`, `applyPendingRenamesTo`, `discardPendingRenames` — is gone. What survived of it in #332 was `applyPendingRenamesTo($module->getContainer())`: the wrapped module's container, reached through a deferral. That is what `$lastModule` already was, so it is no longer deprecated — it is the subject of the operation.

`AbstractModule` goes from 49 lines / 14 methods to **34 lines / 11 methods**, both at 100% coverage.

## What is dropped, and why that is the point

The redesign added one capability along the way: renaming a binding the module composed itself, via `bind()`/`install()`/`override()`. No 2.x release has it, and no caller in the wild uses it — all three real callers wrap. Its specs (`testRenamesBindingIntroducedByInstall`, `testRenamesBindingAfterOverride`) pinned the new capability rather than any 2.x behavior and are removed with it. The rest of `RenameTest` keeps its intent against a wrapped source.

`BindingLogTest`'s rename spec holds unchanged: the move is recorded on the wrapped container's log, and `merge()` carries the event and its provenance across, so a rename still says the moved binding belongs to the module that bound it.

Everything else from the 2.21 cycle is untouched and keeps its value: the circular-dependency detection, the JIT double-construction and named-request recursion fixes, `Container::move()`'s `RenameTargetAlreadyBound` collision check, `BindingLog`, the `Ray\Bindings` snapshots, and the `ModuleCompositionTest` contract layer.

## Commits

1. **`Add red spec for rename() as a wrapper transformation`** — four tests, failing on `2.x`, each a different face of the same violation: the decorator renamed away from its own index (`Unbound`), renamed onto its own inner name (`CircularDependency original -> original`), a wrapped module missing the binding accepted silently, and an `install()`ed binding moved out from under a module that wrapped nothing.
2. **`Restore rename() to its wrapper transformation`** — turns them green.
3. **`docs: record the rename() restoration and correct the 2.21.0 entry`** — the entry credits a `renameBinding()` API that no release ships; it existed only between #319's first design (which added it *alongside* an unchanged `rename()`) and the tag, by which point it had been folded into `rename()` itself.

Checking out the first commit reproduces the recorded failures; the second turns them green.

## Verification

- 283 tests green; `AbstractModule` 100% line and method coverage; cs / Psalm / PHPStan clean (`composer tests` exit 0)
- All three real callers pass **unmodified** against this branch: bear/package 1.20.1 resolves `RouterInterface` to `CliRouter`; BEAR.Defer 13/13; BEAR.DevTools 38/38
- BEAR.Package can drop the workaround it added for 2.21+, which reached for `$this->lastModule` directly

## Deliberately not here

- Making `rename()` throw when nothing is wrapped. It has been a silent no-op for all of 2.x; the manual promises no BC breaks in minors, so tightening it belongs to 3.0.
- An API for renaming a module's own composed bindings. If it is wanted, it should be a separate method with its own name, not a redefinition of `rename()` — and 3.0 is the place to weigh it.
- `Container::move()` mutates the wrapped module's container in place, so a module instance reused across injectors carries the rename. That predates this PR; a snapshot/immutable transformation is 3.0 material.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored dependency-binding rename behavior to match previous 2.x releases.
  * Fixed CLI context support for BEAR.Sunday applications and related tooling.
  * Versions 2.21.0, 2.21.1, and 2.22.0 were removed from Packagist due to this issue.

* **Documentation**
  * Updated the changelog with the fix details and corrected the 2.21.0 feature description.

* **Tests**
  * Added coverage for decorator-style renaming, missing bindings, no-op scenarios, and renamed binding injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->