### PR TITLE
Make dependency resolution coroutine-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `Container` tracks in-progress resolution per coroutine, so a coroutine suspending inside a provider no longer makes another coroutine's resolution of the same index look like a `CircularDependency`.
+- Concurrent construction of an unbuilt singleton across coroutines throws `ConcurrentSingletonConstruction` instead of silently building duplicates; warm up singletons before serving requests.
+
 ## 2.23.1 - 2026-08-30
 
 ### Fixed

--- a/src/di/Container.php
+++ b/src/di/Container.php
@@ -9,6 +9,7 @@ use Ray\Aop\Compiler;
 use Ray\Aop\CompilerInterface;
 use Ray\Aop\Pointcut;
 use Ray\Di\Exception\CircularDependency;
+use Ray\Di\Exception\ConcurrentSingletonConstruction;
 use Ray\Di\Exception\NoHint;
 use Ray\Di\Exception\RenameTargetAlreadyBound;
 use Ray\Di\Exception\Unbound;
@@ -42,6 +43,8 @@ final class Container implements InjectorInterface
      */
     private const MULTI_BINDINGS_INDEX = MultiBindings::class . '-' . Name::ANY;
 
+    private const INJECTION_POINT_INDEX = InjectionPointInterface::class . '-' . Name::ANY;
+
     /** @var MultiBindings */
     public $multiBindings;
 
@@ -52,13 +55,39 @@ final class Container implements InjectorInterface
     private array $pointcuts = [];
 
     /**
-     * Dependency indexes currently being resolved, used to detect circular dependencies
+     * Dependency indexes currently being resolved, keyed by coroutine id
+     * (0 when outside a coroutine), used to detect circular dependencies
      *
+     * Per-coroutine so that a coroutine suspending mid-resolution does not
+     * make another coroutine resolve the same index look like a cycle.
      * Not serialized: resolution state is always empty between getInstance() calls.
+     *
+     * @var array<int, array<string, true>>
+     */
+    private array $resolving = [];
+
+    /**
+     * Singleton indexes currently under construction, set only inside
+     * coroutines; a second coroutine finding its index here throws
+     * ConcurrentSingletonConstruction instead of building a duplicate
+     *
+     * Not serialized (see $resolving).
      *
      * @var array<string, true>
      */
-    private array $resolving = [];
+    private array $constructing = [];
+
+    /**
+     * Per-coroutine injection point overlay, keyed by coroutine id
+     *
+     * Outside coroutines the injection point lives in the container entry as
+     * before; inside coroutines it is kept per coroutine so that a coroutine
+     * suspending mid-resolution cannot observe another coroutine's point.
+     * Not serialized (see $resolving).
+     *
+     * @var array<int, InjectionPointInterface>
+     */
+    private array $injectionPoints = [];
 
     /**
      * Composition-time binding history
@@ -114,12 +143,19 @@ final class Container implements InjectorInterface
      */
     public function setInjectionPoint(InjectionPointInterface $ip): ?InjectionPointInterface
     {
-        $key = InjectionPointInterface::class . '-' . Name::ANY;
-        $existing = $this->container[$key] ?? null;
+        $cid = CoroutineContext::id();
+        if ($cid > 0) {
+            $previous = $this->injectionPoints[$cid] ?? null;
+            $this->injectionPoints[$cid] = $ip;
+
+            return $previous;
+        }
+
+        $existing = $this->container[self::INJECTION_POINT_INDEX] ?? null;
         $previous = $existing instanceof Instance && $existing->value instanceof InjectionPointInterface
             ? $existing->value
             : null;
-        $this->container[$key] = new Instance($ip);
+        $this->container[self::INJECTION_POINT_INDEX] = new Instance($ip);
 
         return $previous;
     }
@@ -131,14 +167,26 @@ final class Container implements InjectorInterface
      */
     public function restoreInjectionPoint(?InjectionPointInterface $ip): void
     {
-        $key = InjectionPointInterface::class . '-' . Name::ANY;
-        if ($ip === null) {
-            unset($this->container[$key]);
+        $cid = CoroutineContext::id();
+        if ($cid > 0) {
+            if ($ip === null) {
+                unset($this->injectionPoints[$cid]);
+
+                return;
+            }
+
+            $this->injectionPoints[$cid] = $ip;
 
             return;
         }
 
-        $this->container[$key] = new Instance($ip);
+        if ($ip === null) {
+            unset($this->container[self::INJECTION_POINT_INDEX]);
+
+            return;
+        }
+
+        $this->container[self::INJECTION_POINT_INDEX] = new Instance($ip);
     }
 
     /**
@@ -186,7 +234,7 @@ final class Container implements InjectorInterface
             throw new BadMethodCallException($interface);
         }
 
-        return $dependency->injectWithArgs($this, $params);
+        return $this->injectSingletonOnce($index, $dependency, fn (): mixed => $dependency->injectWithArgs($this, $params));
     }
 
     /**
@@ -200,11 +248,19 @@ final class Container implements InjectorInterface
      */
     public function getDependency(string $index)
     {
+        if ($index === self::INJECTION_POINT_INDEX) {
+            $injectionPoint = $this->injectionPoints[CoroutineContext::id()] ?? null;
+            if ($injectionPoint !== null) {
+                return $injectionPoint;
+            }
+        }
+
         if (! isset($this->container[$index])) {
             throw $this->unbound($index);
         }
 
-        if (isset($this->resolving[$index])) {
+        $cid = CoroutineContext::id();
+        if (isset($this->resolving[$cid][$index])) {
             $dependency = $this->container[$index];
             // An already-instantiated singleton satisfies re-entrant requests
             // (e.g. from a @PostConstruct method) with its cached instance,
@@ -213,15 +269,65 @@ final class Container implements InjectorInterface
                 return $dependency->inject($this);
             }
 
-            throw new CircularDependency(sprintf("'%s'", implode(' -> ', [...array_keys($this->resolving), $index])));
+            throw new CircularDependency(sprintf("'%s'", implode(' -> ', [...array_keys($this->resolving[$cid]), $index])));
         }
 
-        $this->resolving[$index] = true;
+        $this->resolving[$cid][$index] = true;
         try {
-            return $this->container[$index]->inject($this);
+            $dependency = $this->container[$index];
+
+            return $this->injectSingletonOnce($index, $dependency, fn (): mixed => $dependency->inject($this));
         } finally {
-            unset($this->resolving[$index]);
+            unset($this->resolving[$cid][$index]);
+            if ($this->resolving[$cid] === []) {
+                unset($this->resolving[$cid]);
+            }
         }
+    }
+
+    /**
+     * Inject, refusing to build a singleton concurrently in another coroutine
+     *
+     * Outside coroutines and for already-built or non-singleton dependencies
+     * this is a plain inject. Inside a coroutine, the first coroutine to
+     * build a singleton marks its index; a second coroutine finding the mark
+     * throws ConcurrentSingletonConstruction rather than building a duplicate
+     * (e.g. a second connection pool). Warm up singletons before serving
+     * requests so construction never races.
+     *
+     * @param callable(): mixed $inject
+     *
+     * @return mixed
+     */
+    private function injectSingletonOnce(string $index, DependencyInterface $dependency, callable $inject)
+    {
+        if (CoroutineContext::id() === 0 || ! self::isUnbuiltSingleton($dependency)) {
+            return $inject();
+        }
+
+        if (isset($this->constructing[$index])) {
+            throw new ConcurrentSingletonConstruction(sprintf("'%s'", $index));
+        }
+
+        $this->constructing[$index] = true;
+        try {
+            return $inject();
+        } finally {
+            unset($this->constructing[$index]);
+        }
+    }
+
+    private static function isUnbuiltSingleton(DependencyInterface $dependency): bool
+    {
+        if ($dependency instanceof Dependency) {
+            return $dependency->isSingleton() && ! $dependency->isInstantiated();
+        }
+
+        if ($dependency instanceof DependencyProvider) {
+            return $dependency->isSingleton() && ! $dependency->isInstantiated();
+        }
+
+        return false;
     }
 
     /**

--- a/src/di/DependencyProvider.php
+++ b/src/di/DependencyProvider.php
@@ -91,6 +91,11 @@ final class DependencyProvider implements DependencyInterface, AcceptInterface
         return $this->isSingleton;
     }
 
+    public function isInstantiated(): bool
+    {
+        return $this->isInstantiated;
+    }
+
     /** @inheritDoc */
     public function accept(VisitorInterface $visitor)
     {

--- a/src/di/Exception/ConcurrentSingletonConstruction.php
+++ b/src/di/Exception/ConcurrentSingletonConstruction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di\Exception;
+
+use LogicException;
+
+/**
+ * Message format: '{interface}-{name}' (the index whose construction was already in flight)
+ *
+ * Concurrent singleton construction across coroutines is not supported:
+ * the builder holds no lock a second coroutine could wait on without
+ * risking a cross-coroutine deadlock. Warm up singletons before the server
+ * starts accepting requests (e.g. Ray.Compiler warmup) so construction
+ * never races at request time.
+ */
+final class ConcurrentSingletonConstruction extends LogicException implements ExceptionInterface
+{
+}

--- a/tests/di/CoroutineSafetyTest.php
+++ b/tests/di/CoroutineSafetyTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\CircularDependency;
+use Ray\Di\Exception\ConcurrentSingletonConstruction;
+use Swoole\Coroutine;
+use Swoole\Coroutine\WaitGroup;
+use Throwable;
+
+use function assert;
+use function reset;
+use function Swoole\Coroutine\run;
+
+/**
+ * Coroutine safety of the shared container
+ *
+ * A container shared across Swoole coroutines must not report a false
+ * CircularDependency when one coroutine suspends mid-resolution. Concurrent
+ * construction of an unbuilt singleton is refused with
+ * ConcurrentSingletonConstruction; warm up singletons before serving
+ * requests so that request-time resolution only reads the cached instance.
+ */
+#[RequiresPhpExtension('swoole')]
+class CoroutineSafetyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        FakeSlowProvider::$buildCount = 0;
+    }
+
+    public function testConcurrentTransientResolutionIsNotACycle(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeSlowResource::class)->toProvider(FakeSlowProvider::class);
+            }
+        });
+
+        [$results, $errors] = $this->resolveConcurrently($injector);
+
+        $this->assertCount(0, $errors, (string) ($errors[0] ?? ''));
+        $this->assertCount(2, $results);
+        $this->assertNotSame($results[0], $results[1]);
+        $this->assertSame(2, FakeSlowProvider::$buildCount);
+    }
+
+    public function testConcurrentSingletonConstructionIsRefused(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeSlowResource::class)->toProvider(FakeSlowProvider::class)->in(Scope::SINGLETON);
+            }
+        });
+
+        [$results, $errors] = $this->resolveConcurrently($injector);
+
+        // one coroutine builds; the other is refused instead of building a duplicate
+        $this->assertCount(1, $results);
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(ConcurrentSingletonConstruction::class, reset($errors));
+        $this->assertSame(1, FakeSlowProvider::$buildCount);
+    }
+
+    public function testWarmedUpSingletonIsSharedAcrossCoroutines(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeSlowResource::class)->toProvider(FakeSlowProvider::class)->in(Scope::SINGLETON);
+            }
+        });
+        $warmed = $injector->getInstance(FakeSlowResource::class);
+
+        [$results, $errors] = $this->resolveConcurrently($injector);
+
+        $this->assertCount(0, $errors, (string) ($errors[0] ?? ''));
+        $this->assertSame($warmed, $results[0]);
+        $this->assertSame($warmed, $results[1]);
+        $this->assertSame(1, FakeSlowProvider::$buildCount);
+    }
+
+    public function testRealCircularDependencyIsStillDetectedInsideCoroutine(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeCircularAInterface::class)->to(FakeCircularA::class);
+                $this->bind(FakeCircularBInterface::class)->to(FakeCircularB::class);
+            }
+        });
+
+        $caught = null;
+        run(static function () use ($injector, &$caught): void {
+            Coroutine::create(static function () use ($injector, &$caught): void {
+                try {
+                    $injector->getInstance(FakeCircularAInterface::class);
+                } catch (CircularDependency $e) {
+                    $caught = $e;
+                }
+            });
+        });
+
+        $this->assertInstanceOf(CircularDependency::class, $caught);
+    }
+
+    public function testResolutionSucceedsAfterConcurrentResolution(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeSlowResource::class)->toProvider(FakeSlowProvider::class)->in(Scope::SINGLETON);
+                $this->bind(FakeDiamondSharedInterface::class)->to(FakeDiamondShared::class);
+            }
+        });
+
+        $this->resolveConcurrently($injector);
+
+        // resolution state must not leak across coroutines
+        $this->assertInstanceOf(FakeDiamondShared::class, $injector->getInstance(FakeDiamondSharedInterface::class));
+        $singleton = $injector->getInstance(FakeSlowResource::class);
+        assert($singleton instanceof FakeSlowResource);
+        $this->assertSame(1, FakeSlowProvider::$buildCount);
+    }
+
+    /**
+     * Resolve FakeSlowResource in two coroutines whose provider suspends mid-construction
+     *
+     * @return array{array<int, FakeSlowResource>, array<int, Throwable>}
+     */
+    private function resolveConcurrently(Injector $injector): array
+    {
+        $results = [];
+        $errors = [];
+        run(static function () use ($injector, &$results, &$errors): void {
+            $wg = new WaitGroup();
+            for ($i = 0; $i < 2; $i++) {
+                $wg->add();
+                Coroutine::create(static function () use ($injector, &$results, &$errors, $wg, $i): void {
+                    try {
+                        $results[$i] = $injector->getInstance(FakeSlowResource::class);
+                    } catch (Throwable $e) {
+                        $errors[$i] = $e;
+                    } finally {
+                        $wg->done();
+                    }
+                });
+            }
+
+            $wg->wait();
+        });
+
+        return [$results, $errors];
+    }
+}

--- a/tests/di/Fake/FakeSlowProvider.php
+++ b/tests/di/Fake/FakeSlowProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Swoole\Coroutine;
+
+/**
+ * Provider that suspends mid-construction, simulating coroutine IO
+ * (e.g. a connection pool wait) inside object construction
+ *
+ * @implements ProviderInterface<FakeSlowResource>
+ */
+class FakeSlowProvider implements ProviderInterface
+{
+    public static int $buildCount = 0;
+
+    public function get()
+    {
+        self::$buildCount++;
+        if (Coroutine::getCid() > 0) {
+            Coroutine::sleep(0.05);
+        }
+
+        return new FakeSlowResource();
+    }
+}

--- a/tests/di/Fake/FakeSlowResource.php
+++ b/tests/di/Fake/FakeSlowResource.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeSlowResource
+{
+}

--- a/tests/di/README.md
+++ b/tests/di/README.md
@@ -26,6 +26,7 @@ layer exists so that class of change can never again pass silently.
 | rename(): deferred application, reachable sources, error contract | `RenameTest` |
 | Cycle detection vs legal re-entry (singleton `@PostConstruct`) | `CircularDependencyTest` |
 | Assisted invocation: not available after the call, nested calls restore the outer invocation, coroutine interceptions isolated | `AssistedTest`, `MethodInvocationCoroutineTest` |
+| Coroutine isolation: no false cycle across coroutines, no duplicate singleton construction, real cycles still detected | `CoroutineSafetyTest` |
 | Singleton identity, serialization lifecycle | `DependencyTest`, `InjectorTest` |
 | JIT (untargeted) binding: single construction, named requests fail fast | `InjectorTest` |
 | Module-list merging (`new Injector([$m1, $m2])`): first module wins | `ModuleMergerTest` |


### PR DESCRIPTION
Under Swoole, `Container::$resolving` is shared by every coroutine. When a coroutine suspends mid-resolution (a provider waiting on a connection pool), another coroutine resolving the same index finds it in the set and gets a false `CircularDependency`. In a BEAR.Async demo 12 of 20 concurrent requests failed this way.

- `$resolving` and the injection point are tracked per coroutine id; outside coroutines cid is 0 and behavior is unchanged
- Concurrent construction of an unbuilt singleton across coroutines throws `ConcurrentSingletonConstruction` instead of silently building duplicates (e.g. two connection pools); singletons warmed up before serving requests never hit this
- Reuses `CoroutineContext` from #349; no dependency on ext-swoole/ext-openswoole

Follows #349, which isolated `MethodInvocationProvider` for the same class of problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency resolution across concurrent coroutines, preventing false circular-dependency errors.
  - Prevented duplicate construction of uninitialized singletons during concurrent requests.
  - Concurrent singleton construction now reports a clear error instead of silently creating multiple instances.
  - Preserved detection of genuine circular dependencies within individual coroutines.

- **New Features**
  - Added a public way to determine whether a singleton has already been instantiated.

- **Documentation**
  - Updated the changelog and testing documentation with coroutine-safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->