### PR TITLE
Roll back the singleton cache when @PostConstruct throws

### DIFF
--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -10,6 +10,7 @@ use Ray\Aop\MethodInterceptor;
 use Ray\Aop\WeavedInterface;
 use ReflectionClass;
 use ReflectionMethod;
+use Throwable;
 
 use function assert;
 use function method_exists;
@@ -97,7 +98,21 @@ final class Dependency implements DependencyInterface, AcceptInterface
         // @PostConstruct
         if ($this->postConstruct !== null) {
             assert(method_exists($instance, $this->postConstruct));
-            $instance->{$this->postConstruct}();
+            try {
+                $instance->{$this->postConstruct}();
+            } catch (Throwable $e) {
+                // Roll back the singleton cache so the next resolution rebuilds
+                // instead of returning this half-initialized instance. The cache
+                // is committed before PostConstruct on purpose (to let a singleton
+                // resolve itself from its own lifecycle method); we only unwind it
+                // when PostConstruct actually fails.
+                if ($this->isSingleton) {
+                    $this->instance = null;
+                    $this->isInstantiated = false;
+                }
+
+                throw $e;
+            }
         }
 
         return $instance;
@@ -125,7 +140,16 @@ final class Dependency implements DependencyInterface, AcceptInterface
         // @PostConstruct
         if ($this->postConstruct !== null) {
             assert(method_exists($instance, $this->postConstruct));
-            $instance->{$this->postConstruct}();
+            try {
+                $instance->{$this->postConstruct}();
+            } catch (Throwable $e) {
+                if ($this->isSingleton) {
+                    $this->instance = null;
+                    $this->isInstantiated = false;
+                }
+
+                throw $e;
+            }
         }
 
         return $instance;

--- a/src/di/Dependency.php
+++ b/src/di/Dependency.php
@@ -101,11 +101,6 @@ final class Dependency implements DependencyInterface, AcceptInterface
             try {
                 $instance->{$this->postConstruct}();
             } catch (Throwable $e) {
-                // Roll back the singleton cache so the next resolution rebuilds
-                // instead of returning this half-initialized instance. The cache
-                // is committed before PostConstruct on purpose (to let a singleton
-                // resolve itself from its own lifecycle method); we only unwind it
-                // when PostConstruct actually fails.
                 if ($this->isSingleton) {
                     $this->instance = null;
                     $this->isInstantiated = false;

--- a/tests/di/DependencyTest.php
+++ b/tests/di/DependencyTest.php
@@ -12,6 +12,7 @@ use Ray\Aop\Pointcut;
 use Ray\Aop\WeavedInterface;
 use ReflectionClass;
 use ReflectionMethod;
+use RuntimeException;
 
 use function assert;
 use function is_object;
@@ -207,5 +208,40 @@ class DependencyTest extends TestCase
         $this->assertSame('first', $second->value);
         // postConstruct ran exactly once, not on every injectWithArgs() call
         $this->assertSame(1, $second->postConstructCount);
+    }
+
+    /**
+     * A failed @PostConstruct on the args path must roll back the singleton
+     * cache so the next injectWithArgs() rebuilds instead of returning the
+     * half-initialized cached instance. Mirrors the inject() rollback that
+     * the public getInstance() path is tested for.
+     */
+    public function testInjectWithArgsRollsBackSingletonOnPostConstructFailure(): void
+    {
+        FakePostConstructRetrySingleton::reset();
+
+        /** @var ReflectionClass<object> $class */
+        $class = new ReflectionClass(FakePostConstructRetrySingleton::class);
+        $newInstance = new NewInstance($class, new SetterMethods([]));
+        $dependency = new Dependency($newInstance, new ReflectionMethod(FakePostConstructRetrySingleton::class, 'initialize'));
+        $dependency->setScope(Scope::SINGLETON);
+        $container = new Container();
+
+        // First call: PostConstruct throws.
+        try {
+            $dependency->injectWithArgs($container, []);
+            $this->fail('Expected PostConstruct to throw on the first injectWithArgs call');
+        } catch (RuntimeException $e) {
+            $this->assertSame('PostConstruct failed on first call', $e->getMessage());
+        }
+
+        // Second call must rebuild — the singleton cache was rolled back,
+        // not left holding the half-initialized instance.
+        $instance = $dependency->injectWithArgs($container, []);
+        assert($instance instanceof FakePostConstructRetrySingleton);
+
+        $this->assertSame(2, FakePostConstructRetrySingleton::$constructCount);
+        $this->assertSame(2, FakePostConstructRetrySingleton::$postConstructCount);
+        $this->assertTrue(FakePostConstructRetrySingleton::$initialized);
     }
 }

--- a/tests/di/Fake/FakePostConstructRetrySingleton.php
+++ b/tests/di/Fake/FakePostConstructRetrySingleton.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use RuntimeException;
+
+use Ray\Di\Di\PostConstruct;
+
+/**
+ * A singleton whose @PostConstruct throws on the first call and succeeds on the
+ * second, used to verify the singleton cache is rolled back when PostConstruct
+ * fails so the next resolution rebuilds instead of returning a half-initialized
+ * instance.
+ */
+class FakePostConstructRetrySingleton
+{
+    public static int $constructCount = 0;
+    public static int $postConstructCount = 0;
+    public static bool $initialized = false;
+
+    public function __construct()
+    {
+        self::$constructCount++;
+    }
+
+    #[PostConstruct]
+    public function initialize(): void
+    {
+        self::$postConstructCount++;
+
+        if (self::$postConstructCount === 1) {
+            throw new RuntimeException('PostConstruct failed on first call');
+        }
+
+        self::$initialized = true;
+    }
+
+    public static function reset(): void
+    {
+        self::$constructCount = 0;
+        self::$postConstructCount = 0;
+        self::$initialized = false;
+    }
+}

--- a/tests/di/PostConstructSingletonRetryTest.php
+++ b/tests/di/PostConstructSingletonRetryTest.php
@@ -7,6 +7,8 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+use function assert;
+
 /**
  * Pins the singleton cache rollback contract for @PostConstruct failures
  *

--- a/tests/di/PostConstructSingletonRetryTest.php
+++ b/tests/di/PostConstructSingletonRetryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Pins the singleton cache rollback contract for @PostConstruct failures
+ *
+ * When a singleton's @PostConstruct throws, the half-initialized instance must
+ * not stay cached: the next resolution must rebuild from scratch (re-running the
+ * constructor and PostConstruct) and return a fully initialized object.
+ *
+ * Ray.Compiler already unwinds the cache on PostConstruct failure; this test
+ * aligns the runtime Injector with that behaviour.
+ */
+class PostConstructSingletonRetryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        FakePostConstructRetrySingleton::reset();
+    }
+
+    public function testSingletonRebuildsAfterPostConstructThrows(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakePostConstructRetrySingleton::class)->in(Scope::SINGLETON);
+            }
+        });
+
+        // First resolution: PostConstruct throws.
+        try {
+            $injector->getInstance(FakePostConstructRetrySingleton::class);
+            $this->fail('Expected PostConstruct to throw on the first resolution');
+        } catch (RuntimeException $e) {
+            $this->assertSame('PostConstruct failed on first call', $e->getMessage());
+        }
+
+        // Second resolution must rebuild, not return the cached half-initialized instance.
+        $instance = $injector->getInstance(FakePostConstructRetrySingleton::class);
+
+        assert($instance instanceof FakePostConstructRetrySingleton);
+
+        // The constructor ran again — the singleton cache was rolled back, not reused.
+        $this->assertSame(2, FakePostConstructRetrySingleton::$constructCount);
+        // PostConstruct ran again — the second attempt was not short-circuited.
+        $this->assertSame(2, FakePostConstructRetrySingleton::$postConstructCount);
+        // The returned object is fully initialized.
+        $this->assertTrue(FakePostConstructRetrySingleton::$initialized);
+        $this->assertTrue($instance::$initialized);
+    }
+}


### PR DESCRIPTION
## Summary

When a singleton's `#[PostConstruct]` method throws, `Dependency::inject()` left the half-initialized instance in the singleton cache. Every later resolution returned it silently — no retry, no re-throw — diverging from `Ray.Compiler`, which unwinds the cache and lets the next resolution rebuild.

Closes #343.

## Change

Wrap the `#[PostConstruct]` call in `try/catch (Throwable)` in both `Dependency::inject()` and `Dependency::injectWithArgs()`. On a throw, if the binding is a singleton, clear `$instance` / `$isInstantiated` before rethrowing, so the next resolution rebuilds from scratch.

The cache commit *before* `#[PostConstruct]` is intentional and unchanged — it is what lets a singleton resolve itself from its own lifecycle method without recursing. Only the missing unwind is added.

## Test

A red contract test is added first (`PostConstructSingletonRetryTest`), then the fix turns it green. The test asserts the rebuild concretely: constructor called twice, `#[PostConstruct]` called twice, and the returned object fully initialized — not the half-initialized cached one.

`ModuleCompositionTest` stays green; this touches the PostConstruct lifecycle only, not binding registration, merge order, scope, or AOP weaving.

## Compatibility

Code relying on the old behavior was relying on receiving an object whose initialization failed, so no real breakage is expected. Behaviour change, to be called out in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed singleton initialization no longer leaves behind an unusable cached instance.
  * Retrying after a lifecycle initialization failure now creates and initializes a fresh instance.
  * Initialization errors continue to be reported to the caller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->