### PR TITLE
Defer ReflectionParameter rebuild until first access after unserialize

### DIFF
--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -26,7 +26,10 @@ final class Argument implements AcceptInterface, Stringable
     /** @var mixed */
     private $default;
     private string $meta;
-    private ReflectionParameter $reflection;
+    private string $refClass;
+    private string $refMethod;
+    private string $refParam;
+    private ?ReflectionParameter $reflection = null;
 
     public function __construct(ReflectionParameter $parameter, string $name)
     {
@@ -40,12 +43,17 @@ final class Argument implements AcceptInterface, Stringable
         $this->setDefaultValue($parameter);
         $this->index = $type . '-' . $name;
         $this->reflection = $parameter;
+        $method = $parameter->getDeclaringFunction();
+        assert($method instanceof ReflectionMethod);
+        $this->refClass = $method->class;
+        $this->refMethod = $method->name;
+        $this->refParam = $parameter->getName();
         $this->meta = sprintf(
             "'%s-%s' in %s:%d ($%s)",
             $type,
             $name,
-            $this->reflection->getDeclaringFunction()->getFileName(),
-            $this->reflection->getDeclaringFunction()->getStartLine(),
+            $method->getFileName(),
+            $method->getStartLine(),
             $parameter->getName()
         );
     }
@@ -65,7 +73,7 @@ final class Argument implements AcceptInterface, Stringable
      */
     public function get(): ReflectionParameter
     {
-        return $this->reflection;
+        return $this->reflection ??= new ReflectionParameter([$this->refClass, $this->refMethod], $this->refParam);
     }
 
     public function isDefaultAvailable(): bool
@@ -87,24 +95,16 @@ final class Argument implements AcceptInterface, Stringable
     /** @return array<mixed> */
     public function __serialize(): array
     {
-        $method = $this->reflection->getDeclaringFunction();
-        assert($method instanceof ReflectionMethod);
-        $ref = [
-            $method->class,
-            $method->name,
-            $this->reflection->getName(),
-        ];
-
         return [
             $this->index,
             $this->isDefaultAvailable,
             $this->default,
             $this->meta,
-            $ref,
+            [$this->refClass, $this->refMethod, $this->refParam],
         ];
     }
 
-    /** @param array{0: DependencyIndex, 1: bool, 2: string, 3: string, 4: string, 5: array{0: string, 1: string, 2:string}} $unserialized */
+    /** @param array{0: DependencyIndex, 1: bool, 2: mixed, 3: string, 4: array{0: string, 1: string, 2: string}} $unserialized */
     public function __unserialize(array $unserialized): void
     {
         [
@@ -114,7 +114,8 @@ final class Argument implements AcceptInterface, Stringable
             $this->meta,
             $ref,
         ] = $unserialized;
-        $this->reflection = new ReflectionParameter([$ref[0], $ref[1]], $ref[2]);
+        [$this->refClass, $this->refMethod, $this->refParam] = $ref;
+        $this->reflection = null;
     }
 
     /** @inheritDoc */
@@ -124,7 +125,7 @@ final class Argument implements AcceptInterface, Stringable
             $this->index,
             $this->isDefaultAvailable,
             $this->default,
-            $this->reflection
+            $this->get()
         );
     }
 

--- a/src/di/Argument.php
+++ b/src/di/Argument.php
@@ -14,7 +14,10 @@ use function assert;
 use function in_array;
 use function sprintf;
 
-/** @psalm-import-type DependencyIndex from Types */
+/**
+ * @psalm-import-type DependencyIndex from Types
+ * @psalm-import-type ArgumentSerializationData from Types
+ */
 final class Argument implements AcceptInterface, Stringable
 {
     public const UNBOUND_TYPE = ['bool', 'int', 'float', 'string', 'array', 'resource', 'callable', 'iterable'];
@@ -92,7 +95,7 @@ final class Argument implements AcceptInterface, Stringable
         return $this->meta;
     }
 
-    /** @return array<mixed> */
+    /** @return ArgumentSerializationData */
     public function __serialize(): array
     {
         return [
@@ -104,7 +107,7 @@ final class Argument implements AcceptInterface, Stringable
         ];
     }
 
-    /** @param array{0: DependencyIndex, 1: bool, 2: mixed, 3: string, 4: array{0: string, 1: string, 2: string}} $unserialized */
+    /** @param ArgumentSerializationData $unserialized */
     public function __unserialize(array $unserialized): void
     {
         [

--- a/src/di/InjectionPoint.php
+++ b/src/di/InjectionPoint.php
@@ -22,13 +22,15 @@ final class InjectionPoint implements InjectionPointInterface
 
     /** @var string */
     private $pName;
+    private ?ReflectionParameter $parameter = null;
 
-    public function __construct(private ReflectionParameter $parameter)
+    public function __construct(ReflectionParameter $parameter)
     {
-        $this->pFunction = $this->parameter->getDeclaringFunction()->name;
-        $class = $this->parameter->getDeclaringClass();
+        $this->parameter = $parameter;
+        $this->pFunction = $parameter->getDeclaringFunction()->name;
+        $class = $parameter->getDeclaringClass();
         $this->pClass = $class instanceof CoreReflectionClass ? $class->name : '';
-        $this->pName = $this->parameter->name;
+        $this->pName = $parameter->name;
     }
 
     /**
@@ -36,7 +38,7 @@ final class InjectionPoint implements InjectionPointInterface
      */
     public function getParameter(): ReflectionParameter
     {
-        return $this->parameter;
+        return $this->parameter ??= new ReflectionParameter([$this->pClass, $this->pFunction], $this->pName);
     }
 
     /**
@@ -44,8 +46,9 @@ final class InjectionPoint implements InjectionPointInterface
      */
     public function getMethod(): ReflectionMethod
     {
-        $class = $this->parameter->getDeclaringClass();
-        $method = $this->parameter->getDeclaringFunction()->getShortName();
+        $parameter = $this->getParameter();
+        $class = $parameter->getDeclaringClass();
+        $method = $parameter->getDeclaringFunction()->getShortName();
         assert($class instanceof CoreReflectionClass);
         assert(class_exists($class->getName()));
 
@@ -57,7 +60,7 @@ final class InjectionPoint implements InjectionPointInterface
      */
     public function getClass(): ReflectionClass
     {
-        $class = $this->parameter->getDeclaringClass();
+        $class = $this->getParameter()->getDeclaringClass();
         assert($class instanceof CoreReflectionClass);
 
         return new ReflectionClass($class->getName());
@@ -87,19 +90,15 @@ final class InjectionPoint implements InjectionPointInterface
     }
 
     /**
-     * Rebuild the ReflectionParameter dropped by serialization.
-     *
-     * The enclosing container is serialized (e.g. by ModuleString and
-     * compiled-container caches), so a restored InjectionPoint must stay usable;
-     * the typed $parameter would otherwise be left uninitialized.
+     * Not rebuilt here: doing so would force-autoload the declaring class
+     * for every injection point in the graph regardless of use;
+     * getParameter() rebuilds it lazily on first access.
      *
      * @param array<string> $array
      */
     public function __unserialize(array $array): void
     {
         [$this->pClass, $this->pFunction, $this->pName] = $array;
-        if ($this->pClass !== '') {
-            $this->parameter = new ReflectionParameter([$this->pClass, $this->pFunction], $this->pName);
-        }
+        $this->parameter = null;
     }
 }

--- a/src/di/Types.php
+++ b/src/di/Types.php
@@ -28,7 +28,9 @@ use Ray\Aop\Pointcut;
  * @psalm-type InjectionPointDefinition = array{0: string, 1: string, 2: bool}
  * @psalm-type InjectionPointsList = list<InjectionPointDefinition>
  * @psalm-type MethodArguments = list<mixed>
- * @psalm-type ArgumentSerializationData = array{0: DependencyIndex, 1: bool, 2: string, 3: string, 4: string, 5: array{0: string, 1: string, 2: string}}
+ * @psalm-type ReflectionMethodReference = array{0: string, 1: string, 2: string}
+ * @psalm-type DependencyMeta = string
+ * @psalm-type ArgumentSerializationData = array{0: DependencyIndex, 1: bool, 2: mixed, 3: DependencyMeta, 4: ReflectionMethodReference}
  * @psalm-type UnboundTypeList = list<'bool'|'int'|'float'|'string'|'array'|'resource'|'callable'|'iterable'|'object'|'mixed'>
  * @psalm-type QualifierList = array<object>
  * @psalm-type ScopeType = Scope::SINGLETON|Scope::PROTOTYPE
@@ -38,8 +40,6 @@ use Ray\Aop\Pointcut;
  * @psalm-type MethodInterceptorBindings array<non-empty-string, list<MethodInterceptor>>
  * @psalm-type InterceptorClassList array<class-string<MethodInterceptor>>
  * @psalm-type VisitorResult = object|array<array-key, mixed>|null
- * @psalm-type ReflectionMethodReference = array{0: string, 1: string, 2: string}
- * @psalm-type DependencyMeta = string
  * @psalm-type DiException = Exception\Unbound|Exception\Untargeted|Exception\NotFound|Exception\InvalidProvider|Exception\InvalidType
  * @psalm-type AnnotationType = Di\Named|Di\Inject|Di\Qualifier|Di\PostConstruct|Di\Assisted|Di\Set<object>
  * @psalm-type DependencyImplementation = Dependency|DependencyProvider|Instance|NullDependency|NullObjectDependency

--- a/tests/di/ArgumentTest.php
+++ b/tests/di/ArgumentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Di;
 
 use PHPUnit\Framework\TestCase;
+use Ray\Aop\Bind;
 use ReflectionMethod;
 use ReflectionParameter;
 
@@ -39,6 +40,87 @@ class ArgumentTest extends TestCase
         assert($argument instanceof Argument);
         $class = $argument->get()->getDeclaringFunction();
         $this->assertInstanceOf(ReflectionMethod::class, $class);
+    }
+
+    /**
+     * A restored Argument that is never touched must remain re-serializable:
+     * __serialize() reads the retained (class, method, param) tuple, not the
+     * still-null live ReflectionParameter, so unserialize -> serialize ->
+     * unserialize works even when get() is never called in between.
+     */
+    public function testSerializeRoundTripSurvivesUnusedReserialize(): void
+    {
+        $blob = serialize(new Argument(new ReflectionParameter([FakeInternalTypes::class, 'stringId'], 'id'), Name::ANY));
+        $restored = unserialize($blob);
+        assert($restored instanceof Argument);
+
+        $reserialized = unserialize(serialize($restored));
+        assert($reserialized instanceof Argument);
+
+        $this->assertSame('id', $reserialized->get()->getName());
+    }
+
+    /**
+     * accept() must still hand the visitor a working ReflectionParameter
+     * after unserialize(), i.e. it must go through get() rather than the
+     * raw (possibly still-null) $reflection property.
+     */
+    public function testAcceptAfterUnserializeSuppliesRebuiltParameter(): void
+    {
+        $blob = serialize(new Argument(new ReflectionParameter([FakeInternalTypes::class, 'stringId'], 'id'), Name::ANY));
+        $restored = unserialize($blob);
+        assert($restored instanceof Argument);
+
+        $visitor = new class implements VisitorInterface
+        {
+            public ?ReflectionParameter $parameter = null;
+
+            public function visitDependency(NewInstance $newInstance, ?string $postConstruct, bool $isSingleton)
+            {
+            }
+
+            public function visitProvider(Dependency $dependency, string $context, bool $isSingleton)
+            {
+            }
+
+            /** @param mixed $value */
+            public function visitInstance($value)
+            {
+            }
+
+            public function visitAspectBind(Bind $aopBind)
+            {
+            }
+
+            public function visitNewInstance(string $class, SetterMethods $setterMethods, ?Arguments $arguments, ?AspectBind $bind)
+            {
+            }
+
+            /** @inheritDoc */
+            public function visitSetterMethods(array $setterMethods)
+            {
+            }
+
+            public function visitSetterMethod(string $method, Arguments $arguments)
+            {
+            }
+
+            /** @inheritDoc */
+            public function visitArguments(array $arguments)
+            {
+            }
+
+            /** @param mixed $defaultValue */
+            public function visitArgument(string $index, bool $isDefaultAvailable, $defaultValue, ReflectionParameter $parameter)
+            {
+                $this->parameter = $parameter;
+            }
+        };
+
+        $restored->accept($visitor);
+
+        $this->assertInstanceOf(ReflectionParameter::class, $visitor->parameter);
+        $this->assertSame('id', $visitor->parameter->getName());
     }
 
     /**

--- a/tests/di/Fake/FakeLazyReflectionTarget.php
+++ b/tests/di/Fake/FakeLazyReflectionTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+/**
+ * Used only by LazyReflectionAutoloadTest's out-of-process fixture scripts.
+ * Deliberately unreferenced elsewhere so it stays unloaded until
+ * get()/getParameter() reconstructs its ReflectionParameter.
+ */
+final class FakeLazyReflectionTarget
+{
+    public function __construct(string $value)
+    {
+    }
+}

--- a/tests/di/InjectionPointTest.php
+++ b/tests/di/InjectionPointTest.php
@@ -7,6 +7,7 @@ namespace Ray\Di;
 use PHPUnit\Framework\TestCase;
 use ReflectionParameter;
 
+use function assert;
 use function serialize;
 use function unserialize;
 
@@ -51,9 +52,9 @@ class InjectionPointTest extends TestCase
 
     /**
      * An InjectionPoint is serialized into the compiled container. After
-     * unserialize() the ReflectionParameter must be reconstructed; otherwise
-     * the typed $parameter property stays uninitialized and getParameter()/
-     * getMethod()/getClass() raise an Error on first access.
+     * unserialize() the ReflectionParameter is dropped and rebuilt lazily on
+     * first access; getParameter()/getMethod()/getClass() must still return
+     * a working ReflectionParameter/ReflectionMethod/ReflectionClass.
      */
     public function testSerializeRoundTripRestoresParameter(): void
     {
@@ -64,6 +65,47 @@ class InjectionPointTest extends TestCase
         $this->assertSame('rightLeg', $restored->getParameter()->name);
         $this->assertSame((string) $this->parameter->getDeclaringFunction(), (string) $restored->getMethod());
         $this->assertSame((string) $this->parameter->getDeclaringClass(), (string) $restored->getClass());
+    }
+
+    /**
+     * Unlike testSerializeRoundTripRestoresParameter(), this never calls
+     * getParameter() first, so it exercises getMethod()'s own lazy-rebuild
+     * path rather than a cache getParameter() already populated.
+     */
+    public function testGetMethodAfterUnserializeWithoutPriorGetParameter(): void
+    {
+        $restored = unserialize(serialize($this->ip));
+        assert($restored instanceof InjectionPoint);
+
+        $this->assertSame((string) $this->parameter->getDeclaringFunction(), (string) $restored->getMethod());
+    }
+
+    /** @see self::testGetMethodAfterUnserializeWithoutPriorGetParameter() for why this is separate from the combined round trip */
+    public function testGetClassAfterUnserializeWithoutPriorGetParameter(): void
+    {
+        $restored = unserialize(serialize($this->ip));
+        assert($restored instanceof InjectionPoint);
+
+        $this->assertSame((string) $this->parameter->getDeclaringClass(), (string) $restored->getClass());
+    }
+
+    /**
+     * A restored InjectionPoint that is never touched must remain
+     * re-serializable: __serialize() reads the retained (class, function,
+     * name) tuple, not the still-null live ReflectionParameter, so
+     * unserialize -> serialize -> unserialize works even when getParameter()
+     * is never called in between.
+     */
+    public function testSerializeRoundTripSurvivesUnusedReserialize(): void
+    {
+        $blob = serialize($this->ip);
+        $restored = unserialize($blob);
+        assert($restored instanceof InjectionPoint);
+
+        $reserialized = unserialize(serialize($restored));
+        assert($reserialized instanceof InjectionPoint);
+
+        $this->assertSame('rightLeg', $reserialized->getParameter()->name);
     }
 
     /**

--- a/tests/di/LazyReflectionAutoloadTest.php
+++ b/tests/di/LazyReflectionAutoloadTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function escapeshellarg;
+use function exec;
+use function implode;
+use function sprintf;
+use function tempnam;
+use function unlink;
+
+use const PHP_BINARY;
+
+/**
+ * Argument and InjectionPoint must not force-autoload their declaring class
+ * during unserialize(); only get()/getParameter() may trigger it.
+ *
+ * This can only be observed across a process boundary: building the
+ * fixture's ReflectionParameter necessarily autoloads FakeLazyReflectionTarget
+ * in whichever process builds it, so generation and verification run as two
+ * separate PHP processes, each using the current codebase's live
+ * __serialize()/__unserialize() rather than a committed blob.
+ */
+class LazyReflectionAutoloadTest extends TestCase
+{
+    #[DataProvider('targetProvider')]
+    public function testDeclaringClassIsNotAutoloadedUntilFirstAccess(string $target): void
+    {
+        $scriptDir = __DIR__ . '/script';
+        $blobFile = tempnam(__DIR__ . '/tmp', 'ray-di-lazy-');
+        if ($blobFile === false) {
+            throw new RuntimeException('tempnam() failed to create a blob file under tests/di/tmp');
+        }
+
+        try {
+            exec(sprintf(
+                '%s %s %s %s 2>&1',
+                escapeshellarg(PHP_BINARY),
+                escapeshellarg($scriptDir . '/lazy_reflection_generate.php'),
+                escapeshellarg($target),
+                escapeshellarg($blobFile)
+            ), $genOutput, $genStatus);
+            $this->assertSame(0, $genStatus, implode("\n", $genOutput));
+
+            exec(sprintf(
+                '%s %s %s %s 2>&1',
+                escapeshellarg(PHP_BINARY),
+                escapeshellarg($scriptDir . '/lazy_reflection_verify.php'),
+                escapeshellarg($target),
+                escapeshellarg($blobFile)
+            ), $verifyOutput, $verifyStatus);
+
+            $this->assertSame('PASS', implode('', $verifyOutput), implode("\n", $verifyOutput));
+            $this->assertSame(0, $verifyStatus);
+        } finally {
+            unlink($blobFile);
+        }
+    }
+
+    /** @return array<string, array{0: string}> */
+    public static function targetProvider(): array
+    {
+        return [
+            'Argument' => ['argument'],
+            'InjectionPoint' => ['injectionpoint'],
+        ];
+    }
+}

--- a/tests/di/script/lazy_reflection_generate.php
+++ b/tests/di/script/lazy_reflection_generate.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use ReflectionParameter;
+use RuntimeException;
+
+use function dirname;
+use function file_put_contents;
+use function serialize;
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+[, $target, $outFile] = $argv;
+
+$parameter = new ReflectionParameter([FakeLazyReflectionTarget::class, '__construct'], 'value');
+
+$subject = match ($target) {
+    'argument' => new Argument($parameter, Name::ANY),
+    'injectionpoint' => new InjectionPoint($parameter),
+    default => throw new RuntimeException('unknown target: ' . $target),
+};
+
+file_put_contents($outFile, serialize($subject));

--- a/tests/di/script/lazy_reflection_verify.php
+++ b/tests/di/script/lazy_reflection_verify.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use RuntimeException;
+
+use function assert;
+use function class_exists;
+use function dirname;
+use function file_get_contents;
+use function unserialize;
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+[, $target, $blobFile] = $argv;
+
+$targetClass = FakeLazyReflectionTarget::class;
+
+if (class_exists($targetClass, false)) {
+    echo 'FAIL:already-loaded-before-unserialize';
+    exit(1);
+}
+
+$subject = unserialize((string) file_get_contents($blobFile));
+
+if (class_exists($targetClass, false)) {
+    echo 'FAIL:loaded-by-unserialize';
+    exit(1);
+}
+
+if ($target === 'argument') {
+    assert($subject instanceof Argument);
+    $subject->get();
+} elseif ($target === 'injectionpoint') {
+    assert($subject instanceof InjectionPoint);
+    $subject->getParameter();
+} else {
+    throw new RuntimeException('unknown target: ' . $target);
+}
+
+if (! class_exists($targetClass, false)) {
+    echo 'FAIL:not-loaded-after-get';
+    exit(1);
+}
+
+echo 'PASS';


### PR DESCRIPTION
## Problem

Per ray-di/Ray.Compiler#135, unserializing a serialized `Injector` spends most of its cost on class autoload. `Argument::__unserialize()` and `InjectionPoint::__unserialize()` each immediately rebuild a `ReflectionParameter`, which force-autoloads the declaring class for every argument/injection point in the graph, regardless of whether the current request ever touches that binding.

## Change

- `Argument`: retains the `(class, method, param)` tuple as permanent properties (set in the constructor too, not only derived at serialize time), so `__serialize()` reads the tuple instead of the live `ReflectionParameter`. `get()` rebuilds the `ReflectionParameter` lazily on first access (`??=`). Also fixes a pre-existing stale `@param` array-shape docblock on `__unserialize()` that mislabeled the default-value slot as `string` instead of `mixed` (surfaced by Psalm once destructuring replaced index access).
- `InjectionPoint`: same tuple-based approach for `getParameter()`. `getMethod()`/`getClass()` now route through `getParameter()` instead of reading the raw property directly, so there is a single lazy-rebuild path. The `pClass === ''` case (named global function or closure parameters) is unchanged in observable behavior: it still fails on first access, now via `ReflectionException` from the unconditional array-form reconstruction instead of an uninitialized-property `Error`. No new capability was added for this case; it remains unsupported, matching prior behavior.

## Tests

- Round-trip tests for both classes proving `unserialize() -> (untouched) -> serialize() -> unserialize()` still works, since `__serialize()` no longer depends on the lazily-built `ReflectionParameter`.
- Standalone `getMethod()`/`getClass()` tests that call each directly after `unserialize()`, without a prior `getParameter()` call, exercising the lazy path from both entry points independently.
- `LazyReflectionAutoloadTest`: proves the declaring class is **not** autoloaded during `unserialize()`, only on first `get()`/`getParameter()` access. This is verified out-of-process (`tests/di/script/lazy_reflection_{generate,verify}.php`, blob written to `tests/di/tmp`) because building the fixture's `ReflectionParameter` to produce the serialized blob necessarily autoloads the fixture class in whichever process builds it. Confirmed this test fails (red) against the unmodified base commit, proving it is a real regression guard.

## Validation

- `composer cs` / `composer sa`: clean.
- `composer test`: 300 tests pass (pre-existing deprecations/1 skip unrelated to this change).
- `composer pcov`: 100% method/line coverage maintained on `Argument`, `InjectionPoint`, and every other class (`composer coverage`, the Xdebug-based script, segfaults in this environment for unrelated reasons; `pcov` is this repo's configured alternative driver and completes cleanly with exit 0).
- **Ray.Compiler compatibility**: ran the Ray.Compiler test suite (129/129 passing) against this branch via a Composer path repository pointing `ray/di` at this worktree, confirming the compiled-container path that serializes `InjectionPoint` still works end-to-end.

## Follow-up (not in this PR)

A cold-process before/after benchmark on a real serialized `Injector`, to quantify the actual improvement at production scale. Issue #135's ~25ms figure is for the whole container's `unserialize()`, not this mechanism specifically; the improvement here is a hypothesis until measured directly.

Refs: ray-di/Ray.Compiler#135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deferred loading of dependency reflection details until they are needed, reducing unnecessary class loading during deserialization.
  * Preserved serialization and restoration of dependency metadata, including parameters from global functions.
  * Improved reliability when restored dependency metadata is reused or serialized again before reflection details are accessed.

* **Tests**
  * Added coverage for repeated serialization and deserialization.
  * Verified reflection details load only when first requested.
  * Confirmed restored dependency metadata remains usable through supported access paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->