### PR TITLE
Deprecate just-in-time binding of unbound concrete classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecated
+
+- Just-in-time binding of an unbound concrete class from `getInstance()` now emits an `E_USER_DEPRECATED` notice. Bind the class explicitly; JIT resolution is unavailable under `CompiledInjector` and is not recorded in `bindings.md` ([#337](https://github.com/ray-di/Ray.Di/issues/337)).
+
 ## 2.23.1 - 2026-08-30
 
 ### Fixed

--- a/demo/07-assisted-injection.php
+++ b/demo/07-assisted-injection.php
@@ -14,6 +14,7 @@ $injector = new Injector(new class extends AbstractModule{
     protected function configure()
     {
         $this->bind(FinderInterface::class)->to(Finder::class);
+        $this->bind(MovieFinder::class);
     }
 });
 $finder = $injector->getInstance(MovieFinder::class);

--- a/src/di/Injector.php
+++ b/src/di/Injector.php
@@ -17,6 +17,7 @@ use function spl_autoload_register;
 use function sprintf;
 use function str_replace;
 use function sys_get_temp_dir;
+use function trigger_error;
 
 /**
  * @psalm-import-type BindableInterface from Types
@@ -81,6 +82,14 @@ final class Injector implements InjectorInterface
             if ($name !== Name::ANY) {
                 throw new Unbound(sprintf("'%s-%s'", $interface, $name), 0, $untargeted);
             }
+
+            trigger_error(
+                sprintf(
+                    'Just-in-time binding of unbound concrete class "%s" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+                    $interface,
+                ),
+                E_USER_DEPRECATED,
+            );
 
             /**
              * @psalm-var class-string $interface

--- a/src/di/Injector.php
+++ b/src/di/Injector.php
@@ -19,6 +19,8 @@ use function str_replace;
 use function sys_get_temp_dir;
 use function trigger_error;
 
+use const E_USER_DEPRECATED;
+
 /**
  * @psalm-import-type BindableInterface from Types
  * @psalm-import-type ModuleList from Types

--- a/tests-php8/AssistedInjectTest.php
+++ b/tests-php8/AssistedInjectTest.php
@@ -14,7 +14,12 @@ class AssistedInjectTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->injector = new Injector(new FakeToBindModule(), __DIR__ . '/tmp');
+        $this->injector = new Injector(new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeAssistedInjectConsumer::class);
+            }
+        }, __DIR__ . '/tmp');
     }
 
     public function testAssisted(): void
@@ -74,6 +79,7 @@ class AssistedInjectTest extends TestCase
             {
                 protected function configure()
                 {
+                    $this->bind(FakePropConstruct::class);
                     $this->bind()->annotatedWith('abc')->toInstance('abc');
                 }
             }

--- a/tests/di/AssistedTest.php
+++ b/tests/di/AssistedTest.php
@@ -17,7 +17,12 @@ class AssistedTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->injector = new Injector(new FakeToBindModule());
+        $this->injector = new Injector(new class (new FakeToBindModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeAssistedConsumer::class);
+            }
+        });
     }
 
     public function testAssisted(): void

--- a/tests/di/BindingLogTest.php
+++ b/tests/di/BindingLogTest.php
@@ -219,6 +219,9 @@ LOG;
     {
         $injector = unserialize(serialize(new Injector(null, __DIR__ . '/tmp')));
         assert($injector instanceof Injector);
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeEngine::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector->getInstance(FakeEngine::class); // JIT binding after wakeup
 
         $container = (new ReflectionProperty(Injector::class, 'container'))->getValue($injector);

--- a/tests/di/CircularDependencyTest.php
+++ b/tests/di/CircularDependencyTest.php
@@ -73,6 +73,7 @@ class CircularDependencyTest extends TestCase
             protected function configure(): void
             {
                 $this->bind(FakeDiamondSharedInterface::class)->to(FakeDiamondShared::class);
+                $this->bind(FakeDiamondRoot::class);
             }
         });
 

--- a/tests/di/Fake/FakeAnnoModule.php
+++ b/tests/di/Fake/FakeAnnoModule.php
@@ -8,6 +8,7 @@ class FakeAnnoModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeAnnoOrderClass::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(FakeAnnoMethod1::class),

--- a/tests/di/Fake/FakeAssistedDbModule.php
+++ b/tests/di/Fake/FakeAssistedDbModule.php
@@ -9,5 +9,8 @@ class FakeAssistedDbModule extends AbstractModule
     protected function configure()
     {
         $this->bind(FakeAbstractDb::class)->toProvider(FakeAssistedDbProvider::class);
+        $this->bind(FakeAssistedParamsConsumer::class);
+        $this->bind(FakeAssistedDbProvider::class);
+        $this->bind(FakeAssistedInjectDb::class);
     }
 }

--- a/tests/di/Fake/FakeBcParameterQualifierModule.php
+++ b/tests/di/Fake/FakeBcParameterQualifierModule.php
@@ -10,6 +10,7 @@ class FakeBcParameterQualifierModule extends AbstractModule
 {
     protected function configure(): void
     {
+        $this->bind(FakeClassWithBcParameterQualifier::class);
         // Bind with FakeInjectOne qualifier
         $this->bind(FakeGearStickInterface::class)
             ->annotatedWith(FakeInjectOne::class)

--- a/tests/di/Fake/FakeConstantModule.php
+++ b/tests/di/Fake/FakeConstantModule.php
@@ -8,6 +8,7 @@ class FakeConstantModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeConstantConsumer::class);
         $this->bind()->annotatedWith(FakeConstant::class)->toInstance('kuma');
     }
 }

--- a/tests/di/Fake/FakeInstanceBindModule.php
+++ b/tests/di/Fake/FakeInstanceBindModule.php
@@ -12,5 +12,7 @@ class FakeInstanceBindModule extends AbstractModule
     {
         $this->bind('')->annotatedWith('one')->toInstance(1);
         $this->bind('')->annotatedWith(FakeInjectOne::class)->toInstance(1);
+        $this->bind(FakeAssistedConsumer::class);
+        $this->bind(FakeAssistedInjectConsumer::class);
     }
 }

--- a/tests/di/Fake/FakeInternalTypeModule.php
+++ b/tests/di/Fake/FakeInternalTypeModule.php
@@ -12,6 +12,7 @@ class FakeInternalTypeModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeInternalTypes::class);
         $this->bind('')->annotatedWith('type-bool')->toInstance(false);
         $this->bind('')->annotatedWith('type-int')->toInstance(1);
         $this->bind('')->annotatedWith('type-string')->toInstance('1');

--- a/tests/di/Fake/FakeJitDepConcrete.php
+++ b/tests/di/Fake/FakeJitDepConcrete.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * An unbound concrete class used as a constructor dependency in
+ * FakeJitDepConsumer. It is never just-in-time bound (only top-level
+ * getInstance() performs JIT), so it always surfaces as Unbound.
+ */
+class FakeJitDepConcrete
+{
+}

--- a/tests/di/Fake/FakeJitDepConsumer.php
+++ b/tests/di/Fake/FakeJitDepConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * An implementation of FakeJitDepInterface that depends on an unbound
+ * FakeJitDepConcrete.
+ */
+class FakeJitDepConsumer implements FakeJitDepInterface
+{
+    public function __construct(public FakeJitDepConcrete $dependency)
+    {
+    }
+}

--- a/tests/di/Fake/FakeJitDepInterface.php
+++ b/tests/di/Fake/FakeJitDepInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * A minimal interface for the JIT deprecation contract test: its
+ * implementation depends on an unbound concrete class, so resolving the
+ * interface top-level surfaces the interior dependency as Unbound without
+ * emitting a just-in-time deprecation notice.
+ */
+interface FakeJitDepInterface
+{
+}

--- a/tests/di/Fake/FakeMultiInterceptorModule.php
+++ b/tests/di/Fake/FakeMultiInterceptorModule.php
@@ -8,6 +8,7 @@ class FakeMultiInterceptorModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeAop::class);
         // two interceptors bound in a SINGLE bindInterceptor() call
         $this->bindInterceptor(
             $this->matcher->any(),

--- a/tests/di/Fake/FakePhp8CarModule.php
+++ b/tests/di/Fake/FakePhp8CarModule.php
@@ -12,6 +12,7 @@ class FakePhp8CarModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakePhp8Car::class);
         $this->bind(FakeCarInterface::class)->to(FakePhp8Car::class); // dependent
         $this->bind(FakeEngineInterface::class)->to(FakeEngine::class); // constructor
         $this->bind(FakeTyreInterface::class)->to(FakeTyre::class); // setter

--- a/tests/di/Fake/FakeWalkRobotModule.php
+++ b/tests/di/Fake/FakeWalkRobotModule.php
@@ -8,6 +8,7 @@ class FakeWalkRobotModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeWalkRobot::class);
         $this->bind(FakeLegInterface::class)->toProvider(FakeWalkRobotLegProvider::class);
     }
 }

--- a/tests/di/Fake/FakeWalkRobotOtherDepModule.php
+++ b/tests/di/Fake/FakeWalkRobotOtherDepModule.php
@@ -8,6 +8,7 @@ class FakeWalkRobotOtherDepModule extends AbstractModule
 {
     protected function configure()
     {
+        $this->bind(FakeWalkRobot::class);
         $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
         $this->bind(FakeLegInterface::class)->toProvider(FakeWalkRobotLegProviderWithOtherDep::class);
     }

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -48,9 +48,14 @@ class InjectorTest extends TestCase
      * An unbound concrete class is auto-registered as an untargeted binding:
      * getInstance() catches Untargeted, binds the class on the fly, then
      * resolves it. Removing that self-bind makes the retry recurse endlessly.
+     * JIT resolution is deprecated; the notice steers toward an explicit
+     * binding, which is what CompiledInjector requires.
      */
     public function testGetUnboundConcreteClassIsAutoBound(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeEngine::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector = new Injector(new FakeInstanceBindModule());
         $instance = $injector->getInstance(FakeEngine::class);
         $this->assertInstanceOf(FakeEngine::class, $instance);
@@ -71,6 +76,9 @@ class InjectorTest extends TestCase
 
     public function testUnboundConcreteClassIsConstructedOnlyOnce(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeConstructCounter::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         FakeConstructCounter::$constructCount = 0;
         $injector = new Injector(new FakeInstanceBindModule());
         $instance = $injector->getInstance(FakeConstructCounter::class);
@@ -193,6 +201,9 @@ class InjectorTest extends TestCase
 
     public function testGetConcreteClass(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeRobot::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector = new Injector();
         $robot = $injector->getInstance(FakeRobot::class);
         $this->assertInstanceOf(FakeRobot::class, $robot);
@@ -200,6 +211,9 @@ class InjectorTest extends TestCase
 
     public function testGetConcreteHavingDependency(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeRobotTeam::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector = new Injector(new class extends AbstractModule{
             protected function configure()
             {
@@ -214,6 +228,9 @@ class InjectorTest extends TestCase
 
     public function testGetConcreteClassWithModule(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeCar::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector = new Injector(new FakeCarModule());
         $car = $injector->getInstance(FakeCar::class);
         $this->assertInstanceOf(FakeCar::class, $car);
@@ -340,6 +357,9 @@ class InjectorTest extends TestCase
 
     public function testAopOnDemandByUnboundConcreteClass(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeAop::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $injector = new Injector(new FakeAopInterceptorModule());
         $instance = $injector->getInstance(FakeAop::class);
         $result = $instance->returnSame(2);
@@ -402,6 +422,9 @@ class InjectorTest extends TestCase
 
     public function testNewAbstract(): void
     {
+        $this->expectUserDeprecationMessage(
+            'Just-in-time binding of unbound concrete class "' . FakeConcreteClass::class . '" is deprecated. Bind it explicitly: JIT resolution is unavailable under CompiledInjector and is not recorded in bindings.md.',
+        );
         $this->expectException(Unbound::class);
         (new Injector())->getInstance(FakeConcreteClass::class);
     }

--- a/tests/di/InjectorTest.php
+++ b/tests/di/InjectorTest.php
@@ -295,13 +295,24 @@ class InjectorTest extends TestCase
 
     public function testBuiltinBinding(): void
     {
-        $instance = (new Injector())->getInstance(FakeBuiltin::class);
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeBuiltin::class);
+            }
+        });
+        $instance = $injector->getInstance(FakeBuiltin::class);
         $this->assertInstanceOf(Injector::class, $instance->injector);
     }
 
     public function testSerializeBuiltinBinding(): void
     {
-        $injector = unserialize(serialize(new Injector()));
+        $injector = unserialize(serialize(new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeBuiltin::class);
+            }
+        })));
         assert($injector instanceof InjectorInterface);
         $instance = $injector->getInstance(FakeBuiltin::class);
         $this->assertInstanceOf(Injector::class, $instance->injector);
@@ -566,6 +577,7 @@ class InjectorTest extends TestCase
             protected function configure()
             {
                 $this->bind(FakeEngineInterface::class)->to(FakeEngine::class);
+                $this->bind(FakeSet::class);
             }
         });
         $fakeSet = $injector->getInstance(FakeSet::class);

--- a/tests/di/JitBindingDeprecationTest.php
+++ b/tests/di/JitBindingDeprecationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\Unbound;
+
+use function array_slice;
+use function count;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Just-in-time binding of an unbound concrete class is deprecated (ray-di/Ray.Di#337).
+ *
+ * The deprecation notice must be emitted exactly once, and only for a top-level
+ * unnamed request of an instantiable concrete class:
+ *
+ * - internal (constructor) dependency            -> Unbound, no notice
+ * - top-level getInstance(Concrete::class)       -> resolves, one E_USER_DEPRECATED
+ * - named request getInstance(Concrete, 'name')  -> Unbound, no notice
+ * - non-instantiable type                        -> Unbound, no notice
+ */
+class JitBindingDeprecationTest extends TestCase
+{
+    /** @var list<string> */
+    private array $notices = [];
+
+    protected function setUp(): void
+    {
+        $this->notices = [];
+        set_error_handler(
+            function (int $severity, string $message): bool {
+                $this->notices[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    /** @return list<string> E_USER_DEPRECATED messages observed during $callback */
+    private function captureNotice(callable $callback): array
+    {
+        $before = count($this->notices);
+        $callback();
+
+        return array_slice($this->notices, $before);
+    }
+
+    public function testTopLevelUnboundConcreteResolvesAndEmitsDeprecation(): void
+    {
+        $notices = $this->captureNotice(
+            static fn () => (new Injector())->getInstance(FakeConstructCounter::class),
+        );
+
+        self::assertCount(1, $notices);
+        self::assertStringContainsString(
+            'Just-in-time binding of unbound concrete class "' . FakeConstructCounter::class . '" is deprecated',
+            $notices[0],
+        );
+    }
+
+    public function testInternalUnboundConcreteDependencyIsUnboundWithoutNotice(): void
+    {
+        // FakeJitDepConsumer implements FakeJitDepInterface but depends on an
+        // unbound FakeJitDepConcrete. Resolving the bound interface top-level
+        // never triggers JIT; the unbound interior dep surfaces as Unbound.
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeJitDepInterface::class)->to(FakeJitDepConsumer::class);
+            }
+        });
+
+        $notices = $this->captureNotice(
+            static function () use ($injector): void {
+                try {
+                    $injector->getInstance(FakeJitDepInterface::class);
+                    self::fail('An internal unbound dependency must remain Unbound.');
+                } catch (Unbound) {
+                }
+            },
+        );
+
+        self::assertSame([], $notices);
+    }
+
+    public function testNamedRequestIsUnboundWithoutNotice(): void
+    {
+        $injector = new Injector();
+
+        $notices = $this->captureNotice(
+            static function () use ($injector): void {
+                try {
+                    $injector->getInstance(FakeConstructCounter::class, 'no-such-name');
+                    self::fail('A named request must remain Unbound.');
+                } catch (Unbound) {
+                }
+            },
+        );
+
+        self::assertSame([], $notices);
+    }
+
+    public function testNonInstantiableInterfaceIsUnboundWithoutNotice(): void
+    {
+        $injector = new Injector();
+
+        $notices = $this->captureNotice(
+            static function () use ($injector): void {
+                try {
+                    $injector->getInstance(FakeEngineInterface::class);
+                    self::fail('An interface must remain Unbound.');
+                } catch (Unbound) {
+                }
+            },
+        );
+
+        self::assertSame([], $notices);
+    }
+
+    public function testNonInstantiableAbstractIsUnboundWithoutNotice(): void
+    {
+        $injector = new Injector();
+
+        $notices = $this->captureNotice(
+            static function () use ($injector): void {
+                try {
+                    $injector->getInstance(FakeAbstractClass::class);
+                    self::fail('An abstract class must remain Unbound.');
+                } catch (Unbound) {
+                }
+            },
+        );
+
+        self::assertSame([], $notices);
+    }
+}

--- a/tests/di/ModuleCompositionTest.php
+++ b/tests/di/ModuleCompositionTest.php
@@ -326,6 +326,10 @@ class ModuleCompositionTest extends TestCase
         $module = new class ($chained) extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeEngine2::class);
+                $this->bind(FakeEngine3::class);
                 MultiBinder::newInstance($this, FakeEngineInterface::class)
                     ->addBinding('own')->to(FakeEngine3::class);
                 MultiBinder::newInstance($this, FakeRobotInterface::class)
@@ -355,6 +359,10 @@ class ModuleCompositionTest extends TestCase
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeEngine2::class);
+                $this->bind(FakeRobot::class);
                 $this->install(new class extends AbstractModule {
                     protected function configure(): void
                     {
@@ -393,6 +401,10 @@ class ModuleCompositionTest extends TestCase
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeEngine2::class);
+                $this->bind(FakeEngine3::class);
                 $this->install(new class extends AbstractModule {
                     protected function configure(): void
                     {
@@ -432,6 +444,9 @@ class ModuleCompositionTest extends TestCase
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeEngine2::class);
                 $this->install(new class extends AbstractModule {
                     protected function configure(): void
                     {

--- a/tests/di/MultiBinding/MultiBindingModuleTest.php
+++ b/tests/di/MultiBinding/MultiBindingModuleTest.php
@@ -40,6 +40,14 @@ class MultiBindingModuleTest extends TestCase
         $this->module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(FakeMultiBindingAnnotation::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeEngine2::class);
+                $this->bind(FakeEngine3::class);
+                $this->bind(FakeRobot::class);
+                $this->bind(FakeRobotProvider::class);
+                $this->bind(FakeSetNotFoundWithMap::class);
                 $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
                 $engineBinder->addBinding('one')->to(FakeEngine::class);
                 $engineBinder->addBinding('two')->to(FakeEngine2::class);
@@ -206,7 +214,12 @@ class MultiBindingModuleTest extends TestCase
     public function testSetNotFoundInProvider(): void
     {
         $this->expectException(SetNotFound::class);
-        $injector = new Injector();
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeSetNotFoundWithProvider::class);
+            }
+        });
         $injector->getInstance(FakeSetNotFoundWithProvider::class);
     }
 
@@ -220,6 +233,7 @@ class MultiBindingModuleTest extends TestCase
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
                 MultiBinder::newInstance($this, FakeEngineInterface::class);
                 MultiBinder::newInstance($this, FakeRobotInterface::class);
             }
@@ -240,7 +254,12 @@ class MultiBindingModuleTest extends TestCase
      */
     public function testSetNotBound(): void
     {
-        $injector = new Injector(new NullModule());
+        $injector = new Injector(new class (new NullModule()) extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeMultiBindingConsumer::class);
+            }
+        });
         try {
             $injector->getInstance(FakeMultiBindingConsumer::class);
             self::fail('SetNotBound must be thrown when no MultiBinder declared the #[Set] interface.');
@@ -265,6 +284,7 @@ class MultiBindingModuleTest extends TestCase
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
+                $this->bind(FakeMultiBindingConsumer::class);
                 MultiBinder::newInstance($this, FakeRobotInterface::class)->addBinding('robot')->to(FakeRobot::class);
                 $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
                 $engineBinder->addBinding('one')->to(FakeEngine::class);


### PR DESCRIPTION
Fixes [#337](https://github.com/ray-di/Ray.Di/issues/337).

## Change

When an *unbound concrete class* is resolved through a **top-level** `getInstance(Concrete::class)`, the injector still resolves it on the fly (JIT binding) but now emits an `E_USER_DEPRECATED` notice steering toward an explicit binding. Resolution is unchanged — the class is still bound and returned.

| Case | Before | After |
| --- | --- | --- |
| Internal (constructor) dependency | `Unbound` | `Unbound` (unchanged) |
| Top-level `getInstance(Concrete::class)` | resolves silently | resolves + `E_USER_DEPRECATED` |
| Named `getInstance(Concrete, 'name')` | `Unbound` | `Unbound` (unchanged) |
| Non-instantiable type | `Unbound` | `Unbound` (unchanged) |

The notice fires only for the top-level unnamed instantiable-concrete path. JIT resolution is unavailable under `CompiledInjector` (ray/compiler) and is absent from the composition-time `bindings.md` snapshot, so the notice surfaces a dependency that would otherwise only break at compile time.

## Why deprecate, not remove

See the issue. Ray.Di has no planned v3, so a minor removal would break `getInstance(Concrete::class)` with no escape hatch; deprecation steers toward explicit bindings without breaking change.

## Verification

- New `tests/di/JitBindingDeprecationTest.php` asserts the four-row contract, including that the no-notice paths emit zero `E_USER_DEPRECATED`.
- Existing JIT-dependent tests updated: either assert the expected notice or bind the class explicitly.
- `composer tests` (phpcs + psalm + phpstan + phpunit) green; `Injector` 100% line coverage.
- `demo/07-assisted-injection.php` runs clean with the explicit binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Just-in-time binding of unbound concrete classes now emits a deprecation notice.
  * JIT resolution is unavailable with compiled injectors and is not included in binding documentation.
* **Documentation**
  * Added changelog entries describing the JIT binding deprecation and its limitations.
* **Bug Fixes**
  * Updated dependency-injection configurations to explicitly register required concrete classes, improving predictable resolution.
* **Tests**
  * Added coverage for deprecation notices and confirmed expected behavior for interfaces, named requests, and nested dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->