### PR TITLE
Reject non-instantiable classes from just-in-time binding

### DIFF
--- a/src/di/Bind.php
+++ b/src/di/Bind.php
@@ -40,7 +40,7 @@ final class Bind implements Stringable
         public readonly string $source = ''
     ) {
         $this->validate = new BindValidator();
-        $bindUntarget = class_exists($this->interface) && ! (new \ReflectionClass($this->interface))->isAbstract() && ! $this->isRegistered($this->interface);
+        $bindUntarget = class_exists($this->interface) && (new \ReflectionClass($this->interface))->isInstantiable() && ! $this->isRegistered($this->interface);
         $this->bound = new NullDependency();
         if ($bindUntarget) {
             /** @var class-string $interface */

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -246,7 +246,7 @@ final class Container implements InjectorInterface
     {
         /** @psalm-suppress PossiblyUndefinedArrayOffset -- $index is always "{interface}-{name}" */
         [$class, $name] = explode('-', $index, 2);
-        if (class_exists($class) && ! (new ReflectionClass($class))->isAbstract()) {
+        if (class_exists($class) && (new ReflectionClass($class))->isInstantiable()) {
             return new Untargeted($class);
         }
 

--- a/tests/di/Fake/FakePrivateConstructor.php
+++ b/tests/di/Fake/FakePrivateConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+final class FakePrivateConstructor
+{
+    /** @param array<class-string> $classes */
+    private function __construct(array $classes)
+    {
+    }
+}

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -56,6 +56,19 @@ class InjectorTest extends TestCase
         $this->assertInstanceOf(FakeEngine::class, $instance);
     }
 
+    public function testGetUnboundNonInstantiableConcreteClassThrowsUnbound(): void
+    {
+        $injector = new Injector(new FakeInstanceBindModule());
+
+        try {
+            $injector->getInstance(FakePrivateConstructor::class);
+            self::fail('A non-instantiable class must not be just-in-time bound.');
+        } catch (Unbound $e) {
+            self::assertSame(Unbound::class, $e::class);
+            self::assertSame("'" . FakePrivateConstructor::class . "-'", $e->getMessage());
+        }
+    }
+
     public function testUnboundConcreteClassIsConstructedOnlyOnce(): void
     {
         FakeConstructCounter::$constructCount = 0;


### PR DESCRIPTION
## Summary

- JIT / untargeted eligibility used `!isAbstract()`, so concrete classes with a private constructor were still treated as JIT candidates.
- After NewInstance switched to language-level `new $class(...)` (2.21+), resolving an unbound non-instantiable class surfaces a bare PHP `Error` instead of a DI exception.
- Use `ReflectionClass::isInstantiable()` in `Container::unbound` and the matching untargeted path in `Bind`, so those cases fail with `Unbound` and never attempt construction.
- Top-level JIT of public instantiable concrete classes is unchanged (2.x compatibility). Nested dependencies are still not auto-bound.

## Test plan

- [x] `./vendor/bin/phpunit` (284 tests)
- [x] New case: unbound private-constructor class throws `Unbound` (not `Error`)
- [x] Existing auto-bind of unbound public concrete still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for classes that cannot be instantiated, including classes with private constructors.
  * Such classes now correctly produce an unbound error instead of being resolved automatically.

* **Tests**
  * Added coverage confirming the expected exception and message for non-instantiable, unbound classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->