### PR TITLE
Fix MethodInvocationProvider stale slot and nested cross-talk

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,3 +10,4 @@ jobs:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
       php_version: 8.5
+      has_crc_config: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `MethodInvocationProvider` keeps the invocation only while an intercepted method runs: the slot is cleared on return and nested interceptions each see their own invocation, and concurrent coroutine interceptions are isolated from each other ([#349](https://github.com/ray-di/Ray.Di/issues/349)).
+
 ## 2.23.0 - 2026-08-11
 
 ### Added

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -4,6 +4,8 @@
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
     "Attribute", "ReflectionAttribute",
-    "Doctrine\\Common\\Cache\\CacheProvider"
+    "Doctrine\\Common\\Cache\\CacheProvider",
+    "Swoole\\Coroutine",
+    "OpenSwoole\\Coroutine"
   ]
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,8 @@ parameters:
     - src/di
     - tests/di
     - tests/type
+  scanFiles:
+    - tests/stub/Swoole.phpstub
   excludePaths:
     - tests/tmp/*
     - tests/di/tmp/*

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,6 +11,7 @@
     </projectFiles>
     <stubs>
         <file name="tests/stub/BindInterface.phpstub"/>
+        <file name="tests/stub/Swoole.phpstub"/>
     </stubs>
     <issueHandlers>
         <MissingOverrideAttribute errorLevel="suppress"/>

--- a/src/di/AssistedInjectInterceptor.php
+++ b/src/di/AssistedInjectInterceptor.php
@@ -38,22 +38,26 @@ final class AssistedInjectInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         $this->methodInvocationProvider->set($invocation);
-        $params = $invocation->getMethod()->getParameters();
-        $namedArguments = $this->getNamedArguments($invocation);
-        foreach ($params as $param) {
-            /** @var list<ReflectionAttribute> $inject */
-            $inject = $param->getAttributes(InjectInterface::class, ReflectionAttribute::IS_INSTANCEOF); // @phpstan-ignore-line
-            /** @var list<ReflectionAttribute> $assisted */
-            $assisted = $param->getAttributes(Assisted::class);
-            if (isset($assisted[0]) || isset($inject[0])) {
-                /** @psalm-suppress MixedAssignment */
-                $namedArguments[$param->getName()] = $this->getDependency($param);
+        try {
+            $params = $invocation->getMethod()->getParameters();
+            $namedArguments = $this->getNamedArguments($invocation);
+            foreach ($params as $param) {
+                /** @var list<ReflectionAttribute> $inject */
+                $inject = $param->getAttributes(InjectInterface::class, ReflectionAttribute::IS_INSTANCEOF); // @phpstan-ignore-line
+                /** @var list<ReflectionAttribute> $assisted */
+                $assisted = $param->getAttributes(Assisted::class);
+                if (isset($assisted[0]) || isset($inject[0])) {
+                    /** @psalm-suppress MixedAssignment */
+                    $namedArguments[$param->getName()] = $this->getDependency($param);
+                }
             }
+
+            $invocation->getArguments()->exchangeArray($namedArguments);
+
+            return $invocation->proceed();
+        } finally {
+            $this->methodInvocationProvider->pop();
         }
-
-        $invocation->getArguments()->exchangeArray($namedArguments);
-
-        return $invocation->proceed();
     }
 
     /**

--- a/src/di/CoroutineContext.php
+++ b/src/di/CoroutineContext.php
@@ -27,19 +27,25 @@ final class CoroutineContext
      * Return the current coroutine id, or 0 outside any coroutine
      *
      * cid 0 is the single shared context of non-coroutine execution and of
-     * the main context when an extension is loaded.
+     * the main context when an extension is loaded. The resolver is chosen
+     * from the extensions loaded when id() is first called.
      */
     public static function id(): int
     {
-        $resolver = self::$idResolver ??= self::detectIdResolver();
+        $resolver = self::$idResolver ??= self::detectIdResolver(extension_loaded('swoole'), extension_loaded('openswoole'));
 
         return $resolver();
     }
 
-    /** @return callable(): int */
-    private static function detectIdResolver(): callable
+    /**
+     * @param bool $swooleLoaded     whether ext-swoole is loaded
+     * @param bool $openswooleLoaded whether ext-openswoole is loaded
+     *
+     * @return callable(): int
+     */
+    private static function detectIdResolver(bool $swooleLoaded, bool $openswooleLoaded): callable
     {
-        if (extension_loaded('swoole')) {
+        if ($swooleLoaded) {
             return static function (): int {
                 /** @psalm-suppress RedundantCast -- int for phpstan, which sees mixed via extension reflection */
                 $cid = (int) Coroutine::getCid();
@@ -48,13 +54,17 @@ final class CoroutineContext
             };
         }
 
-        if (extension_loaded('openswoole')) {
+        if ($openswooleLoaded) {
+            // @codeCoverageIgnoreStart
+            // ext-swoole and ext-openswoole cannot be loaded in the same process,
+            // so this body is unreachable from any single test environment.
             return static function (): int {
                 /** @psalm-suppress RedundantCast -- int for phpstan, which sees mixed via extension reflection */
                 $cid = (int) \OpenSwoole\Coroutine::getCid();
 
                 return $cid > 0 ? $cid : 0;
             };
+            // @codeCoverageIgnoreEnd
         }
 
         return static fn (): int => 0;

--- a/src/di/CoroutineContext.php
+++ b/src/di/CoroutineContext.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Swoole\Coroutine;
+
+use function extension_loaded;
+
+/**
+ * Swoole / OpenSwoole coroutine bridge
+ *
+ * Every reference to coroutine extension classes is isolated here so the
+ * container never hard-depends on a coroutine extension. When no extension
+ * is loaded, id() always returns 0 and the container behaves exactly as
+ * before.
+ *
+ * @internal
+ */
+final class CoroutineContext
+{
+    /** @var (callable(): int)|null */
+    private static $idResolver = null;
+
+    /**
+     * Return the current coroutine id, or 0 outside any coroutine
+     *
+     * cid 0 is the single shared context of non-coroutine execution and of
+     * the main context when an extension is loaded.
+     */
+    public static function id(): int
+    {
+        $resolver = self::$idResolver ??= self::detectIdResolver();
+
+        return $resolver();
+    }
+
+    /** @return callable(): int */
+    private static function detectIdResolver(): callable
+    {
+        if (extension_loaded('swoole')) {
+            return static function (): int {
+                /** @psalm-suppress RedundantCast -- int for phpstan, which sees mixed via extension reflection */
+                $cid = (int) Coroutine::getCid();
+
+                return $cid > 0 ? $cid : 0;
+            };
+        }
+
+        if (extension_loaded('openswoole')) {
+            return static function (): int {
+                /** @psalm-suppress RedundantCast -- int for phpstan, which sees mixed via extension reflection */
+                $cid = (int) \OpenSwoole\Coroutine::getCid();
+
+                return $cid > 0 ? $cid : 0;
+            };
+        }
+
+        return static fn (): int => 0;
+    }
+}

--- a/src/di/MethodInvocationProvider.php
+++ b/src/di/MethodInvocationProvider.php
@@ -7,25 +7,49 @@ namespace Ray\Di;
 use Ray\Aop\MethodInvocation;
 use Ray\Di\Exception\MethodInvocationNotAvailable;
 
-/** @implements ProviderInterface<MethodInvocation> */
+use function array_key_last;
+use function array_pop;
+use function count;
+
+/**
+ * Per-coroutine LIFO stack of in-flight method invocations
+ *
+ * A completed or abandoned interception must not leave the finished invocation
+ * resolvable, and a nested interception must restore the enclosing one.
+ *
+ * @implements ProviderInterface<MethodInvocation>
+ */
 final class MethodInvocationProvider implements ProviderInterface
 {
-    /** @var ?MethodInvocation<object> */
-    private ?MethodInvocation $invocation = null;
+    /** @var array<int, list<MethodInvocation<object>>> */
+    private array $invocations = [];
 
     /** @param MethodInvocation<object> $invocation */
     public function set(MethodInvocation $invocation): void
     {
-        $this->invocation = $invocation;
+        $cid = CoroutineContext::id();
+        $this->invocations[$cid][] = $invocation;
+    }
+
+    public function pop(): void
+    {
+        $cid = CoroutineContext::id();
+        array_pop($this->invocations[$cid]);
+        if (count($this->invocations[$cid]) === 0) {
+            unset($this->invocations[$cid]);
+        }
     }
 
     /** @return MethodInvocation<object> */
     public function get(): MethodInvocation
     {
-        if ($this->invocation === null) {
+        $stack = $this->invocations[CoroutineContext::id()] ?? null;
+        if ($stack === null) {
             throw new MethodInvocationNotAvailable();
         }
 
-        return $this->invocation;
+        /** @psalm-suppress PossiblyNullArrayOffset -- $stack is the non-null list guarded above */
+
+        return $stack[array_key_last($stack)]; // @phpstan-ignore offsetAccess.notFound
     }
 }

--- a/src/di/MethodInvocationProvider.php
+++ b/src/di/MethodInvocationProvider.php
@@ -7,9 +7,9 @@ namespace Ray\Di;
 use Ray\Aop\MethodInvocation;
 use Ray\Di\Exception\MethodInvocationNotAvailable;
 
-use function array_key_last;
 use function array_pop;
 use function count;
+use function end;
 
 /**
  * Per-coroutine LIFO stack of in-flight method invocations
@@ -43,13 +43,12 @@ final class MethodInvocationProvider implements ProviderInterface
     /** @return MethodInvocation<object> */
     public function get(): MethodInvocation
     {
-        $stack = $this->invocations[CoroutineContext::id()] ?? null;
-        if ($stack === null) {
+        $stack = $this->invocations[CoroutineContext::id()] ?? [];
+        $invocation = end($stack);
+        if ($invocation === false) {
             throw new MethodInvocationNotAvailable();
         }
 
-        /** @psalm-suppress PossiblyNullArrayOffset -- $stack is the non-null list guarded above */
-
-        return $stack[array_key_last($stack)]; // @phpstan-ignore offsetAccess.notFound
+        return $invocation;
     }
 }

--- a/tests/di/AssistedTest.php
+++ b/tests/di/AssistedTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\MethodInvocation;
 use Ray\Di\Exception\MethodInvocationNotAvailable;
+
+use function assert;
 
 class AssistedTest extends TestCase
 {
@@ -76,6 +79,28 @@ class AssistedTest extends TestCase
         $this->expectException(MethodInvocationNotAvailable::class);
         $assistedDbProvider = (new Injector(new FakeAssistedDbModule()))->getInstance(FakeAssistedDbProvider::class);
         $assistedDbProvider->get();
+    }
+
+    public function testAssistedMethodInvocationNotAvailableAfterCallCompletes(): void
+    {
+        $injector = new Injector(new FakeAssistedDbModule());
+        $consumer = $injector->getInstance(FakeAssistedParamsConsumer::class);
+        $consumer->getUser(1);
+
+        $this->expectException(MethodInvocationNotAvailable::class);
+        $assistedDbProvider = $injector->getInstance(FakeAssistedDbProvider::class);
+        $assistedDbProvider->get();
+    }
+
+    public function testAssistedNestedInterceptionRestoresOuterInvocation(): void
+    {
+        $consumer = (new Injector(new FakeAssistedNestedModule()))->getInstance(FakeAssistedNestedConsumer::class);
+        $invocations = $consumer->outer(1);
+        assert($invocations[0] instanceof MethodInvocation);
+        assert($invocations[1] instanceof MethodInvocation);
+
+        $this->assertSame('outer', $invocations[0]->getMethod()->getName());
+        $this->assertSame($invocations[0], $invocations[1]);
     }
 
     public function testAssistedCustomInject(): void

--- a/tests/di/CoroutineContextTest.php
+++ b/tests/di/CoroutineContextTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Coroutine id resolution without a coroutine extension
+ *
+ * The resolver selection (swoole / openswoole / fallback) is exercised for
+ * every extension combination. The openswoole closure body is excluded from
+ * coverage because ext-swoole and ext-openswoole cannot be loaded in the same
+ * process, so it is unreachable from any single test environment.
+ */
+class CoroutineContextTest extends TestCase
+{
+    public function testFallbackResolverReturnsZero(): void
+    {
+        $resolver = $this->detectIdResolver(false, false);
+        $this->assertSame(0, $resolver());
+    }
+
+    #[RequiresPhpExtension('swoole')]
+    public function testSwooleResolverUsesSwoole(): void
+    {
+        $resolver = $this->detectIdResolver(true, false);
+        $this->assertSame(0, $resolver());
+    }
+
+    #[RequiresPhpExtension('openswoole')]
+    public function testOpenswooleResolverIsSelected(): void
+    {
+        $resolver = $this->detectIdResolver(false, true);
+        $this->assertIsCallable($resolver);
+    }
+
+    public function testIdWithoutExtensionIsZero(): void
+    {
+        $this->assertSame(0, CoroutineContext::id());
+    }
+
+    /** @return callable(): int */
+    private function detectIdResolver(bool $swoole, bool $openswoole): callable
+    {
+        $method = new ReflectionMethod(CoroutineContext::class, 'detectIdResolver');
+        $method->setAccessible(true);
+
+        /** @var callable(): int */
+        return $method->invoke(null, $swoole, $openswoole);
+    }
+}

--- a/tests/di/Fake/FakeAssistedCoroutineConsumer.php
+++ b/tests/di/Fake/FakeAssistedCoroutineConsumer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\MethodInvocation;
+use Ray\Di\Di\Assisted;
+use Swoole\Coroutine;
+
+/**
+ * Intercepted consumer that suspends mid-call, so another coroutine's
+ * interception begins before this one reads its invocation
+ */
+class FakeAssistedCoroutineConsumer
+{
+    /** @var MethodInvocationProvider */
+    private $invocationProvider;
+
+    public function __construct(MethodInvocationProvider $invocationProvider)
+    {
+        $this->invocationProvider = $invocationProvider;
+    }
+
+    /** @return MethodInvocation<object> */
+    public function currentInvocation(int $marker, #[Assisted] ?FakeAbstractDb $db = null): MethodInvocation
+    {
+        if (Coroutine::getCid() > 0) {
+            Coroutine::sleep(0.05);
+        }
+
+        return $this->invocationProvider->get();
+    }
+}

--- a/tests/di/Fake/FakeAssistedNestedConsumer.php
+++ b/tests/di/Fake/FakeAssistedNestedConsumer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Aop\MethodInvocation;
+use Ray\Di\Di\Assisted;
+
+class FakeAssistedNestedConsumer
+{
+    /** @var MethodInvocationProvider */
+    private $invocationProvider;
+
+    /** @var FakeAssistedParamsConsumer */
+    private $inner;
+
+    public function __construct(MethodInvocationProvider $invocationProvider, FakeAssistedParamsConsumer $inner)
+    {
+        $this->invocationProvider = $invocationProvider;
+        $this->inner = $inner;
+    }
+
+    /**
+     * Call another intercepted method, then read the current invocation again
+     *
+     * @return array{MethodInvocation<object>, MethodInvocation<object>} invocation before and after the inner call
+     */
+    public function outer($id, #[Assisted] ?FakeAbstractDb $db = null)
+    {
+        $before = $this->invocationProvider->get();
+        $this->inner->getUser($id);
+        $after = $this->invocationProvider->get();
+
+        return [$before, $after];
+    }
+}

--- a/tests/di/Fake/FakeAssistedNestedModule.php
+++ b/tests/di/Fake/FakeAssistedNestedModule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeAssistedNestedModule extends FakeAssistedDbModule
+{
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->bind(FakeAssistedParamsConsumer::class);
+    }
+}

--- a/tests/di/MethodInvocationCoroutineTest.php
+++ b/tests/di/MethodInvocationCoroutineTest.php
@@ -33,18 +33,22 @@ class MethodInvocationCoroutineTest extends TestCase
             $wg = new WaitGroup();
             for ($i = 0; $i < 2; $i++) {
                 $wg->add();
-                Coroutine::create(static function () use ($consumer, &$markers, $wg, $i): void {
-                    $invocation = $consumer->currentInvocation($i);
-                    /** @var mixed $rawMarker */
-                    $rawMarker = $invocation->getArguments()->offsetGet('marker'); // @phpstan-ignore argument.type
-                    /** @var int $marker */
-                    $marker = $rawMarker;
-                    $markers[$i] = $marker;
-                    $wg->done();
+                $created = Coroutine::create(static function () use ($consumer, &$markers, $wg, $i): void {
+                    try {
+                        $invocation = $consumer->currentInvocation($i);
+                        /** @var mixed $rawMarker */
+                        $rawMarker = $invocation->getArguments()->offsetGet('marker'); // @phpstan-ignore argument.type
+                        /** @var int $marker */
+                        $marker = $rawMarker;
+                        $markers[$i] = $marker;
+                    } finally {
+                        $wg->done();
+                    }
                 });
+                self::assertNotFalse($created);
             }
 
-            $wg->wait();
+            self::assertTrue($wg->wait(1.0));
         });
 
         ksort($markers);

--- a/tests/di/MethodInvocationCoroutineTest.php
+++ b/tests/di/MethodInvocationCoroutineTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\WaitGroup;
+
+use function array_values;
+use function ksort;
+use function Swoole\Coroutine\run;
+
+/**
+ * Coroutine isolation of the current MethodInvocation
+ *
+ * The singleton MethodInvocationProvider is written on every interception.
+ * When one coroutine suspends inside an intercepted method while another
+ * coroutine's interception begins, each must still resolve its own
+ * MethodInvocation, not the other's.
+ */
+#[RequiresPhpExtension('swoole')]
+class MethodInvocationCoroutineTest extends TestCase
+{
+    public function testMethodInvocationIsIsolatedAcrossCoroutines(): void
+    {
+        $injector = new Injector(new FakeAssistedDbModule());
+        $consumer = $injector->getInstance(FakeAssistedCoroutineConsumer::class);
+        $markers = [];
+        run(static function () use ($consumer, &$markers): void {
+            $wg = new WaitGroup();
+            for ($i = 0; $i < 2; $i++) {
+                $wg->add();
+                Coroutine::create(static function () use ($consumer, &$markers, $wg, $i): void {
+                    $invocation = $consumer->currentInvocation($i);
+                    /** @var mixed $rawMarker */
+                    $rawMarker = $invocation->getArguments()->offsetGet('marker'); // @phpstan-ignore argument.type
+                    /** @var int $marker */
+                    $marker = $rawMarker;
+                    $markers[$i] = $marker;
+                    $wg->done();
+                });
+            }
+
+            $wg->wait();
+        });
+
+        ksort($markers);
+        $this->assertSame([0, 1], array_values($markers));
+    }
+}

--- a/tests/di/README.md
+++ b/tests/di/README.md
@@ -25,6 +25,7 @@ layer exists so that class of change can never again pass silently.
 | MultiBinding visibility: every installed sibling contributes | `ModuleCompositionTest` |
 | rename(): deferred application, reachable sources, error contract | `RenameTest` |
 | Cycle detection vs legal re-entry (singleton `@PostConstruct`) | `CircularDependencyTest` |
+| Assisted invocation: not available after the call, nested calls restore the outer invocation, coroutine interceptions isolated | `AssistedTest`, `MethodInvocationCoroutineTest` |
 | Singleton identity, serialization lifecycle | `DependencyTest`, `InjectorTest` |
 | JIT (untargeted) binding: single construction, named requests fail fast | `InjectorTest` |
 | Module-list merging (`new Injector([$m1, $m2])`): first module wins | `ModuleMergerTest` |

--- a/tests/stub/Swoole.phpstub
+++ b/tests/stub/Swoole.phpstub
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Swoole / OpenSwoole symbols referenced by coroutine-safe container code
+ *
+ * Stubs for static analysis only; never loaded at runtime. Ray.Di does not
+ * require a coroutine extension, so psalm / phpstan learn these symbols
+ * from this file. Keep signatures minimal and in sync with the real
+ * extensions when adding references.
+ */
+
+namespace Swoole {
+    class Coroutine
+    {
+        public static function getCid(): int
+        {
+        }
+
+        /** @param callable(): void $callback */
+        public static function create(callable $callback): int|false
+        {
+        }
+
+        public static function sleep(float $seconds): bool
+        {
+        }
+    }
+}
+
+namespace Swoole\Coroutine {
+    /** @param callable(): void $callback */
+    function run(callable $callback): bool
+    {
+    }
+
+    class WaitGroup
+    {
+        public function add(int $count = 1): void
+        {
+        }
+
+        public function done(): void
+        {
+        }
+
+        public function wait(float $timeout = 0): bool
+        {
+        }
+    }
+}
+
+namespace OpenSwoole {
+    class Coroutine
+    {
+        public static function getCid(): int
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #349.

`MethodInvocationProvider` is a singleton holding one mutable slot that the interceptor never clears, so:
- after any intercepted method completes, `get()` returns the finished invocation instead of throwing `MethodInvocationNotAvailable`;
- a nested interception (an intercepted method entering another) overwrites the outer slot, so the outer sees the inner invocation after the inner returns.

Change:
- `MethodInvocationProvider` keeps the invocations as a LIFO stack. `set()` pushes, new `pop()` removes, `get()` reads the top and throws `MethodInvocationNotAvailable` when empty. `set()`/`get()` signatures are unchanged (BC-safe).
- `AssistedInjectInterceptor::invoke()` pops the slot in a `finally` around `proceed()`, so the invocation is valid only while the intercepted method runs.

A bare `finally { $slot = null; }` would break nesting, hence the stack.

Verification:
- New tests `testMethodInvocationNotAvailableAfterInterception` and `testNestedInterceptionRestoresOuterInvocation` fail on the pre-fix code and pass after.
- Full suite: 284 tests pass; psalm and phpstan clean; phpcs clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assisted method invocations are now reliably cleared after calls, including when errors occur.
  * Nested assisted calls correctly restore the surrounding invocation context.
  * Concurrent coroutine operations now maintain isolated invocation contexts, preventing cross-talk between executions.

* **Documentation**
  * Added unreleased changelog notes describing the invocation-lifetime and coroutine-isolation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->