### PR TITLE
Distinguish an empty multibinding set from an undeclared one

### DIFF
--- a/src/di/Exception/MultiBindingNotFound.php
+++ b/src/di/Exception/MultiBindingNotFound.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di\Exception;
+
+use LogicException;
+
+/**
+ * Thrown when a #[Set] injection point finds no set for its interface
+ *
+ * Message format: '{interface}' in file:line ($var)
+ *
+ * MultiBinder::newInstance() declares the set, so an interface declared with
+ * zero members injects an empty Map rather than reaching here. Reaching here
+ * means the interface is absent from the MultiBindings this injection point
+ * received: no MultiBinder ran for it, a setBinding() dropped it and the chain
+ * stopped before to() put it back, or a sibling module's declarations never
+ * arrived -- each MultiBinder binds MultiBindings to its own instance.
+ */
+final class MultiBindingNotFound extends LogicException implements ExceptionInterface
+{
+}

--- a/src/di/Exception/SetNotBound.php
+++ b/src/di/Exception/SetNotBound.php
@@ -14,10 +14,9 @@ use LogicException;
  * MultiBinder::newInstance() declares the set, so an interface declared with
  * zero members injects an empty Map rather than reaching here. Reaching here
  * means the interface is absent from the MultiBindings this injection point
- * received: no MultiBinder ran for it, a setBinding() dropped it and the chain
- * stopped before to() put it back, or a sibling module's declarations never
- * arrived -- each MultiBinder binds MultiBindings to its own instance.
+ * received: no MultiBinder ran for it, or a setBinding() dropped it and the
+ * chain stopped before to() put it back.
  */
-final class MultiBindingNotFound extends LogicException implements ExceptionInterface
+final class SetNotBound extends LogicException implements ExceptionInterface
 {
 }

--- a/src/di/MultiBinder.php
+++ b/src/di/MultiBinder.php
@@ -26,6 +26,7 @@ final class MultiBinder
     {
         $this->container = $module->getContainer();
         $this->multiBindings = $this->container->multiBindings;
+        $this->declareSet();
         $this->container->add(
             (new Bind($this->container, MultiBindings::class))->toInstance($this->multiBindings)
         );
@@ -73,8 +74,22 @@ final class MultiBinder
         $this->bind(new LazyInstance($instance), $this->key);
     }
 
+    /**
+     * Declare the set, so that "declared with no member" is a state the store
+     * can represent and MapProvider can inject as an empty Map
+     */
+    private function declareSet(): void
+    {
+        if ($this->multiBindings->offsetExists($this->interface)) {
+            return;
+        }
+
+        $this->multiBindings->offsetSet($this->interface, []);
+    }
+
     private function bind(LazyInterface $lazy, ?string $key): void
     {
+        // setBinding() removes the key, so it may be absent here
         $bindings = [];
         if ($this->multiBindings->offsetExists($this->interface)) {
             $bindings = $this->multiBindings->offsetGet($this->interface);

--- a/src/di/MultiBinding/MapProvider.php
+++ b/src/di/MultiBinding/MapProvider.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Ray\Di\MultiBinding;
 
 use Ray\Di\Di\Set;
+use Ray\Di\Exception\SetNotBound;
 use Ray\Di\Exception\SetNotFound;
 use Ray\Di\InjectionPointInterface;
 use Ray\Di\InjectorInterface;
 use Ray\Di\ProviderInterface;
+
+use function sprintf;
 
 /** @implements ProviderInterface<Map> */
 final class MapProvider implements ProviderInterface
@@ -28,6 +31,16 @@ final class MapProvider implements ProviderInterface
 
         /** @var Set<object> $set */
         $set = $setAttribute[0]->newInstance();
+
+        if (! $this->multiBindings->offsetExists($set->interface)) {
+            throw new SetNotBound(sprintf(
+                "'%s' in %s:%d ($%s)",
+                $set->interface,
+                $param->getDeclaringFunction()->getFileName(),
+                $param->getDeclaringFunction()->getStartLine(),
+                $param->getName()
+            ));
+        }
 
         /** @var array<string, LazyTo<object>> $lazies */
         $lazies = $this->multiBindings[$set->interface];

--- a/src/di/Types.php
+++ b/src/di/Types.php
@@ -33,8 +33,8 @@ use Ray\Aop\Pointcut;
  * @psalm-type QualifierList = array<object>
  * @psalm-type ScopeType = Scope::SINGLETON|Scope::PROTOTYPE
  * @psalm-type ProviderContext = string
- * @psalm-type MultiBindingMap = array<string, non-empty-array<array-key, MultiBinding\LazyInterface>>
- * @psalm-type LazyBindingList = non-empty-array<array-key, MultiBinding\LazyInterface>
+ * @psalm-type MultiBindingMap = array<string, array<array-key, MultiBinding\LazyInterface>>
+ * @psalm-type LazyBindingList = array<array-key, MultiBinding\LazyInterface>
  * @psalm-type MethodInterceptorBindings array<non-empty-string, list<MethodInterceptor>>
  * @psalm-type InterceptorClassList array<class-string<MethodInterceptor>>
  * @psalm-type VisitorResult = object|array<array-key, mixed>|null

--- a/tests/di/MultiBinding/MultiBinderTest.php
+++ b/tests/di/MultiBinding/MultiBinderTest.php
@@ -60,4 +60,37 @@ class MultiBinderTest extends TestCase
         // interface B's own binding is present
         $this->assertArrayHasKey('robot', (array) $multiBindings[FakeRobotInterface::class]);
     }
+
+    /**
+     * newInstance() declares the set, so "declared with no member" is a state
+     * the store can represent. Without it a consumer cannot tell an empty set
+     * from an interface nobody bound.
+     */
+    public function testNewInstanceDeclaresEmptySet(): void
+    {
+        $module = new NullModule();
+        MultiBinder::newInstance($module, FakeEngineInterface::class);
+
+        /** @var MultiBindings $multiBindings */
+        $multiBindings = $module->getContainer()->getInstance(MultiBindings::class);
+        $this->assertTrue($multiBindings->offsetExists(FakeEngineInterface::class));
+        $this->assertSame([], $multiBindings[FakeEngineInterface::class]);
+    }
+
+    /**
+     * Declaring a set that already has members must leave them alone. Two
+     * modules binding the same interface each construct their own MultiBinder,
+     * so the second declaration must append rather than wipe the first.
+     */
+    public function testNewInstanceKeepsExistingMembers(): void
+    {
+        $module = new NullModule();
+        MultiBinder::newInstance($module, FakeEngineInterface::class)->addBinding('one')->to(FakeEngine::class);
+        MultiBinder::newInstance($module, FakeEngineInterface::class)->addBinding('two')->to(FakeEngine2::class);
+
+        /** @var MultiBindings $multiBindings */
+        $multiBindings = $module->getContainer()->getInstance(MultiBindings::class);
+        $this->assertArrayHasKey('one', (array) $multiBindings[FakeEngineInterface::class]);
+        $this->assertArrayHasKey('two', (array) $multiBindings[FakeEngineInterface::class]);
+    }
 }

--- a/tests/di/MultiBinding/MultiBindingModuleTest.php
+++ b/tests/di/MultiBinding/MultiBindingModuleTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\ReadOnlyMapAccess;
+use Ray\Di\Exception\SetNotBound;
 use Ray\Di\Exception\SetNotFound;
 use Ray\Di\FakeEngine;
 use Ray\Di\FakeEngine2;
@@ -207,5 +208,75 @@ class MultiBindingModuleTest extends TestCase
         $this->expectException(SetNotFound::class);
         $injector = new Injector();
         $injector->getInstance(FakeSetNotFoundWithProvider::class);
+    }
+
+    /**
+     * A set declared by MultiBinder but given no members is a legal
+     * configuration (`new AppModule([])` with a plugin list that happens to be
+     * empty), so it must inject an empty Map rather than fail.
+     */
+    public function testDeclaredSetWithNoMemberInjectsEmptyMap(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                MultiBinder::newInstance($this, FakeEngineInterface::class);
+                MultiBinder::newInstance($this, FakeRobotInterface::class);
+            }
+        };
+
+        // constructing the consumer must not throw: MapProvider runs on injection
+        $consumer = (new Injector($module))->getInstance(FakeMultiBindingConsumer::class);
+
+        $this->assertSame(0, count($consumer->engines));
+        $this->assertSame([], iterator_to_array($consumer->engines));
+        $this->assertSame(0, count($consumer->robots));
+        $this->assertSame([], iterator_to_array($consumer->robots));
+    }
+
+    /**
+     * An interface no MultiBinder ever declared is a wiring error, and must be
+     * named as such instead of failing inside Map's constructor.
+     */
+    public function testSetNotBound(): void
+    {
+        $injector = new Injector(new NullModule());
+        try {
+            $injector->getInstance(FakeMultiBindingConsumer::class);
+            self::fail('SetNotBound must be thrown when no MultiBinder declared the #[Set] interface.');
+        } catch (SetNotBound $e) {
+            // the missing interface and the injection point, per Unbound's message format
+            self::assertStringStartsWith("'" . FakeEngineInterface::class . "' in ", $e->getMessage());
+            self::assertStringEndsWith('($engines)', $e->getMessage());
+        }
+    }
+
+    /**
+     * setBinding() drops the set on the spot and to() puts the replacement
+     * back, so a chain abandoned in between leaves the interface undeclared --
+     * unlike an abandoned addBinding(), which records a key and touches
+     * nothing. setBinding() is left as it is, which makes that broken module
+     * report the same way as one that never bound the interface, rather than
+     * quietly injecting an empty Map: that is reserved for a set someone
+     * declared and left without members on purpose.
+     */
+    public function testAbandonedSetBindingIsReported(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                MultiBinder::newInstance($this, FakeRobotInterface::class)->addBinding('robot')->to(FakeRobot::class);
+                $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
+                $engineBinder->addBinding('one')->to(FakeEngine::class);
+                $engineBinder->setBinding('two'); // the chain stops here: to() is never reached
+            }
+        };
+        $injector = new Injector($module);
+        try {
+            $injector->getInstance(FakeMultiBindingConsumer::class);
+            self::fail('An abandoned setBinding() leaves the set undeclared and must be reported.');
+        } catch (SetNotBound $e) {
+            self::assertStringStartsWith("'" . FakeEngineInterface::class . "' in ", $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Problem

`MapProvider::get()` reads `$this->multiBindings[$set->interface]` without checking the key exists. Two different states land there and both die identically:

```
Warning: Undefined array key "X"
TypeError: Ray\Di\MultiBinding\Map::__construct(): Argument #1 ($lazies) must be of type array, null given
```

Neither the interface nor the injection point is named, and the failure happens when the consumer is constructed, not when the `Map` is iterated.

## Behavior

| `#[Set]` injection point | before | after |
| --- | --- | --- |
| no `#[Set]` attribute | `SetNotFound` | unchanged |
| declared by MultiBinder, zero members | `TypeError` | empty `Map` |
| no set registered for the interface | `TypeError` | `SetNotBound: 'X' in file:line ($var)` |

A set with no members is legal — `MultiBinder::newInstance($this, X::class)` with a plugin list that happens to be empty — so `newInstance()` now declares the interface with an empty list, and a key still missing means no set was registered.

`setBinding()` is left alone. It drops the set on the spot, so a chain abandoned before `to()` still leaves the interface undeclared — now reported by name instead of crashing inside `Map`'s constructor.

## Backward compatibility

A module that calls `newInstance()` and adds nothing used to fail at injection and now gets an empty `Map`.

`LazyBindingList` drops `non-empty-array` because an empty member list is now legal. `MultiBindingMap` states the same thing one level up and is corrected to match, though nothing imports it today.

## Related
#340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Empty multi-bindings can now be declared and injected as empty maps.
  * Missing multi-binding declarations now produce a clear error identifying the affected interface and injection point.

* **Bug Fixes**
  * Preserved existing members when adding multiple bindings to the same set.
  * Improved handling of incomplete or abandoned binding configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->