### PR TITLE
Keep the first install's entry on a same-key multibinding collision

### DIFF
--- a/src/di/MultiBinding/MultiBindings.php
+++ b/src/di/MultiBinding/MultiBindings.php
@@ -7,7 +7,7 @@ namespace Ray\Di\MultiBinding;
 use ArrayObject;
 use Ray\Di\Types;
 
-use function array_merge_recursive;
+use function is_int;
 
 /**
  * @psalm-import-type LazyBindingList from Types
@@ -15,10 +15,32 @@ use function array_merge_recursive;
  */
 final class MultiBindings extends ArrayObject
 {
+    /**
+     * An existing string key keeps its first entry, matching the += winner of
+     * the container merge; integer-keyed (unnamed) entries append
+     */
     public function merge(self $multiBindings): void
     {
-        $this->exchangeArray(
-            array_merge_recursive($this->getArrayCopy(), $multiBindings->getArrayCopy())
-        );
+        foreach ($multiBindings->getArrayCopy() as $interface => $lazies) {
+            if (! $this->offsetExists($interface)) {
+                $this->offsetSet($interface, $lazies);
+                continue;
+            }
+
+            /** @var LazyBindingList $existing */
+            $existing = $this[$interface];
+            foreach ($lazies as $key => $lazy) {
+                if (is_int($key)) {
+                    $existing[] = $lazy;
+                    continue;
+                }
+
+                if (! isset($existing[$key])) {
+                    $existing[$key] = $lazy;
+                }
+            }
+
+            $this->offsetSet($interface, $existing);
+        }
     }
 }

--- a/src/di/MultiBinding/MultiBindings.php
+++ b/src/di/MultiBinding/MultiBindings.php
@@ -15,32 +15,35 @@ use function is_int;
  */
 final class MultiBindings extends ArrayObject
 {
-    /**
-     * An existing string key keeps its first entry, matching the += winner of
-     * the container merge; integer-keyed (unnamed) entries append
-     */
     public function merge(self $multiBindings): void
     {
         foreach ($multiBindings->getArrayCopy() as $interface => $lazies) {
-            if (! $this->offsetExists($interface)) {
-                $this->offsetSet($interface, $lazies);
+            /** @var LazyBindingList $existing */
+            $existing = $this->offsetExists($interface) ? $this[$interface] : [];
+            $this->offsetSet($interface, $this->mergeEntries($existing, $lazies));
+        }
+    }
+
+    /**
+     * An existing string key keeps its first entry, matching the += winner of
+     * the container merge; integer-keyed (unnamed) entries append
+     *
+     * @param LazyBindingList $existing
+     * @param LazyBindingList $lazies
+     *
+     * @return LazyBindingList
+     */
+    private function mergeEntries(array $existing, array $lazies): array
+    {
+        foreach ($lazies as $key => $lazy) {
+            if (is_int($key)) {
+                $existing[] = $lazy;
                 continue;
             }
 
-            /** @var LazyBindingList $existing */
-            $existing = $this[$interface];
-            foreach ($lazies as $key => $lazy) {
-                if (is_int($key)) {
-                    $existing[] = $lazy;
-                    continue;
-                }
-
-                if (! isset($existing[$key])) {
-                    $existing[$key] = $lazy;
-                }
-            }
-
-            $this->offsetSet($interface, $existing);
+            $existing[$key] ??= $lazy;
         }
+
+        return $existing;
     }
 }

--- a/tests/di/ModuleCompositionTest.php
+++ b/tests/di/ModuleCompositionTest.php
@@ -23,6 +23,8 @@ use function iterator_to_array;
  *   own install()     vs constructor-chained module -> own install()
  *   bind()            vs install() (either order)   -> bind()
  *   first install()   vs second install()           -> first install()
+ *   first install's multibinding entry vs second install's, same Map key
+ *                                                   -> first install's entry
  *   outer chain       vs inner chain                -> outer
  *   override() target vs anything already bound     -> override() target
  *
@@ -378,5 +380,81 @@ class ModuleCompositionTest extends TestCase
             array_keys(iterator_to_array($consumer->engines))
         );
         $this->assertSame(['robot'], array_keys(iterator_to_array($consumer->robots)));
+    }
+
+    /**
+     * A same-key multibinding collision across two installs resolves like an
+     * ordinary binding collision: the first install's entry wins. Without a
+     * decided winner the merge nests both entries into an array and Map
+     * iteration dies invoking it as a callable (#345).
+     */
+    public function testFirstInstallWinsWhenMultiBindingKeysCollideAcrossInstalls(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('shared-key')->to(FakeEngine::class);
+                        MultiBinder::newInstance($this, FakeRobotInterface::class)
+                            ->addBinding('robot')->to(FakeRobot::class);
+                    }
+                });
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('shared-key')->to(FakeEngine2::class);
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding('second-only')->to(FakeEngine3::class);
+                    }
+                });
+            }
+        };
+        $consumer = (new Injector($module))->getInstance(FakeMultiBindingConsumer::class);
+        $engines = iterator_to_array($consumer->engines);
+
+        // colliding key: the first install's entry wins
+        $this->assertInstanceOf(FakeEngine::class, $engines['shared-key']);
+        // non-colliding entries from both installs are kept, in install order
+        $this->assertSame(['shared-key', 'second-only'], array_keys($engines));
+        $this->assertInstanceOf(FakeEngine3::class, $engines['second-only']);
+    }
+
+    /**
+     * Unnamed (integer-keyed) entries cannot collide on a key, so a merge
+     * appends them from both installs in install order.
+     */
+    public function testUnnamedMultiBindingEntriesAppendAcrossInstalls(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding()->to(FakeEngine::class);
+                        MultiBinder::newInstance($this, FakeRobotInterface::class)
+                            ->addBinding('robot')->to(FakeRobot::class);
+                    }
+                });
+                $this->install(new class extends AbstractModule {
+                    protected function configure(): void
+                    {
+                        MultiBinder::newInstance($this, FakeEngineInterface::class)
+                            ->addBinding()->to(FakeEngine2::class);
+                    }
+                });
+            }
+        };
+        $consumer = (new Injector($module))->getInstance(FakeMultiBindingConsumer::class);
+        $engines = iterator_to_array($consumer->engines);
+
+        $this->assertSame([0, 1], array_keys($engines));
+        $this->assertInstanceOf(FakeEngine::class, $engines[0]);
+        $this->assertInstanceOf(FakeEngine2::class, $engines[1]);
     }
 }


### PR DESCRIPTION
## Problem

Closes #345.

When two sibling modules `addBinding()` the same key for the same interface, `MultiBindings::merge()` used `array_merge_recursive`, which nests the two `LazyInterface` values into an array. The merge stays silent and `Map` dies at iteration time invoking the array as a callable:

```
Error: Array callback must have exactly two elements
```

## Approach

Decide the winner instead of nesting, matching the container merge (`+=` / install precedence):

- an existing **string key keeps its first entry** — first install wins, same as ordinary bindings (`testFirstInstallWinsWhenTwoInstallsCollide`)
- **integer-keyed (unnamed) entries append** — they cannot collide on a key; behavior unchanged from `array_merge_recursive`

`merge()` no longer uses `array_merge_recursive`; the entry merge is explicit per interface.

## Tests

Two contract tests in `ModuleCompositionTest` (per the project's "assert the winner" rule), and the composition spec table in the file header gained the multibinding row:

- `testFirstInstallWinsWhenMultiBindingKeysCollideAcrossInstalls` — red before the fix with the exact `Error` from #345, green after; asserts the concrete class at the colliding key and that non-colliding keys from both installs survive in order
- `testUnnamedMultiBindingEntriesAppendAcrossInstalls` — pins that unnamed entries from both installs append (passed before and after)

Full suite: 282 tests, 471 assertions — OK. phpcs / Psalm / PHPStan clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-binding composition so keyed entries preserve the first installed value when keys collide.
  * Ensured unnamed entries are appended consistently in installation order.
  * Preserved existing entries while adding new, non-conflicting bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->