### PR TITLE
Fix multibindings being lost from all but the first installed module

### DIFF
--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -303,6 +303,18 @@ final class Container implements InjectorInterface
         $this->multiBindings->merge($container->multiBindings);
         $this->container += $otherContainer;
         $this->pointcuts = array_merge($this->pointcuts, $container->getPointcuts());
+        $this->bindMergedMultiBindings();
+    }
+
+    /** Re-point the MultiBindings binding at the merged store */
+    private function bindMergedMultiBindings(): void
+    {
+        $index = MultiBindings::class . '-' . Name::ANY;
+        if (! isset($this->container[$index])) {
+            return;
+        }
+
+        $this->container[$index] = new Instance($this->multiBindings);
     }
 
     /**

--- a/tests/di/ModuleCompositionTest.php
+++ b/tests/di/ModuleCompositionTest.php
@@ -337,4 +337,46 @@ class ModuleCompositionTest extends TestCase
             array_keys(iterator_to_array($consumer->engines))
         );
     }
+
+    /**
+     * Every installed sibling contributes its multibindings, even when the
+     * installing module declares none of its own.
+     *
+     * MultiBinder binds MultiBindings::class toInstance() the store of the
+     * module it was called on, so each sibling carries its own store into the
+     * parent as an ordinary binding while merge() collects the entries into the
+     * parent's store. The binding that wins must be the merged store, not
+     * whichever sibling happened to be installed first.
+     */
+    public function testEveryInstalledSiblingContributesMultiBindings(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('first-sibling')->to(FakeEngine::class);
+                    }
+                });
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('second-sibling')->to(FakeEngine2::class);
+                        MultiBinder::newInstance($this, FakeRobotInterface::class)
+                            ->addBinding('robot')->to(FakeRobot::class);
+                    }
+                });
+            }
+        };
+        $consumer = (new Injector($module))->getInstance(FakeMultiBindingConsumer::class);
+
+        $this->assertSame(
+            ['first-sibling', 'second-sibling'],
+            array_keys(iterator_to_array($consumer->engines))
+        );
+        $this->assertSame(['robot'], array_keys(iterator_to_array($consumer->robots)));
+    }
 }

--- a/tests/di/MultiBinding/MultiBindingModuleTest.php
+++ b/tests/di/MultiBinding/MultiBindingModuleTest.php
@@ -168,6 +168,23 @@ class MultiBindingModuleTest extends TestCase
         $this->assertArrayHasKey('four', (array) $multiBindings[FakeEngineInterface::class]);
     }
 
+    /**
+     * MultiBindings resolves to the container's own store — the object
+     * Container::merge() accumulates entries into — so what was merged is what
+     * gets injected.
+     *
+     * Holds even with no MultiBinder in play: MultiBindingModule's binding is
+     * what makes the index exist at all, and without it the request falls
+     * through to just-in-time binding and yields an unrelated empty store.
+     */
+    public function testMultiBindingsResolvesToTheContainersOwnStore(): void
+    {
+        $module = new NullModule();
+        $injector = new Injector($module);
+
+        $this->assertSame($module->getContainer()->multiBindings, $injector->getInstance(MultiBindings::class));
+    }
+
     public function testAnnotation(): void
     {
         $injector = new Injector($this->module);

--- a/tests/di/README.md
+++ b/tests/di/README.md
@@ -22,6 +22,7 @@ layer exists so that class of change can never again pass silently.
 | Binding precedence: bind() / install() / constructor chain / override() | `ModuleCompositionTest` |
 | AOP wrapping order across modules and install() | `ModuleCompositionTest` |
 | MultiBinding collection order across modules | `ModuleCompositionTest` |
+| MultiBinding visibility: every installed sibling contributes | `ModuleCompositionTest` |
 | rename(): deferred application, reachable sources, error contract | `RenameTest` |
 | Cycle detection vs legal re-entry (singleton `@PostConstruct`) | `CircularDependencyTest` |
 | Singleton identity, serialization lifecycle | `DependencyTest`, `InjectorTest` |


### PR DESCRIPTION
## Summary

`MultiBinder` binds `MultiBindings::class` `toInstance()` its own module's store,
so `Container::merge()` merges the entries correctly but `+=` picks the first
installed module's store as the winner — later siblings' multibindings vanish,
surfacing only as a `TypeError` from `MapProvider` elsewhere.

Re-point the binding at the merged store after each merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-bindings from installed sibling modules are now merged and remain available through dependency injection.
  * Multi-binding consumers now consistently receive the container’s own combined store, even without an explicitly configured binder.
  * Multi-binding entries remain accessible when modules are composed together.

* **Documentation**
  * Added contract documentation describing multi-binding visibility across installed sibling modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->