### PR TITLE
Exclude the MultiBindings index from the BindingLog

### DIFF
--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -37,12 +37,8 @@ use function sprintf;
 final class Container implements InjectorInterface
 {
     /**
-     * Index of the MultiBindings container binding
-     *
-     * MultiBinder installs a toInstance binding for MultiBindings under
-     * Name::ANY; it is bookkeeping infrastructure, not a user binding, so it
-     * is excluded from the BindingLog (the entries themselves are written
-     * straight to the store and never logged either).
+     * Bookkeeping binding installed by MultiBinder, not a user binding,
+     * so it is excluded from the BindingLog
      */
     private const MULTI_BINDINGS_INDEX = MultiBindings::class . '-' . Name::ANY;
 

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -307,10 +307,7 @@ final class Container implements InjectorInterface
         $otherContainer = $container->getContainer();
         // iterate the incoming (usually smaller) side: O(incoming), not O(accumulated)
         $collidingIndexes = array_keys(array_intersect_key($otherContainer, $this->container));
-        // The MultiBindings binding collides on every merge (each module
-        // carries its own), but it is bookkeeping infrastructure: exclude it
-        // so no keep event is emitted and its provenance is not adopted.
-        // bindMergedMultiBindings() re-points the binding to the merged store.
+        // MultiBindings collides on every merge by design; excluded from the log (see MULTI_BINDINGS_INDEX)
         $collidingIndexes = array_values(array_filter(
             $collidingIndexes,
             static fn (string $index): bool => $index !== self::MULTI_BINDINGS_INDEX

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -16,9 +16,11 @@ use Ray\Di\Exception\Untargeted;
 use Ray\Di\MultiBinding\MultiBindings;
 use ReflectionClass;
 
+use function array_filter;
 use function array_intersect_key;
 use function array_keys;
 use function array_merge;
+use function array_values;
 use function class_exists;
 use function explode;
 use function implode;
@@ -34,6 +36,16 @@ use function sprintf;
  */
 final class Container implements InjectorInterface
 {
+    /**
+     * Index of the MultiBindings container binding
+     *
+     * MultiBinder installs a toInstance binding for MultiBindings under
+     * Name::ANY; it is bookkeeping infrastructure, not a user binding, so it
+     * is excluded from the BindingLog (the entries themselves are written
+     * straight to the store and never logged either).
+     */
+    private const MULTI_BINDINGS_INDEX = MultiBindings::class . '-' . Name::ANY;
+
     /** @var MultiBindings */
     public $multiBindings;
 
@@ -86,6 +98,10 @@ final class Container implements InjectorInterface
         $previous = $this->container[$index] ?? null;
         $dependency = $bind->getBound();
         $dependency->register($this->container, $bind);
+        if ($index === self::MULTI_BINDINGS_INDEX) {
+            return;
+        }
+
         /** @psalm-suppress InvalidArrayAccess -- register()'s @param-out leaves the DependencyContainer alias unexpanded */
         $this->log->register(
             $index,
@@ -291,6 +307,14 @@ final class Container implements InjectorInterface
         $otherContainer = $container->getContainer();
         // iterate the incoming (usually smaller) side: O(incoming), not O(accumulated)
         $collidingIndexes = array_keys(array_intersect_key($otherContainer, $this->container));
+        // The MultiBindings binding collides on every merge (each module
+        // carries its own), but it is bookkeeping infrastructure: exclude it
+        // so no keep event is emitted and its provenance is not adopted.
+        // bindMergedMultiBindings() re-points the binding to the merged store.
+        $collidingIndexes = array_values(array_filter(
+            $collidingIndexes,
+            static fn (string $index): bool => $index !== self::MULTI_BINDINGS_INDEX
+        ));
         $keptDependencies = [];
         $discardedDependencies = [];
         foreach ($collidingIndexes as $index) {
@@ -309,7 +333,7 @@ final class Container implements InjectorInterface
     /** Re-point the MultiBindings binding at the merged store */
     private function bindMergedMultiBindings(): void
     {
-        $index = MultiBindings::class . '-' . Name::ANY;
+        $index = self::MULTI_BINDINGS_INDEX;
         if (! isset($this->container[$index])) {
             return;
         }

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Di\MultiBinding\MultiBindings;
 use ReflectionProperty;
 
+use function array_filter;
 use function assert;
 use function serialize;
 use function unserialize;
@@ -223,6 +225,83 @@ LOG;
         assert($container instanceof Container);
 
         $this->assertSame(Injector::class, $container->log->getSource(FakeEngine::class . '-'));
+    }
+
+    /**
+     * The MultiBindings container binding is infrastructure that
+     * MultiBinder installs alongside the real map/set entries; the entries
+     * themselves bypass the log (they are written straight to the store), so
+     * logging only the MultiBindings binding produces noise that the
+     * docblock promises is absent. Assert that promise holds: no event of
+     * any kind (bind/replace/keep/move) carries the MultiBindings index, and
+     * the provenance map has no entry for it.
+     */
+    public function testMultiBindingsIndexIsExcludedFromTheLog(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                MultiBinder::newInstance($this, FakeEngineInterface::class)
+                    ->addBinding('one')->to(FakeEngine::class);
+                MultiBinder::newInstance($this, FakeRobotInterface::class)
+                    ->addBinding('robot')->to(FakeRobot::class);
+            }
+        };
+        $log = $module->getContainer()->log;
+        $index = MultiBindings::class . '-' . Name::ANY;
+
+        foreach ($log->getEvents() as $event) {
+            $this->assertNotSame($index, $event->index, 'MultiBindings index must not appear in any event: ' . $event);
+        }
+
+        $this->assertArrayNotHasKey($index, $log->getSources());
+        $this->assertNull($log->getSource($index));
+    }
+
+    /**
+     * The same exclusion holds across a module merge: when sibling modules
+     * each install their own MultiBinder, the MultiBindings binding collides
+     * on the merge and would otherwise surface as a keep event. The keep
+     * event is the noise the #340 fix made invisible by re-pointing the
+     * binding after the merge; the log must not record it in the first place.
+     */
+    public function testMultiBindingsIndexEmitsNoKeepEventOnMerge(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('first')->to(FakeEngine::class);
+                    }
+                });
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('second')->to(FakeEngine2::class);
+                        MultiBinder::newInstance($this, FakeRobotInterface::class)
+                            ->addBinding('robot')->to(FakeRobot::class);
+                    }
+                });
+            }
+        };
+        $log = $module->getContainer()->log;
+        $index = MultiBindings::class . '-' . Name::ANY;
+
+        $keepEvents = array_filter(
+            $log->getEvents(),
+            static fn (BindingEvent $event): bool => $event->type === BindingEvent::KEEP && $event->index === $index
+        );
+        $this->assertSame([], $keepEvents, 'No keep event for the MultiBindings index after merge');
+
+        foreach ($log->getEvents() as $event) {
+            $this->assertNotSame($index, $event->index, 'MultiBindings index must not appear in any event: ' . $event);
+        }
+
+        $this->assertArrayNotHasKey($index, $log->getSources());
     }
 
     private function composeGoldenLog(): BindingLog


### PR DESCRIPTION
## Summary

`BindingLog` documents "Pointcuts and MultiBindings are not logged", but the MultiBindings container *binding* was in fact logged: `MultiBinder` registers it through `Container::add()` (BIND/REPLACE events), and on merge it collides into a KEEP event. `Container::bindMergedMultiBindings()` (added in #340) then re-points that binding with no log event, so the KEEP event names a "winner" that no longer exists and the "N discarded" summary counts a phantom discard.

The half-logged state is the worst of both. Closes #342.

## Change (Option B)

Exclude the MultiBindings index from logging entirely, making the docblock literally true and self-consistent with the entry-level exclusion (store entries already bypass the log):

- `Container::add()`: skip `log->register()` for the MultiBindings index; the binding still registers in the container.
- `Container::merge()`: filter the MultiBindings index out of the colliding indexes so no KEEP event is emitted and its provenance is not adopted.
- A `MULTI_BINDINGS_INDEX` constant is the single source of truth, reused by `bindMergedMultiBindings()`.

The `+=` / `multiBindings->merge()` / `bindMergedMultiBindings()` behaviour is unchanged; only the log is no longer lied to.

## Test

Red contract test first, then the fix:
- a single module with two MultiBinder calls: no event carries the MultiBindings index, and the provenance map has no entry for it;
- two sibling installed modules: no KEEP event for the MultiBindings index after merge.

`ModuleCompositionTest` stays green; no composition contract outcome flips.

## Out of scope

Problem 3 of #342 — a same-key entry collision across modules that nests the entry via `array_merge_recursive` and breaks the Map/Lazy contract — is split into a separate issue (#345).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal infrastructure bindings are no longer exposed in binding logs or provenance records.
  * Prevented unnecessary `KEEP` events for internal bindings during module merges.
* **Tests**
  * Added coverage for initial composition and sibling-module merges to ensure internal binding events remain suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->